### PR TITLE
feat(matching): add priority ordering to RuleBasedMatcher

### DIFF
--- a/app/Filament/Resources/HeadMappingResource.php
+++ b/app/Filament/Resources/HeadMappingResource.php
@@ -65,6 +65,13 @@ class HeadMappingResource extends Resource
                             ->label('Bank Name')
                             ->helperText('Optional: restrict this rule to a specific bank')
                             ->maxLength(255),
+
+                        Forms\Components\TextInput::make('priority')
+                            ->label('Priority')
+                            ->numeric()
+                            ->integer()
+                            ->minValue(1)
+                            ->helperText('Optional: lower number = higher priority. Overrides automatic ordering.'),
                     ])
                     ->columns(2),
             ]);
@@ -95,6 +102,12 @@ class HeadMappingResource extends Resource
                 Tables\Columns\TextColumn::make('usage_count')
                     ->label('Uses')
                     ->numeric()
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('priority')
+                    ->label('Priority')
+                    ->numeric()
+                    ->placeholder('Auto')
                     ->sortable(),
 
                 Tables\Columns\TextColumn::make('creator.name')

--- a/app/Models/HeadMapping.php
+++ b/app/Models/HeadMapping.php
@@ -21,12 +21,13 @@ class HeadMapping extends Model
         'bank_name',
         'created_by',
         'usage_count',
+        'priority',
     ];
 
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['pattern', 'match_type', 'account_head_id', 'bank_name', 'usage_count'])
+            ->logOnly(['pattern', 'match_type', 'account_head_id', 'bank_name', 'usage_count', 'priority'])
             ->logOnlyDirty()
             ->useLogName('head-mappings');
     }
@@ -36,6 +37,7 @@ class HeadMapping extends Model
         return [
             'match_type' => MatchType::class,
             'usage_count' => 'integer',
+            'priority' => 'integer',
         ];
     }
 

--- a/app/Services/HeadMatcher/RuleBasedMatcher.php
+++ b/app/Services/HeadMatcher/RuleBasedMatcher.php
@@ -11,7 +11,24 @@ use Illuminate\Support\Collection;
 class RuleBasedMatcher
 {
     /**
+     * Match type specificity scores — higher means more specific.
+     *
+     * @var array<string, int>
+     */
+    private const MATCH_TYPE_SPECIFICITY = [
+        'exact' => 3,
+        'regex' => 2,
+        'contains' => 1,
+    ];
+
+    /**
      * Match transactions against existing head mapping rules.
+     *
+     * Rules are ordered by specificity before matching:
+     * 1. Manual priority (lower number = higher priority, null = no override)
+     * 2. Match type specificity: exact > regex > contains
+     * 3. Bank name specificity: bank-specific > any-bank (null)
+     * 4. Usage count descending (most-used rules first)
      *
      * @param  Collection<int, Transaction>  $transactions
      * @return array<int, array{transaction_id: int, account_head_id: int, mapping_id: int}>
@@ -28,7 +45,7 @@ class RuleBasedMatcher
             });
         }
 
-        $rules = $query->get();
+        $rules = $this->sortByPriority($query->get());
 
         $matches = [];
         /** @var array<int, int> $usageCounts */
@@ -51,7 +68,7 @@ class RuleBasedMatcher
 
                     $usageCounts[$rule->id] = ($usageCounts[$rule->id] ?? 0) + 1;
 
-                    break; // First match wins
+                    break; // First match wins (from priority-ordered rules)
                 }
             }
         }
@@ -62,6 +79,63 @@ class RuleBasedMatcher
         }
 
         return $matches;
+    }
+
+    /**
+     * Sort rules by priority for deterministic matching.
+     *
+     * @param  Collection<int, HeadMapping>  $rules
+     * @return Collection<int, HeadMapping>
+     */
+    private function sortByPriority(Collection $rules): Collection
+    {
+        return $rules->sort(function (HeadMapping $a, HeadMapping $b): int {
+            // 1. Manual priority takes precedence (lower number = higher priority)
+            // Rules with a manual priority always come before rules without one
+            if ($a->priority !== null && $b->priority === null) {
+                return -1;
+            }
+            if ($a->priority === null && $b->priority !== null) {
+                return 1;
+            }
+            if ($a->priority !== null && $b->priority !== null) {
+                $priorityDiff = $a->priority - $b->priority;
+                if ($priorityDiff !== 0) {
+                    return $priorityDiff;
+                }
+            }
+
+            // 2. Match type specificity: exact > regex > contains
+            $aSpecificity = $this->matchTypeSpecificity($a->match_type);
+            $bSpecificity = $this->matchTypeSpecificity($b->match_type);
+            $specificityDiff = $bSpecificity - $aSpecificity; // Higher specificity first
+            if ($specificityDiff !== 0) {
+                return $specificityDiff;
+            }
+
+            // 3. Bank name specificity: bank-specific > null/any-bank
+            $aBankSpecific = $a->bank_name !== null ? 1 : 0;
+            $bBankSpecific = $b->bank_name !== null ? 1 : 0;
+            $bankDiff = $bBankSpecific - $aBankSpecific; // Bank-specific first
+            if ($bankDiff !== 0) {
+                return $bankDiff;
+            }
+
+            // 4. Usage count descending
+            return $b->usage_count - $a->usage_count;
+        })->values();
+    }
+
+    /**
+     * Get the specificity score for a match type.
+     *
+     * @param  \App\Enums\MatchType|string  $matchType
+     */
+    private function matchTypeSpecificity(mixed $matchType): int
+    {
+        $value = $matchType instanceof \App\Enums\MatchType ? $matchType->value : (string) $matchType;
+
+        return self::MATCH_TYPE_SPECIFICITY[$value] ?? 0;
     }
 
     /**

--- a/database/factories/HeadMappingFactory.php
+++ b/database/factories/HeadMappingFactory.php
@@ -33,6 +33,7 @@ class HeadMappingFactory extends Factory
             'bank_name' => null,
             'created_by' => User::factory(),
             'usage_count' => 0,
+            'priority' => null,
         ];
     }
 
@@ -62,6 +63,13 @@ class HeadMappingFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'usage_count' => $count,
+        ]);
+    }
+
+    public function withPriority(int $priority): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => $priority,
         ]);
     }
 }

--- a/database/migrations/2026_02_25_165820_add_priority_to_head_mappings_table.php
+++ b/database/migrations/2026_02_25_165820_add_priority_to_head_mappings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('head_mappings', function (Blueprint $table) {
+            $table->integer('priority')->nullable()->after('usage_count');
+            $table->index('priority');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('head_mappings', function (Blueprint $table) {
+            $table->dropIndex(['priority']);
+            $table->dropColumn('priority');
+        });
+    }
+};

--- a/tests/Feature/Services/RuleBasedMatcherTest.php
+++ b/tests/Feature/Services/RuleBasedMatcherTest.php
@@ -133,7 +133,7 @@ describe('RuleBasedMatcher::match()', function () {
             ->and($mapping2->fresh()->usage_count)->toBe(5);
     });
 
-    it('uses first match wins strategy', function () {
+    it('uses first match wins from priority-ordered rules', function () {
         $head1 = AccountHead::factory()->create(['name' => 'Head 1']);
         $head2 = AccountHead::factory()->create(['name' => 'Head 2']);
 
@@ -155,6 +155,230 @@ describe('RuleBasedMatcher::match()', function () {
         $matches = $matcher->match($file->transactions);
 
         expect($matches)->toHaveCount(1);
+    });
+
+    it('prioritizes exact match over contains match', function () {
+        $exactHead = AccountHead::factory()->create(['name' => 'Exact Head']);
+        $containsHead = AccountHead::factory()->create(['name' => 'Contains Head']);
+
+        // Create contains rule first (inserted before exact)
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY JUNE 2024',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $containsHead->id,
+        ]);
+
+        // Create exact rule second (inserted after contains)
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY JUNE 2024',
+            'match_type' => MatchType::Exact,
+            'account_head_id' => $exactHead->id,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'SALARY JUNE 2024']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($exactHead->id);
+    });
+
+    it('prioritizes regex match over contains match', function () {
+        $regexHead = AccountHead::factory()->create(['name' => 'Regex Head']);
+        $containsHead = AccountHead::factory()->create(['name' => 'Contains Head']);
+
+        // Create contains rule first
+        HeadMapping::factory()->create([
+            'pattern' => 'NEFT',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $containsHead->id,
+        ]);
+
+        // Create regex rule second
+        HeadMapping::factory()->create([
+            'pattern' => '/NEFT[-\/]\d+/i',
+            'match_type' => MatchType::Regex,
+            'account_head_id' => $regexHead->id,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'NEFT-12345 TRANSFER']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($regexHead->id);
+    });
+
+    it('prioritizes exact match over regex match', function () {
+        $exactHead = AccountHead::factory()->create(['name' => 'Exact Head']);
+        $regexHead = AccountHead::factory()->create(['name' => 'Regex Head']);
+
+        // Create regex rule first
+        HeadMapping::factory()->create([
+            'pattern' => '/^SALARY JUNE 2024$/i',
+            'match_type' => MatchType::Regex,
+            'account_head_id' => $regexHead->id,
+        ]);
+
+        // Create exact rule second
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY JUNE 2024',
+            'match_type' => MatchType::Exact,
+            'account_head_id' => $exactHead->id,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'SALARY JUNE 2024']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($exactHead->id);
+    });
+
+    it('prioritizes bank-specific rule over any-bank rule within same match type', function () {
+        $bankHead = AccountHead::factory()->create(['name' => 'Bank-specific Head']);
+        $anyHead = AccountHead::factory()->create(['name' => 'Any Bank Head']);
+
+        // Create any-bank rule first
+        HeadMapping::factory()->create([
+            'pattern' => 'NEFT',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $anyHead->id,
+            'bank_name' => null,
+        ]);
+
+        // Create bank-specific rule second
+        HeadMapping::factory()->forBank('HDFC')->create([
+            'pattern' => 'NEFT',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $bankHead->id,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'NEFT TRANSFER']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions, 'HDFC');
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($bankHead->id);
+    });
+
+    it('prioritizes higher usage_count when same match type and bank specificity', function () {
+        $popularHead = AccountHead::factory()->create(['name' => 'Popular Head']);
+        $newHead = AccountHead::factory()->create(['name' => 'New Head']);
+
+        // Create low-usage rule first
+        HeadMapping::factory()->create([
+            'pattern' => 'EMI',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $newHead->id,
+            'usage_count' => 2,
+        ]);
+
+        // Create high-usage rule second
+        HeadMapping::factory()->create([
+            'pattern' => 'EMI',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $popularHead->id,
+            'usage_count' => 50,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'EMI PAYMENT']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($popularHead->id);
+    });
+
+    it('uses manual priority column to override automatic ordering', function () {
+        $manualHead = AccountHead::factory()->create(['name' => 'Manual Priority Head']);
+        $exactHead = AccountHead::factory()->create(['name' => 'Exact Head']);
+
+        // Create an exact match rule (normally highest specificity)
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY JUNE 2024',
+            'match_type' => MatchType::Exact,
+            'account_head_id' => $exactHead->id,
+            'priority' => null,
+        ]);
+
+        // Create a contains match rule with manual priority override
+        HeadMapping::factory()->create([
+            'pattern' => 'SALARY',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $manualHead->id,
+            'priority' => 1, // Highest priority (lower number = higher)
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'SALARY JUNE 2024']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions);
+
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($manualHead->id);
+    });
+
+    it('resolves overlapping rules deterministically', function () {
+        $head1 = AccountHead::factory()->create(['name' => 'Head A']);
+        $head2 = AccountHead::factory()->create(['name' => 'Head B']);
+        $head3 = AccountHead::factory()->create(['name' => 'Head C']);
+
+        // Contains rule, no bank, low usage
+        HeadMapping::factory()->create([
+            'pattern' => 'TRANSFER',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head1->id,
+            'usage_count' => 5,
+            'bank_name' => null,
+        ]);
+
+        // Contains rule, bank-specific, low usage
+        HeadMapping::factory()->forBank('HDFC')->create([
+            'pattern' => 'TRANSFER',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head2->id,
+            'usage_count' => 3,
+        ]);
+
+        // Exact rule, no bank, no usage
+        HeadMapping::factory()->create([
+            'pattern' => 'NEFT TRANSFER TO VENDOR',
+            'match_type' => MatchType::Exact,
+            'account_head_id' => $head3->id,
+            'usage_count' => 0,
+            'bank_name' => null,
+        ]);
+
+        $file = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file)->create(['description' => 'NEFT TRANSFER TO VENDOR']);
+
+        $matcher = new RuleBasedMatcher;
+        $matches = $matcher->match($file->transactions, 'HDFC');
+
+        // Exact match should win over contains despite bank specificity or usage
+        expect($matches)->toHaveCount(1)
+            ->and($matches[0]['account_head_id'])->toBe($head3->id);
+
+        // Run it again to verify determinism
+        $file2 = ImportedFile::factory()->create();
+        Transaction::factory()->unmapped()->for($file2)->create(['description' => 'NEFT TRANSFER TO VENDOR']);
+
+        $matches2 = $matcher->match($file2->transactions, 'HDFC');
+
+        expect($matches2)->toHaveCount(1)
+            ->and($matches2[0]['account_head_id'])->toBe($head3->id);
     });
 
     it('ignores rules with inactive account heads', function () {


### PR DESCRIPTION
## Summary
- Replace first-match-wins ordering with specificity-based priority in `RuleBasedMatcher`
- Add `priority` column (nullable integer) to `head_mappings` table for manual override
- Rules are now ordered by: manual priority > match type specificity (exact > regex > contains) > bank specificity (bank-specific > any-bank) > usage count descending
- Update Filament HeadMappingResource with priority field in form and table

Closes #7

## Changes
- **Migration**: Add `priority` column with index to `head_mappings` table
- **HeadMapping model**: Add `priority` to `$fillable`, `casts`, and activity log
- **HeadMappingFactory**: Add `priority` field and `withPriority()` state method
- **RuleBasedMatcher**: Add `sortByPriority()` method with 4-level comparison and `matchTypeSpecificity()` helper
- **HeadMappingResource**: Add priority form input (numeric, min 1) and table column
- **Tests**: 7 new tests covering all priority ordering scenarios (exact over contains, regex over contains, exact over regex, bank specificity, usage count, manual priority override, deterministic overlapping rules)

## Test plan
- [x] `php artisan test --filter=RuleBased` -- 17 tests pass (10 existing + 7 new)
- [x] `php artisan test --filter=HeadMatcher` -- all related tests pass
- [x] `vendor/bin/phpstan analyse` -- 0 errors at level 6
- [x] `php artisan test --compact` -- full suite 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)