### PR TITLE
Fix HeadMatcherService N+1 query and memory issues

### DIFF
--- a/app/Services/HeadMatcher/HeadMatcherService.php
+++ b/app/Services/HeadMatcher/HeadMatcherService.php
@@ -14,6 +14,10 @@ class HeadMatcherService
 {
     protected float $confidenceThreshold = 0.8;
 
+    protected int $ruleChunkSize = 500;
+
+    protected int $aiChunkSize = 50;
+
     public function __construct(
         protected RuleBasedMatcher $ruleBasedMatcher,
     ) {}
@@ -30,29 +34,19 @@ class HeadMatcherService
      */
     public function matchForFile(ImportedFile $importedFile): array
     {
-        $transactions = $importedFile->transactions()
+        $hasUnmapped = $importedFile->transactions()
             ->where('mapping_type', MappingType::Unmapped)
-            ->get();
+            ->exists();
 
-        if ($transactions->isEmpty()) {
+        if (! $hasUnmapped) {
             return ['rule_matched' => 0, 'ai_matched' => 0, 'unmatched' => 0];
         }
 
-        // Pass 1: Rule-based matching
-        $ruleMatches = $this->ruleBasedMatcher->match($transactions, $importedFile->bank_name);
-        $ruleCount = $this->ruleBasedMatcher->applyMatches($ruleMatches);
+        // Pass 1: Rule-based matching in chunks
+        $ruleCount = $this->runChunkedRuleMatching($importedFile);
 
-        // Refresh for remaining unmapped
-        $unmapped = $importedFile->transactions()
-            ->where('mapping_type', MappingType::Unmapped)
-            ->get();
-
-        $aiCount = 0;
-
-        if ($unmapped->isNotEmpty()) {
-            // Pass 2: AI matching
-            $aiCount = $this->runAiMatching($unmapped);
-        }
+        // Pass 2: AI matching in chunks for remaining unmapped
+        $aiCount = $this->runChunkedAiMatching($importedFile);
 
         // Update file stats
         $importedFile->update([
@@ -71,15 +65,57 @@ class HeadMatcherService
     }
 
     /**
-     * Run AI matching on a collection of unmapped transactions.
+     * Run rule-based matching in chunks to avoid loading all transactions at once.
      */
-    protected function runAiMatching(Collection $transactions): int
+    protected function runChunkedRuleMatching(ImportedFile $importedFile): int
     {
-        $chartOfAccounts = AccountHead::where('is_active', true)
+        $totalMatched = 0;
+
+        $importedFile->transactions()
+            ->where('mapping_type', MappingType::Unmapped)
+            ->chunkById($this->ruleChunkSize, function (Collection $transactions) use ($importedFile, &$totalMatched) {
+                $ruleMatches = $this->ruleBasedMatcher->match($transactions, $importedFile->bank_name);
+                $totalMatched += $this->ruleBasedMatcher->applyMatches($ruleMatches);
+            });
+
+        return $totalMatched;
+    }
+
+    /**
+     * Run AI matching in batches of descriptions per agent call.
+     */
+    protected function runChunkedAiMatching(ImportedFile $importedFile): int
+    {
+        $totalMatched = 0;
+
+        // Load chart of accounts once for all chunks
+        $chartOfAccounts = $this->loadChartOfAccounts();
+
+        $importedFile->transactions()
+            ->where('mapping_type', MappingType::Unmapped)
+            ->chunkById($this->aiChunkSize, function (Collection $transactions) use (&$totalMatched, $chartOfAccounts) {
+                $totalMatched += $this->runAiMatching($transactions, $chartOfAccounts);
+            });
+
+        return $totalMatched;
+    }
+
+    /**
+     * Load active account heads formatted for the AI agent.
+     */
+    protected function loadChartOfAccounts(): string
+    {
+        return AccountHead::where('is_active', true)
             ->get()
             ->map(fn (AccountHead $head) => "{$head->id}: {$head->name} ({$head->group_name})")
             ->implode("\n");
+    }
 
+    /**
+     * Run AI matching on a collection of unmapped transactions.
+     */
+    protected function runAiMatching(Collection $transactions, string $chartOfAccounts): int
+    {
         $descriptions = $transactions->map(fn (Transaction $t) => [
             'id' => $t->id,
             'description' => $t->description,

--- a/app/Services/HeadMatcher/RuleBasedMatcher.php
+++ b/app/Services/HeadMatcher/RuleBasedMatcher.php
@@ -31,6 +31,8 @@ class RuleBasedMatcher
         $rules = $query->get();
 
         $matches = [];
+        /** @var array<int, int> $usageCounts */
+        $usageCounts = [];
 
         foreach ($transactions as $transaction) {
             if ($transaction->mapping_type !== MappingType::Unmapped) {
@@ -47,11 +49,16 @@ class RuleBasedMatcher
                         'mapping_id' => $rule->id,
                     ];
 
-                    $rule->increment('usage_count');
+                    $usageCounts[$rule->id] = ($usageCounts[$rule->id] ?? 0) + 1;
 
                     break; // First match wins
                 }
             }
+        }
+
+        // Bulk update usage counts — one query per matched rule instead of per match
+        foreach ($usageCounts as $mappingId => $count) {
+            HeadMapping::where('id', $mappingId)->increment('usage_count', $count);
         }
 
         return $matches;

--- a/tests/Feature/Services/HeadMatcherServiceTest.php
+++ b/tests/Feature/Services/HeadMatcherServiceTest.php
@@ -59,6 +59,35 @@ describe('HeadMatcherService::matchForFile()', function () {
 
         expect($result)->toBeInstanceOf(HeadMatcherService::class);
     });
+
+    it('matches many transactions using chunked rule-based matching', function () {
+        $head1 = AccountHead::factory()->create(['name' => 'Salary']);
+        $head2 = AccountHead::factory()->create(['name' => 'EMI']);
+
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY',
+            'match_type' => \App\Enums\MatchType::Contains,
+            'account_head_id' => $head1->id,
+            'usage_count' => 0,
+        ]);
+        $emiMapping = HeadMapping::factory()->create([
+            'pattern' => 'EMI',
+            'match_type' => \App\Enums\MatchType::Contains,
+            'account_head_id' => $head2->id,
+            'usage_count' => 0,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->count(5)->create(['description' => 'SALARY JUNE']);
+        Transaction::factory()->unmapped()->for($file)->count(3)->create(['description' => 'EMI PAYMENT']);
+
+        $service = app(HeadMatcherService::class);
+        $results = $service->matchForFile($file);
+
+        expect($results['rule_matched'])->toBe(8)
+            ->and($results['unmatched'])->toBe(0)
+            ->and($emiMapping->fresh()->usage_count)->toBe(3);
+    });
 });
 
 describe('HeadMatcherService::resolveAccountHead()', function () {

--- a/tests/Feature/Services/RuleBasedMatcherTest.php
+++ b/tests/Feature/Services/RuleBasedMatcherTest.php
@@ -85,6 +85,54 @@ describe('RuleBasedMatcher::match()', function () {
         expect($mapping->fresh()->usage_count)->toBe(1);
     });
 
+    it('bulk increments usage_count for multiple matches on same rule', function () {
+        $head = AccountHead::factory()->create();
+        $mapping = HeadMapping::factory()->create([
+            'pattern' => 'EMI',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head->id,
+            'usage_count' => 5,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->count(3)->create(['description' => 'EMI PAYMENT']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(3)
+            ->and($mapping->fresh()->usage_count)->toBe(8);
+    });
+
+    it('bulk increments usage_count for multiple rules correctly', function () {
+        $head1 = AccountHead::factory()->create();
+        $head2 = AccountHead::factory()->create();
+
+        $mapping1 = HeadMapping::factory()->create([
+            'pattern' => 'SALARY',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head1->id,
+            'usage_count' => 0,
+        ]);
+        $mapping2 = HeadMapping::factory()->create([
+            'pattern' => 'EMI',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head2->id,
+            'usage_count' => 2,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->count(2)->create(['description' => 'SALARY JUNE']);
+        Transaction::factory()->unmapped()->for($file)->count(3)->create(['description' => 'EMI PAYMENT']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions()->get());
+
+        expect($matches)->toHaveCount(5)
+            ->and($mapping1->fresh()->usage_count)->toBe(2)
+            ->and($mapping2->fresh()->usage_count)->toBe(5);
+    });
+
     it('uses first match wins strategy', function () {
         $head1 = AccountHead::factory()->create(['name' => 'Head 1']);
         $head2 = AccountHead::factory()->create(['name' => 'Head 2']);


### PR DESCRIPTION
Closes #19 - Replace per-match increment with bulk usage_count updates, chunk rule-based matching (500) and AI matching (50), use exists() for empty check, extract loadChartOfAccounts()