### PR TITLE
Fix PostgreSQL timestamps to TIMESTAMPTZ

### DIFF
--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,16 +12,16 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
+            $table->timestampTz('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
-            $table->timestamps();
+            $table->timestampsTz();
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {
             $table->string('email')->primary();
             $table->string('token');
-            $table->timestamp('created_at')->nullable();
+            $table->timestampTz('created_at')->nullable();
         });
 
         Schema::create('sessions', function (Blueprint $table) {

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -38,7 +38,7 @@ return new class extends Migration
             $table->text('queue');
             $table->longText('payload');
             $table->longText('exception');
-            $table->timestamp('failed_at')->useCurrent();
+            $table->timestampTz('failed_at')->useCurrent();
         });
     }
 

--- a/database/migrations/2024_01_01_000003_create_account_heads_table.php
+++ b/database/migrations/2024_01_01_000003_create_account_heads_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->string('tally_guid')->nullable();
             $table->string('group_name')->nullable();
             $table->boolean('is_active')->default(true);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('name');
             $table->index('group_name');

--- a/database/migrations/2024_01_01_000004_create_imported_files_table.php
+++ b/database/migrations/2024_01_01_000004_create_imported_files_table.php
@@ -21,8 +21,8 @@ return new class extends Migration
             $table->unsignedInteger('mapped_rows')->default(0);
             $table->text('error_message')->nullable();
             $table->foreignId('uploaded_by')->constrained('users');
-            $table->timestamp('processed_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('processed_at')->nullable();
+            $table->timestampsTz();
 
             $table->index('status');
             $table->index('bank_name');

--- a/database/migrations/2024_01_01_000005_create_transactions_table.php
+++ b/database/migrations/2024_01_01_000005_create_transactions_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->float('ai_confidence')->nullable();
             $table->text('raw_data')->nullable(); // encrypted JSONB
             $table->string('bank_format')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('imported_file_id');
             $table->index('account_head_id');

--- a/database/migrations/2024_01_01_000006_create_head_mappings_table.php
+++ b/database/migrations/2024_01_01_000006_create_head_mappings_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->string('bank_name')->nullable();
             $table->foreignId('created_by')->constrained('users');
             $table->unsignedInteger('usage_count')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('account_head_id');
             $table->index('bank_name');

--- a/database/migrations/2026_02_24_155636_fix_timestamps_to_timestamptz.php
+++ b/database/migrations/2026_02_24_155636_fix_timestamps_to_timestamptz.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Convert all timestamp columns from TIMESTAMP to TIMESTAMPTZ.
+     *
+     * Financial data requires timezone-aware timestamps for correct
+     * date/time handling in India (Asia/Kolkata).
+     */
+    public function up(): void
+    {
+        // users
+        DB::statement("ALTER TABLE users ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE users ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE users ALTER COLUMN email_verified_at TYPE TIMESTAMPTZ USING email_verified_at AT TIME ZONE 'UTC'");
+
+        // password_reset_tokens
+        DB::statement("ALTER TABLE password_reset_tokens ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+
+        // failed_jobs
+        DB::statement("ALTER TABLE failed_jobs ALTER COLUMN failed_at TYPE TIMESTAMPTZ USING failed_at AT TIME ZONE 'UTC'");
+
+        // account_heads
+        DB::statement("ALTER TABLE account_heads ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE account_heads ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC'");
+
+        // imported_files
+        DB::statement("ALTER TABLE imported_files ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE imported_files ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE imported_files ALTER COLUMN processed_at TYPE TIMESTAMPTZ USING processed_at AT TIME ZONE 'UTC'");
+
+        // transactions
+        DB::statement("ALTER TABLE transactions ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE transactions ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC'");
+
+        // head_mappings
+        DB::statement("ALTER TABLE head_mappings ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'");
+        DB::statement("ALTER TABLE head_mappings ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC'");
+
+    }
+
+    /**
+     * Reverse the conversion back to TIMESTAMP.
+     */
+    public function down(): void
+    {
+        // users
+        DB::statement('ALTER TABLE users ALTER COLUMN created_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE users ALTER COLUMN updated_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE users ALTER COLUMN email_verified_at TYPE TIMESTAMP');
+
+        // password_reset_tokens
+        DB::statement('ALTER TABLE password_reset_tokens ALTER COLUMN created_at TYPE TIMESTAMP');
+
+        // failed_jobs
+        DB::statement('ALTER TABLE failed_jobs ALTER COLUMN failed_at TYPE TIMESTAMP');
+
+        // account_heads
+        DB::statement('ALTER TABLE account_heads ALTER COLUMN created_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE account_heads ALTER COLUMN updated_at TYPE TIMESTAMP');
+
+        // imported_files
+        DB::statement('ALTER TABLE imported_files ALTER COLUMN created_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE imported_files ALTER COLUMN updated_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE imported_files ALTER COLUMN processed_at TYPE TIMESTAMP');
+
+        // transactions
+        DB::statement('ALTER TABLE transactions ALTER COLUMN created_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE transactions ALTER COLUMN updated_at TYPE TIMESTAMP');
+
+        // head_mappings
+        DB::statement('ALTER TABLE head_mappings ALTER COLUMN created_at TYPE TIMESTAMP');
+        DB::statement('ALTER TABLE head_mappings ALTER COLUMN updated_at TYPE TIMESTAMP');
+
+    }
+};


### PR DESCRIPTION
## Summary
- Creates migration to ALTER all existing timestamp columns to TIMESTAMPTZ
- Updates all migration files to use timestampsTz() and timestampTz()
- Ensures migrate:fresh also creates correct column types

Closes #3

## Test plan
- [ ] Run migrate:fresh and verify all timestamp columns are TIMESTAMPTZ
- [ ] Verify existing data is preserved with timezone info

Generated with [Claude Code](https://claude.com/claude-code)
