### PR TITLE
feat(audit): enable Spatie Activity Log for audit trail

### DIFF
--- a/app/Models/AccountHead.php
+++ b/app/Models/AccountHead.php
@@ -6,10 +6,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class AccountHead extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected $fillable = [
         'name',
@@ -18,6 +21,14 @@ class AccountHead extends Model
         'group_name',
         'is_active',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'parent_id', 'tally_guid', 'group_name', 'is_active'])
+            ->logOnlyDirty()
+            ->useLogName('account-heads');
+    }
 
     protected function casts(): array
     {

--- a/app/Models/HeadMapping.php
+++ b/app/Models/HeadMapping.php
@@ -6,10 +6,13 @@ use App\Enums\MatchType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class HeadMapping extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected $fillable = [
         'pattern',
@@ -19,6 +22,14 @@ class HeadMapping extends Model
         'created_by',
         'usage_count',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['pattern', 'match_type', 'account_head_id', 'bank_name', 'usage_count'])
+            ->logOnlyDirty()
+            ->useLogName('head-mappings');
+    }
 
     protected function casts(): array
     {

--- a/app/Models/ImportedFile.php
+++ b/app/Models/ImportedFile.php
@@ -9,10 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class ImportedFile extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected static function booted(): void
     {
@@ -37,6 +40,26 @@ class ImportedFile extends Model
         'uploaded_by',
         'processed_at',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'bank_name',
+                'statement_type',
+                'file_path',
+                'original_filename',
+                'file_hash',
+                'status',
+                'total_rows',
+                'mapped_rows',
+                'error_message',
+                'uploaded_by',
+                'processed_at',
+            ])
+            ->logOnlyDirty()
+            ->useLogName('imported-files');
+    }
 
     protected function casts(): array
     {

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class Transaction extends Model
 {
     use HasFactory;
+    use LogsActivity;
 
     protected $fillable = [
         'imported_file_id',
@@ -26,6 +29,22 @@ class Transaction extends Model
         'raw_data',
         'bank_format',
     ];
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'imported_file_id',
+                'date',
+                'reference_number',
+                'account_head_id',
+                'mapping_type',
+                'ai_confidence',
+                'bank_format',
+            ])
+            ->logOnlyDirty()
+            ->useLogName('transactions');
+    }
 
     protected function casts(): array
     {

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,0 +1,52 @@
+<?php
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITY_LOGGER_ENABLED', true),
+
+    /*
+     * When the clean-command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'delete_records_older_than_days' => 365,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'default',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject returns soft deleted models.
+     */
+    'subject_returns_soft_deleted_models' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => \Spatie\Activitylog\Models\Activity::class,
+
+    /*
+     * This is the name of the table that will be created by the migration and
+     * used by the Activity model shipped with this package.
+     */
+    'table_name' => env('ACTIVITY_LOGGER_TABLE_NAME', 'activity_log'),
+
+    /*
+     * This is the database connection that will be used by the migration and
+     * the Activity model shipped with this package. In case it's not set
+     * Laravel's database.default will be used instead.
+     */
+    'database_connection' => env('ACTIVITY_LOGGER_DB_CONNECTION'),
+];

--- a/database/migrations/2026_02_25_000001_create_activity_log_table.php
+++ b/database/migrations/2026_02_25_000001_create_activity_log_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))
+            ->create(config('activitylog.table_name'), function (Blueprint $table) {
+                $table->id();
+                $table->text('log_name')->nullable();
+                $table->text('description');
+                $table->nullableMorphs('subject', 'subject');
+                $table->text('event')->nullable();
+                $table->nullableMorphs('causer', 'causer');
+                $table->jsonb('properties')->nullable();
+                $table->uuid('batch_uuid')->nullable();
+                $table->timestampsTz();
+
+                $table->index('log_name');
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::connection(config('activitylog.database_connection'))
+            ->dropIfExists(config('activitylog.table_name'));
+    }
+};

--- a/tests/Feature/Models/ActivityLogTest.php
+++ b/tests/Feature/Models/ActivityLogTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\Models\Activity;
+
+describe('AccountHead activity logging', function () {
+    it('logs activity when an account head is created', function () {
+        $head = AccountHead::factory()->create(['name' => 'Office Rent']);
+
+        $activity = Activity::where('subject_type', AccountHead::class)
+            ->where('subject_id', $head->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->log_name)->toBe('account-heads')
+            ->and($activity->description)->toBe('created')
+            ->and($activity->properties['attributes']['name'])->toBe('Office Rent');
+    });
+});
+
+describe('HeadMapping activity logging', function () {
+    it('logs changed fields when a head mapping is updated', function () {
+        $mapping = HeadMapping::factory()->create(['pattern' => 'SALARY']);
+
+        $mapping->update(['pattern' => 'SALARY PAYMENT']);
+
+        $activity = Activity::where('subject_type', HeadMapping::class)
+            ->where('subject_id', $mapping->id)
+            ->where('event', 'updated')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->log_name)->toBe('head-mappings')
+            ->and($activity->properties['old']['pattern'])->toBe('SALARY')
+            ->and($activity->properties['attributes']['pattern'])->toBe('SALARY PAYMENT');
+    });
+});
+
+describe('ImportedFile activity logging', function () {
+    it('logs activity when an imported file is deleted', function () {
+        Storage::fake('local');
+
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'HDFC',
+            'original_filename' => 'statement.pdf',
+        ]);
+        $fileId = $file->id;
+
+        $file->delete();
+
+        $activity = Activity::where('subject_type', ImportedFile::class)
+            ->where('subject_id', $fileId)
+            ->where('event', 'deleted')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->log_name)->toBe('imported-files');
+    });
+});
+
+describe('Encrypted fields are excluded from activity log', function () {
+    it('does not log encrypted Transaction fields', function () {
+        $transaction = Transaction::factory()->create([
+            'description' => 'Secret payment details',
+            'debit' => 5000.00,
+            'credit' => null,
+            'balance' => 15000.00,
+            'raw_data' => ['secret' => 'data'],
+        ]);
+
+        $activity = Activity::where('subject_type', Transaction::class)
+            ->where('subject_id', $transaction->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->log_name)->toBe('transactions');
+
+        $loggedAttributes = $activity->properties['attributes'] ?? [];
+
+        expect($loggedAttributes)->not->toHaveKey('description')
+            ->and($loggedAttributes)->not->toHaveKey('debit')
+            ->and($loggedAttributes)->not->toHaveKey('credit')
+            ->and($loggedAttributes)->not->toHaveKey('balance')
+            ->and($loggedAttributes)->not->toHaveKey('raw_data');
+    });
+
+    it('does not log encrypted ImportedFile fields', function () {
+        $file = ImportedFile::factory()->create([
+            'account_number' => '9876543210',
+            'bank_name' => 'ICICI',
+        ]);
+
+        $activity = Activity::where('subject_type', ImportedFile::class)
+            ->where('subject_id', $file->id)
+            ->where('event', 'created')
+            ->first();
+
+        expect($activity)->not->toBeNull();
+
+        $loggedAttributes = $activity->properties['attributes'] ?? [];
+
+        expect($loggedAttributes)->not->toHaveKey('account_number')
+            ->and($loggedAttributes)->toHaveKey('bank_name');
+    });
+});


### PR DESCRIPTION
## Summary
- Add LogsActivity trait to AccountHead, HeadMapping, ImportedFile, and Transaction models
- Encrypted fields excluded from activity logs via logOnly() to prevent sensitive data exposure
- PostgreSQL-compliant migration with TIMESTAMPTZ, JSONB, and TEXT columns
- Each model uses logOnlyDirty() and descriptive useLogName()

## Test plan
- [x] Creating AccountHead logs activity with correct log name and attributes
- [x] Updating HeadMapping logs old and new values for changed fields
- [x] Deleting ImportedFile logs the deletion event
- [x] Encrypted Transaction fields are NOT logged
- [x] Encrypted ImportedFile fields are NOT logged
- [x] PHPStan and Pint pass

Closes #16

Generated with [Claude Code](https://claude.com/claude-code)
