### PR TITLE
feat(ai): make AI model configurable via env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,15 @@ For new migrations, these rules are non-negotiable:
 - `StatementParser` — PDF → structured transaction data
 - `HeadMatcher` — transaction descriptions → account head suggestions with confidence
 
+**Model configuration:** Each agent reads its model from `config/ai.php` via environment variables:
+
+| Agent | Env Var | Config Key | Default |
+|-------|---------|------------|---------|
+| `StatementParser` | `AI_PARSING_MODEL` | `ai.models.parsing` | `mistral-large-latest` |
+| `HeadMatcher` | `AI_MATCHING_MODEL` | `ai.models.matching` | `mistral-large-latest` |
+
+The agents use the `model()` method (laravel/ai convention) to resolve the model at runtime, allowing model changes without code modifications.
+
 ### Background Jobs
 - `ProcessImportedFile` — parses PDF via StatementParser agent, creates transactions
 - `MatchTransactionHeads` — runs rule-based + AI matching on unmapped transactions

--- a/app/Ai/Agents/HeadMatcher.php
+++ b/app/Ai/Agents/HeadMatcher.php
@@ -4,7 +4,6 @@ namespace App\Ai\Agents;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxTokens;
-use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
@@ -14,7 +13,6 @@ use Laravel\Ai\Promptable;
 use Stringable;
 
 #[Provider(Lab::Mistral)]
-#[Model('mistral-large-latest')]
 #[MaxTokens(4096)]
 #[Temperature(0.2)]
 class HeadMatcher implements Agent, HasStructuredOutput
@@ -22,6 +20,14 @@ class HeadMatcher implements Agent, HasStructuredOutput
     use Promptable;
 
     protected string $chartOfAccounts = '';
+
+    /**
+     * Get the model to use for head matching.
+     */
+    public function model(): string
+    {
+        return config('ai.models.matching', 'mistral-large-latest');
+    }
 
     /**
      * Set the chart of accounts context (format: "ID: Name (Group)" per line).

--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -4,7 +4,6 @@ namespace App\Ai\Agents;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxTokens;
-use Laravel\Ai\Attributes\Model;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Contracts\Agent;
@@ -14,12 +13,19 @@ use Laravel\Ai\Promptable;
 use Stringable;
 
 #[Provider(Lab::Mistral)]
-#[Model('mistral-large-latest')]
 #[MaxTokens(8192)]
 #[Temperature(0.1)]
 class StatementParser implements Agent, HasStructuredOutput
 {
     use Promptable;
+
+    /**
+     * Get the model to use for statement parsing.
+     */
+    public function model(): string
+    {
+        return config('ai.models.parsing', 'mistral-large-latest');
+    }
 
     public function instructions(): Stringable|string
     {

--- a/config/ai.php
+++ b/config/ai.php
@@ -20,4 +20,22 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | AI Model Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configure which models each AI agent uses. This allows switching models
+    | via environment variables without code changes.
+    |
+    */
+
+    'models' => [
+
+        'parsing' => env('AI_PARSING_MODEL', 'mistral-large-latest'),
+
+        'matching' => env('AI_MATCHING_MODEL', 'mistral-large-latest'),
+
+    ],
+
 ];

--- a/tests/Feature/Ai/AgentsTest.php
+++ b/tests/Feature/Ai/AgentsTest.php
@@ -23,6 +23,20 @@ describe('StatementParser agent', function () {
     it('has HasStructuredOutput schema method', function () {
         expect(method_exists(StatementParser::class, 'schema'))->toBeTrue();
     });
+
+    it('uses the configured model from ai config', function () {
+        $agent = new StatementParser;
+
+        expect($agent->model())->toBe(config('ai.models.parsing'));
+    });
+
+    it('adapts to a custom model when config is changed', function () {
+        config()->set('ai.models.parsing', 'mistral-small-latest');
+
+        $agent = new StatementParser;
+
+        expect($agent->model())->toBe('mistral-small-latest');
+    });
 });
 
 describe('HeadMatcher agent', function () {
@@ -53,5 +67,19 @@ describe('HeadMatcher agent', function () {
 
     it('has HasStructuredOutput schema method', function () {
         expect(method_exists(HeadMatcher::class, 'schema'))->toBeTrue();
+    });
+
+    it('uses the configured model from ai config', function () {
+        $agent = new HeadMatcher;
+
+        expect($agent->model())->toBe(config('ai.models.matching'));
+    });
+
+    it('adapts to a custom model when config is changed', function () {
+        config()->set('ai.models.matching', 'codestral-latest');
+
+        $agent = new HeadMatcher;
+
+        expect($agent->model())->toBe('codestral-latest');
     });
 });


### PR DESCRIPTION
## Summary

- Add `AI_PARSING_MODEL` and `AI_MATCHING_MODEL` env vars to configure AI agent models at runtime
- Replace hardcoded `#[Model('mistral-large-latest')]` attributes with `model()` methods that read from `config/ai.php`
- Add `models` section to `config/ai.php` with environment variable support and sensible defaults
- Document model configuration in CLAUDE.md

Closes #5

## Changes

| File | Change |
|------|--------|
| `config/ai.php` | Add `models.parsing` and `models.matching` config with `env()` |
| `app/Ai/Agents/StatementParser.php` | Replace `#[Model]` attribute with `model()` method |
| `app/Ai/Agents/HeadMatcher.php` | Replace `#[Model]` attribute with `model()` method |
| `tests/Feature/Ai/AgentsTest.php` | Add 4 tests for config-driven model selection |
| `CLAUDE.md` | Document AI model configuration table |

## Notes

- The `model()` method is the framework-supported way to override model selection in `laravel/ai` (the `Promptable` trait checks for it before falling back to the `#[Model]` attribute)
- `.env.example` needs manual update to add `AI_PARSING_MODEL=mistral-large-latest` and `AI_MATCHING_MODEL=mistral-large-latest` (protected by hook)
- Default model remains `mistral-large-latest` so this is a backward-compatible change

## Test plan

- [x] New tests verify agents use config values (not hardcoded)
- [x] New tests verify agents adapt when config is changed at runtime
- [x] All 13 agent tests pass (including 4 new ones)
- [x] PHPStan passes with 0 errors
- [x] Full test suite passes (only pre-existing DB schema failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)