### PR TITLE
feat(models): add soft deletes with cascade behavior

### DIFF
--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -11,7 +11,10 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use UnitEnum;
 
 class AccountHeadResource extends Resource
@@ -93,6 +96,8 @@ class AccountHeadResource extends Resource
             ])
             ->defaultSort('name')
             ->filters([
+                TrashedFilter::make(),
+
                 Tables\Filters\TernaryFilter::make('is_active')
                     ->label('Active'),
 
@@ -105,10 +110,14 @@ class AccountHeadResource extends Resource
             ->actions([
                 Actions\EditAction::make(),
                 Actions\DeleteAction::make(),
+                Actions\ForceDeleteAction::make(),
+                Actions\RestoreAction::make(),
             ])
             ->bulkActions([
                 Actions\BulkActionGroup::make([
                     Actions\DeleteBulkAction::make(),
+                    Actions\ForceDeleteBulkAction::make(),
+                    Actions\RestoreBulkAction::make(),
                 ]),
             ])
             ->headerActions([
@@ -122,6 +131,15 @@ class AccountHeadResource extends Resource
                     })
                     ->disabled()
                     ->tooltip('Coming soon — awaiting Tally XML reference format'),
+            ]);
+    }
+
+    /** @return Builder<AccountHead> */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
             ]);
     }
 

--- a/app/Filament/Resources/AccountHeadResource/Pages/EditAccountHead.php
+++ b/app/Filament/Resources/AccountHeadResource/Pages/EditAccountHead.php
@@ -14,6 +14,8 @@ class EditAccountHead extends EditRecord
     {
         return [
             Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
         ];
     }
 }

--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -14,8 +14,10 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class ImportedFileResource extends Resource
 {
@@ -110,6 +112,8 @@ class ImportedFileResource extends Resource
             ])
             ->defaultSort('created_at', 'desc')
             ->filters([
+                TrashedFilter::make(),
+
                 Tables\Filters\SelectFilter::make('status')
                     ->options(ImportStatus::class),
 
@@ -147,11 +151,24 @@ class ImportedFileResource extends Resource
                     ])),
 
                 Actions\DeleteAction::make(),
+                Actions\ForceDeleteAction::make(),
+                Actions\RestoreAction::make(),
             ])
             ->bulkActions([
                 Actions\BulkActionGroup::make([
                     Actions\DeleteBulkAction::make(),
+                    Actions\ForceDeleteBulkAction::make(),
+                    Actions\RestoreBulkAction::make(),
                 ]),
+            ]);
+    }
+
+    /** @return Builder<ImportedFile> */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
             ]);
     }
 

--- a/app/Models/AccountHead.php
+++ b/app/Models/AccountHead.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -13,6 +14,7 @@ class AccountHead extends Model
 {
     use HasFactory;
     use LogsActivity;
+    use SoftDeletes;
 
     protected $fillable = [
         'name',

--- a/app/Models/ImportedFile.php
+++ b/app/Models/ImportedFile.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -16,13 +17,26 @@ class ImportedFile extends Model
 {
     use HasFactory;
     use LogsActivity;
+    use SoftDeletes;
 
     protected static function booted(): void
     {
         static::deleting(function (ImportedFile $file) {
-            if ($file->file_path && Storage::disk('local')->exists($file->file_path)) {
-                Storage::disk('local')->delete($file->file_path);
+            if ($file->isForceDeleting()) {
+                if ($file->file_path && Storage::disk('local')->exists($file->file_path)) {
+                    Storage::disk('local')->delete($file->file_path);
+                }
+            } else {
+                Transaction::where('imported_file_id', $file->id)->each(
+                    fn (Transaction $transaction) => $transaction->delete()
+                );
             }
+        });
+
+        static::restoring(function (ImportedFile $file) {
+            Transaction::onlyTrashed()->where('imported_file_id', $file->id)->each(
+                fn (Transaction $transaction) => $transaction->restore()
+            );
         });
     }
 

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -14,6 +15,7 @@ class Transaction extends Model
 {
     use HasFactory;
     use LogsActivity;
+    use SoftDeletes;
 
     protected $fillable = [
         'imported_file_id',

--- a/database/migrations/2026_02_25_000002_add_soft_deletes_to_models.php
+++ b/database/migrations/2026_02_25_000002_add_soft_deletes_to_models.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->softDeletesTz();
+        });
+
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->softDeletesTz();
+        });
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->softDeletesTz();
+        });
+
+        // Convert the existing unique constraint on account_heads to a partial
+        // unique index that only applies to non-deleted records (PostgreSQL rule:
+        // partial unique with WHERE deleted_at IS NULL when using soft deletes).
+        // Must drop the constraint (not index) because Laravel's unique() creates
+        // a constraint in PostgreSQL.
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->dropUnique('account_heads_name_group_unique');
+        });
+        DB::statement(
+            'CREATE UNIQUE INDEX account_heads_name_group_unique ON account_heads (name, group_name) WHERE deleted_at IS NULL'
+        );
+
+        // Convert the existing unique constraint on imported_files.file_hash to
+        // a partial unique index as well.
+        // Drop the Laravel-generated unique index first.
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->dropUnique(['file_hash']);
+        });
+        DB::statement(
+            'CREATE UNIQUE INDEX imported_files_file_hash_unique ON imported_files (file_hash) WHERE deleted_at IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        // Restore original unique constraints
+        DB::statement('DROP INDEX IF EXISTS imported_files_file_hash_unique');
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->unique('file_hash');
+        });
+
+        DB::statement('DROP INDEX IF EXISTS account_heads_name_group_unique');
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->unique(['name', 'group_name'], 'account_heads_name_group_unique');
+        });
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropSoftDeletesTz();
+        });
+
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->dropSoftDeletesTz();
+        });
+
+        Schema::table('account_heads', function (Blueprint $table) {
+            $table->dropSoftDeletesTz();
+        });
+    }
+};

--- a/tests/Feature/Models/AccountHeadTest.php
+++ b/tests/Feature/Models/AccountHeadTest.php
@@ -1,6 +1,61 @@
 <?php
 
 use App\Models\AccountHead;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+describe('AccountHead soft deletes', function () {
+    it('uses the SoftDeletes trait', function () {
+        expect(in_array(SoftDeletes::class, class_uses_recursive(AccountHead::class)))->toBeTrue();
+    });
+
+    it('is excluded from normal queries after soft delete', function () {
+        $head = AccountHead::factory()->create();
+
+        $head->delete();
+
+        expect(AccountHead::find($head->id))->toBeNull();
+    });
+
+    it('can be restored after soft delete', function () {
+        $head = AccountHead::factory()->create();
+        $head->delete();
+
+        $head->restore();
+
+        expect(AccountHead::find($head->id))->not->toBeNull();
+    });
+
+    it('is permanently removed after force delete', function () {
+        $head = AccountHead::factory()->create();
+
+        $head->forceDelete();
+
+        expect(AccountHead::withTrashed()->find($head->id))->toBeNull();
+    });
+
+    it('is included in withTrashed queries after soft delete', function () {
+        $head = AccountHead::factory()->create();
+        $head->delete();
+
+        expect(AccountHead::withTrashed()->find($head->id))->not->toBeNull();
+        expect(AccountHead::withTrashed()->find($head->id)->trashed())->toBeTrue();
+    });
+
+    it('allows duplicate name+group when one is soft-deleted', function () {
+        $head = AccountHead::factory()->create([
+            'name' => 'Unique Test Head',
+            'group_name' => 'Test Group',
+        ]);
+        $head->delete();
+
+        $newHead = AccountHead::factory()->create([
+            'name' => 'Unique Test Head',
+            'group_name' => 'Test Group',
+        ]);
+
+        expect($newHead->exists)->toBeTrue();
+    });
+});
 
 describe('AccountHead::fullPath', function () {
     it('returns just the name when there is no parent', function () {

--- a/tests/Feature/Models/ImportedFileTest.php
+++ b/tests/Feature/Models/ImportedFileTest.php
@@ -1,7 +1,94 @@
 <?php
 
 use App\Models\ImportedFile;
+use App\Models\Transaction;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
+
+describe('ImportedFile soft deletes', function () {
+    it('uses the SoftDeletes trait', function () {
+        expect(in_array(SoftDeletes::class, class_uses_recursive(ImportedFile::class)))->toBeTrue();
+    });
+
+    it('is excluded from normal queries after soft delete', function () {
+        $file = ImportedFile::factory()->create();
+
+        $file->delete();
+
+        expect(ImportedFile::find($file->id))->toBeNull();
+    });
+
+    it('can be restored after soft delete', function () {
+        $file = ImportedFile::factory()->create();
+        $file->delete();
+
+        $file->restore();
+
+        expect(ImportedFile::find($file->id))->not->toBeNull();
+    });
+
+    it('is permanently removed after force delete', function () {
+        $file = ImportedFile::factory()->create();
+
+        $file->forceDelete();
+
+        expect(ImportedFile::withTrashed()->find($file->id))->toBeNull();
+    });
+
+    it('is included in withTrashed queries after soft delete', function () {
+        $file = ImportedFile::factory()->create();
+        $file->delete();
+
+        expect(ImportedFile::withTrashed()->find($file->id))->not->toBeNull();
+        expect(ImportedFile::withTrashed()->find($file->id)->trashed())->toBeTrue();
+    });
+
+    it('does not delete file from storage on soft delete', function () {
+        Storage::fake('local');
+        Storage::disk('local')->put('statements/test.pdf', 'content');
+
+        $file = ImportedFile::factory()->create(['file_path' => 'statements/test.pdf']);
+        $file->delete();
+
+        Storage::disk('local')->assertExists('statements/test.pdf');
+    });
+
+    it('deletes file from storage on force delete', function () {
+        Storage::fake('local');
+        Storage::disk('local')->put('statements/test.pdf', 'content');
+
+        $file = ImportedFile::factory()->create(['file_path' => 'statements/test.pdf']);
+        $file->forceDelete();
+
+        Storage::disk('local')->assertMissing('statements/test.pdf');
+    });
+});
+
+describe('ImportedFile cascade soft deletes', function () {
+    it('soft-deletes associated transactions when soft-deleted', function () {
+        $file = ImportedFile::factory()->create();
+        $transactions = Transaction::factory()->for($file, 'importedFile')->count(3)->create();
+
+        $file->delete();
+
+        foreach ($transactions as $transaction) {
+            expect(Transaction::find($transaction->id))->toBeNull();
+            expect(Transaction::withTrashed()->find($transaction->id)->trashed())->toBeTrue();
+        }
+    });
+
+    it('restores associated transactions when restored', function () {
+        $file = ImportedFile::factory()->create();
+        $transactions = Transaction::factory()->for($file, 'importedFile')->count(3)->create();
+        $file->delete();
+
+        $file->restore();
+
+        foreach ($transactions as $transaction) {
+            expect(Transaction::find($transaction->id))->not->toBeNull();
+        }
+    });
+});
 
 describe('ImportedFile::mappedPercentage', function () {
     it('returns 0 when total_rows is zero', function () {
@@ -29,22 +116,22 @@ describe('ImportedFile::mappedPercentage', function () {
     });
 });
 
-describe('ImportedFile deleting event', function () {
-    it('deletes the file from storage when model is deleted', function () {
+describe('ImportedFile forceDeleting event', function () {
+    it('deletes the file from storage when model is force-deleted', function () {
         Storage::fake('local');
         Storage::disk('local')->put('statements/test.pdf', 'content');
 
         $file = ImportedFile::factory()->create(['file_path' => 'statements/test.pdf']);
-        $file->delete();
+        $file->forceDelete();
 
         Storage::disk('local')->assertMissing('statements/test.pdf');
     });
 
-    it('does not fail when file does not exist on disk', function () {
+    it('does not fail when file does not exist on disk during force delete', function () {
         Storage::fake('local');
 
         $file = ImportedFile::factory()->create(['file_path' => 'statements/nonexistent.pdf']);
-        $file->delete();
+        $file->forceDelete();
 
         expect(true)->toBeTrue(); // No exception thrown
     });

--- a/tests/Feature/Models/TransactionTest.php
+++ b/tests/Feature/Models/TransactionTest.php
@@ -3,6 +3,38 @@
 use App\Models\AccountHead;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+describe('Transaction soft deletes', function () {
+    it('uses the SoftDeletes trait', function () {
+        expect(in_array(SoftDeletes::class, class_uses_recursive(Transaction::class)))->toBeTrue();
+    });
+
+    it('is excluded from normal queries after soft delete', function () {
+        $transaction = Transaction::factory()->create();
+
+        $transaction->delete();
+
+        expect(Transaction::find($transaction->id))->toBeNull();
+    });
+
+    it('can be restored after soft delete', function () {
+        $transaction = Transaction::factory()->create();
+        $transaction->delete();
+
+        $transaction->restore();
+
+        expect(Transaction::find($transaction->id))->not->toBeNull();
+    });
+
+    it('is permanently removed after force delete', function () {
+        $transaction = Transaction::factory()->create();
+
+        $transaction->forceDelete();
+
+        expect(Transaction::withTrashed()->find($transaction->id))->toBeNull();
+    });
+});
 
 describe('Transaction scopes', function () {
     beforeEach(function () {


### PR DESCRIPTION
## Summary
- Add `SoftDeletes` trait to `AccountHead`, `ImportedFile`, and `Transaction` models with `TIMESTAMPTZ` `deleted_at` columns
- Convert existing unique constraints (`account_heads.name+group_name`, `imported_files.file_hash`) to PostgreSQL partial unique indexes (`WHERE deleted_at IS NULL`) per project rules
- Cascade soft delete/restore: soft-deleting an `ImportedFile` also soft-deletes its associated `Transaction` records, and restoring reverses this
- Update Filament resources with `TrashedFilter`, `RestoreAction`, `ForceDeleteAction`, and `getEloquentQuery()` override for admin panel soft-delete support
- Move file storage cleanup from `deleting` to `forceDeleting` event so files are preserved during soft delete

Closes #12

## Test plan
- [x] AccountHead: soft delete, restore, force delete, withTrashed, partial unique index
- [x] ImportedFile: soft delete, restore, force delete, withTrashed, storage preserved on soft delete, storage cleaned on force delete
- [x] ImportedFile cascade: soft-deleting cascades to transactions, restoring cascades back
- [x] Transaction: SoftDeletes trait, soft delete, restore, force delete
- [x] All 194 existing tests pass (400 assertions)
- [x] PHPStan level 6 passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)