### PR TITLE
Fix account head lookup by name in AI matching (use IDs)

### DIFF
--- a/app/Ai/Agents/HeadMatcher.php
+++ b/app/Ai/Agents/HeadMatcher.php
@@ -23,6 +23,9 @@ class HeadMatcher implements Agent, HasStructuredOutput
 
     protected string $chartOfAccounts = '';
 
+    /**
+     * Set the chart of accounts context (format: "ID: Name (Group)" per line).
+     */
     public function withChartOfAccounts(string $chartOfAccounts): static
     {
         $this->chartOfAccounts = $chartOfAccounts;
@@ -40,10 +43,15 @@ class HeadMatcher implements Agent, HasStructuredOutput
 
         Rules:
         - Match based on the nature of the transaction (salary, rent, utilities, vendor payments, etc.)
+        - Always return the account head ID (suggested_head_id) from the chart of accounts
+        - Also return the account head name (suggested_head_name) for readability
         - Provide a confidence score between 0 and 1 for each match
         - Provide brief reasoning for each suggestion
         - If no good match exists, suggest the closest head with a low confidence score
         - Consider Indian business context (GST, TDS, etc.)
+
+        The chart of accounts is provided in the format "ID: Name (Group)".
+        Always use the numeric ID from this list for suggested_head_id.
         INSTRUCTIONS;
 
         if ($this->chartOfAccounts) {
@@ -58,6 +66,7 @@ class HeadMatcher implements Agent, HasStructuredOutput
         return [
             'matches' => $schema->array()->items([
                 'transaction_id' => $schema->integer()->required(),
+                'suggested_head_id' => $schema->integer()->required(),
                 'suggested_head_name' => $schema->string()->required(),
                 'confidence' => $schema->number()->required(),
                 'reasoning' => $schema->string()->required(),

--- a/app/Services/HeadMatcher/HeadMatcherService.php
+++ b/app/Services/HeadMatcher/HeadMatcherService.php
@@ -8,6 +8,7 @@ use App\Models\AccountHead;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
 
 class HeadMatcherService
 {
@@ -98,38 +99,61 @@ class HeadMatcherService
         $matched = 0;
 
         foreach ($response['matches'] ?? [] as $match) {
-            if ($match['confidence'] < $this->confidenceThreshold) {
-                // Still store the suggestion but mark as AI with low confidence
-                $head = AccountHead::where('name', $match['suggested_head_name'])->first();
+            $head = $this->resolveAccountHead($match);
 
-                if ($head) {
-                    Transaction::where('id', $match['transaction_id'])
-                        ->where('mapping_type', MappingType::Unmapped)
-                        ->update([
-                            'account_head_id' => $head->id,
-                            'mapping_type' => MappingType::Ai,
-                            'ai_confidence' => $match['confidence'],
-                        ]);
-                    $matched++;
-                }
-
+            if (! $head) {
                 continue;
             }
 
-            $head = AccountHead::where('name', $match['suggested_head_name'])->first();
-
-            if ($head) {
-                Transaction::where('id', $match['transaction_id'])
-                    ->where('mapping_type', MappingType::Unmapped)
-                    ->update([
-                        'account_head_id' => $head->id,
-                        'mapping_type' => MappingType::Ai,
-                        'ai_confidence' => $match['confidence'],
-                    ]);
-                $matched++;
-            }
+            Transaction::where('id', $match['transaction_id'])
+                ->where('mapping_type', MappingType::Unmapped)
+                ->update([
+                    'account_head_id' => $head->id,
+                    'mapping_type' => MappingType::Ai,
+                    'ai_confidence' => $match['confidence'],
+                ]);
+            $matched++;
         }
 
         return $matched;
+    }
+
+    /**
+     * Resolve an account head from AI match data, preferring ID lookup with name fallback.
+     *
+     * @param  array<string, mixed>  $match
+     */
+    private function resolveAccountHead(array $match): ?AccountHead
+    {
+        // Primary: lookup by ID
+        if (isset($match['suggested_head_id'])) {
+            $head = AccountHead::find($match['suggested_head_id']);
+
+            if ($head) {
+                return $head;
+            }
+        }
+
+        // Fallback: lookup by name
+        if (isset($match['suggested_head_name'])) {
+            $head = AccountHead::where('name', $match['suggested_head_name'])->first();
+
+            if ($head) {
+                Log::warning('AI matching: account head resolved by name fallback', [
+                    'suggested_head_id' => $match['suggested_head_id'] ?? null,
+                    'suggested_head_name' => $match['suggested_head_name'],
+                    'resolved_id' => $head->id,
+                ]);
+
+                return $head;
+            }
+        }
+
+        Log::warning('AI matching: could not resolve account head', [
+            'suggested_head_id' => $match['suggested_head_id'] ?? null,
+            'suggested_head_name' => $match['suggested_head_name'] ?? null,
+        ]);
+
+        return null;
     }
 }

--- a/database/migrations/2026_02_24_000008_add_unique_name_group_to_account_heads.php
+++ b/database/migrations/2026_02_24_000008_add_unique_name_group_to_account_heads.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->unique(['name', 'group_name'], 'account_heads_name_group_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->dropUnique('account_heads_name_group_unique');
+        });
+    }
+};

--- a/tests/Feature/Services/HeadMatcherServiceTest.php
+++ b/tests/Feature/Services/HeadMatcherServiceTest.php
@@ -5,6 +5,7 @@ use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Services\HeadMatcher\HeadMatcherService;
+use App\Services\HeadMatcher\RuleBasedMatcher;
 
 describe('HeadMatcherService::matchForFile()', function () {
     it('returns zeros when no unmapped transactions', function () {
@@ -57,5 +58,45 @@ describe('HeadMatcherService::matchForFile()', function () {
         $result = $service->setConfidenceThreshold(0.5);
 
         expect($result)->toBeInstanceOf(HeadMatcherService::class);
+    });
+});
+
+describe('HeadMatcherService::resolveAccountHead()', function () {
+    it('resolves account head by ID', function () {
+        $head = AccountHead::factory()->create();
+        $service = new HeadMatcherService(new RuleBasedMatcher);
+
+        $method = new ReflectionMethod($service, 'resolveAccountHead');
+        $result = $method->invoke($service, [
+            'suggested_head_id' => $head->id,
+            'suggested_head_name' => 'Wrong Name',
+        ]);
+
+        expect($result->id)->toBe($head->id);
+    });
+
+    it('falls back to name when ID not found', function () {
+        $head = AccountHead::factory()->create(['name' => 'Salary']);
+        $service = new HeadMatcherService(new RuleBasedMatcher);
+
+        $method = new ReflectionMethod($service, 'resolveAccountHead');
+        $result = $method->invoke($service, [
+            'suggested_head_id' => 99999,
+            'suggested_head_name' => 'Salary',
+        ]);
+
+        expect($result->id)->toBe($head->id);
+    });
+
+    it('returns null when neither ID nor name matches', function () {
+        $service = new HeadMatcherService(new RuleBasedMatcher);
+
+        $method = new ReflectionMethod($service, 'resolveAccountHead');
+        $result = $method->invoke($service, [
+            'suggested_head_id' => 99999,
+            'suggested_head_name' => 'Nonexistent Head',
+        ]);
+
+        expect($result)->toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- Updates HeadMatcher agent schema to include `suggested_head_id` (integer, required)
- Updates LLM instructions to always return account head IDs from the chart of accounts
- Changes chart of accounts format to "ID: Name (Group)" so LLM can reference IDs
- Adds `resolveAccountHead()` method with ID-first lookup and name-based fallback with logging
- Removes duplicated threshold branching in `runAiMatching()` (both paths did the same thing)
- Adds composite unique constraint on `account_heads(name, group_name)`

Closes #13

## Test plan
- [ ] AI matching uses head ID for primary lookup
- [ ] Falls back to name when ID not found (with warning log)
- [ ] Returns null when neither matches (with warning log)
- [ ] Run `php artisan test --filter=HeadMatcherService`
- [ ] Migration adds unique constraint successfully

Generated with [Claude Code](https://claude.com/claude-code)