### PR TITLE
Add health check endpoint for monitoring (#9)

### DIFF
--- a/app/Http/Controllers/HealthCheckController.php
+++ b/app/Http/Controllers/HealthCheckController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class HealthCheckController
+{
+    public function __invoke(): JsonResponse
+    {
+        $checks = [
+            'database' => $this->checkDatabase(),
+            'storage' => $this->checkStorage(),
+            'queue' => $this->checkQueue(),
+        ];
+
+        $healthy = ! in_array('failed', $checks, true);
+
+        return response()->json([
+            'status' => $healthy ? 'healthy' : 'unhealthy',
+            'checks' => $checks,
+        ], $healthy ? 200 : 503);
+    }
+
+    private function checkDatabase(): string
+    {
+        try {
+            DB::connection()->getPdo();
+
+            return 'ok';
+        } catch (\Throwable) {
+            return 'failed';
+        }
+    }
+
+    private function checkStorage(): string
+    {
+        try {
+            $testFile = '.health_check_'.time();
+            $disk = Storage::disk('local');
+
+            if (! $disk->put($testFile, 'ok')) {
+                return 'failed';
+            }
+
+            if (! $disk->exists($testFile)) {
+                return 'failed';
+            }
+
+            $disk->delete($testFile);
+
+            return 'ok';
+        } catch (\Throwable) {
+            return 'failed';
+        }
+    }
+
+    private function checkQueue(): string
+    {
+        try {
+            $staleCount = DB::table('jobs')
+                ->where('created_at', '<', now()->subHours(1)->getTimestamp())
+                ->count();
+
+            return $staleCount > 100 ? 'degraded' : 'ok';
+        } catch (\Throwable) {
+            return 'failed';
+        }
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\HealthCheckController;
 use App\Http\Controllers\ImportedFileDownloadController;
 use Illuminate\Support\Facades\Route;
+
+Route::get('/health', HealthCheckController::class);
 
 Route::get('/', function () {
     return redirect('/admin');

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+describe('Health check endpoint', function () {
+    it('returns 200 with healthy status when all checks pass', function () {
+        $response = $this->getJson('/health');
+
+        $response->assertOk()
+            ->assertJson(['status' => 'healthy'])
+            ->assertJsonStructure([
+                'status',
+                'checks' => [
+                    'database',
+                    'storage',
+                    'queue',
+                ],
+            ]);
+    });
+
+    it('returns component statuses as ok when healthy', function () {
+        $response = $this->getJson('/health');
+
+        $response->assertOk()
+            ->assertJsonPath('checks.database', 'ok')
+            ->assertJsonPath('checks.storage', 'ok');
+    });
+
+    it('does not require authentication', function () {
+        $response = $this->getJson('/health');
+
+        $response->assertOk();
+    });
+
+    it('returns 503 when database is unreachable', function () {
+        DB::shouldReceive('connection->getPdo')
+            ->andThrow(new \RuntimeException('Connection refused'));
+
+        $response = $this->getJson('/health');
+
+        $response->assertServiceUnavailable()
+            ->assertJson(['status' => 'unhealthy'])
+            ->assertJsonPath('checks.database', 'failed');
+    });
+
+    it('returns 503 when storage is not writable', function () {
+        Storage::shouldReceive('disk->put')->andReturn(false);
+        Storage::shouldReceive('disk->exists')->andReturn(false);
+
+        $response = $this->getJson('/health');
+
+        $response->assertServiceUnavailable()
+            ->assertJson(['status' => 'unhealthy'])
+            ->assertJsonPath('checks.storage', 'failed');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `/health` JSON endpoint that checks database, storage, and queue status
- Returns `200 {"status": "healthy"}` or `503 {"status": "unhealthy"}` with per-component statuses
- Queue check returns "degraded" if >100 stale jobs (older than 1 hour)
- No authentication required — suitable for load balancers and uptime monitors

## Test plan
- [x] All 234 tests pass (5 new health check tests)
- [x] PHPStan clean
- [x] Verified: returns 200 when healthy, 503 on DB failure, 503 on storage failure
- [x] No auth middleware on the route

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)