### PR TITLE
feat(imports): unified DocumentProcessor service with file-type routing (#41)

### DIFF
--- a/app/Enums/StatementType.php
+++ b/app/Enums/StatementType.php
@@ -8,12 +8,14 @@ enum StatementType: string implements HasLabel
 {
     case Bank = 'bank';
     case CreditCard = 'credit_card';
+    case Invoice = 'invoice';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::Bank => 'Bank Statement',
             self::CreditCard => 'Credit Card Statement',
+            self::Invoice => 'Invoice',
         };
     }
 }

--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -36,8 +36,13 @@ class ImportedFileResource extends Resource
                 Section::make('Upload Statement')
                     ->schema([
                         Forms\Components\FileUpload::make('file_path')
-                            ->label('Statement PDF')
-                            ->acceptedFileTypes(['application/pdf'])
+                            ->label('Statement File')
+                            ->acceptedFileTypes([
+                                'application/pdf',
+                                'text/csv',
+                                'application/vnd.ms-excel',
+                                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                            ])
                             ->directory('statements')
                             ->disk('local')
                             ->maxSize(10240) // 10MB

--- a/app/Jobs/ProcessImportedFile.php
+++ b/app/Jobs/ProcessImportedFile.php
@@ -2,20 +2,15 @@
 
 namespace App\Jobs;
 
-use App\Ai\Agents\StatementParser;
 use App\Enums\ImportStatus;
-use App\Enums\MappingType;
 use App\Models\ImportedFile;
-use App\Models\Transaction;
+use App\Services\DocumentProcessor\DocumentProcessor;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Laravel\Ai\Files\Document;
 
 class ProcessImportedFile implements ShouldQueue
 {
@@ -39,76 +34,20 @@ class ProcessImportedFile implements ShouldQueue
         return [30, 120, 300];
     }
 
-    public function handle(): void
+    public function handle(DocumentProcessor $documentProcessor): void
     {
-        $this->importedFile->update(['status' => ImportStatus::Processing]);
-
         try {
-            $response = (new StatementParser)->prompt(
-                'Parse all transactions from this bank statement. Extract every single transaction row.',
-                attachments: [
-                    Document::fromStorage($this->importedFile->file_path),
-                ]
-            );
+            $documentProcessor->process($this->importedFile);
 
-            if (! isset($response['transactions']) || ! is_array($response['transactions'])) {
-                Log::warning('StatementParser returned invalid response', [
-                    'file_id' => $this->importedFile->id,
-                    'response' => $response,
-                ]);
+            // Dispatch head matching job only on successful completion
+            $this->importedFile->refresh();
 
-                throw new \RuntimeException(
-                    'StatementParser response missing valid transactions array.'
-                );
+            /** @var ImportStatus $status */
+            $status = $this->importedFile->status;
+
+            if ($status === ImportStatus::Completed) {
+                MatchTransactionHeads::dispatch($this->importedFile);
             }
-
-            $bankName = $response['bank_name'] ?? null;
-            $accountNumber = $response['account_number'] ?? null;
-            $transactions = $response['transactions'];
-
-            if (empty($transactions)) {
-                $this->importedFile->update([
-                    'status' => ImportStatus::Failed,
-                    'error_message' => 'No transactions found in the statement.',
-                ]);
-
-                return;
-            }
-
-            DB::transaction(function () use ($bankName, $accountNumber, $transactions) {
-                if ($bankName) {
-                    $this->importedFile->update(['bank_name' => $bankName]);
-                }
-
-                if ($accountNumber) {
-                    $this->importedFile->update(['account_number' => $accountNumber]);
-                }
-
-                foreach ($transactions as $row) {
-                    Transaction::create([
-                        'imported_file_id' => $this->importedFile->id,
-                        'date' => Carbon::parse($row['date']),
-                        'description' => $row['description'] ?? '',
-                        'reference_number' => $row['reference'] ?? null,
-                        'debit' => isset($row['debit']) ? (string) $row['debit'] : null,
-                        'credit' => isset($row['credit']) ? (string) $row['credit'] : null,
-                        'balance' => isset($row['balance']) ? (string) $row['balance'] : null,
-                        'mapping_type' => MappingType::Unmapped,
-                        'raw_data' => $row,
-                        'bank_format' => $bankName,
-                    ]);
-                }
-
-                $this->importedFile->update([
-                    'status' => ImportStatus::Completed,
-                    'total_rows' => count($transactions),
-                    'mapped_rows' => 0,
-                    'processed_at' => now(),
-                ]);
-            });
-
-            // Dispatch head matching job
-            MatchTransactionHeads::dispatch($this->importedFile);
 
         } catch (\Throwable $e) {
             Log::error('Failed to process imported file', [

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace App\Services\DocumentProcessor;
+
+use App\Ai\Agents\StatementParser;
+use App\Enums\ImportStatus;
+use App\Enums\MappingType;
+use App\Enums\StatementType;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\Files\Document;
+use Maatwebsite\Excel\Facades\Excel;
+
+class DocumentProcessor
+{
+    /**
+     * Process an imported file by detecting its format and routing to the appropriate parser.
+     */
+    public function process(ImportedFile $file): void
+    {
+        $file->update(['status' => ImportStatus::Processing]);
+
+        $format = $this->detectFormat($file);
+
+        match ($format) {
+            'csv', 'xlsx' => $this->parseStructured($file),
+            'pdf' => $this->parsePdf($file),
+            default => throw new \RuntimeException("Unsupported file format: {$format}"),
+        };
+    }
+
+    /**
+     * Detect file format from the original filename extension.
+     */
+    public function detectFormat(ImportedFile $file): string
+    {
+        $extension = strtolower(pathinfo($file->original_filename, PATHINFO_EXTENSION));
+
+        $supportedFormats = ['pdf', 'csv', 'xlsx'];
+
+        if (! in_array($extension, $supportedFormats)) {
+            throw new \RuntimeException(
+                "Unsupported file extension: .{$extension}. Supported: ".implode(', ', $supportedFormats)
+            );
+        }
+
+        return $extension;
+    }
+
+    /**
+     * Parse structured files (CSV/XLSX) programmatically via Maatwebsite Excel.
+     */
+    protected function parseStructured(ImportedFile $file): void
+    {
+        $import = new StructuredFileImport;
+
+        Excel::import($import, $file->file_path, 'local');
+
+        $rows = $import->getRows();
+
+        if (empty($rows)) {
+            $file->update([
+                'status' => ImportStatus::Failed,
+                'error_message' => 'No data rows found in the file.',
+            ]);
+
+            return;
+        }
+
+        DB::transaction(function () use ($file, $rows) {
+            foreach ($rows as $row) {
+                $normalized = $this->normalizeStructuredRow($row);
+
+                Transaction::create([
+                    'imported_file_id' => $file->id,
+                    'date' => $normalized['date'],
+                    'description' => $normalized['description'] ?? '',
+                    'reference_number' => $normalized['reference'] ?? null,
+                    'debit' => $normalized['debit'],
+                    'credit' => $normalized['credit'],
+                    'balance' => $normalized['balance'],
+                    'mapping_type' => MappingType::Unmapped,
+                    'raw_data' => $row,
+                    'bank_format' => $file->bank_name,
+                ]);
+            }
+
+            $file->update([
+                'status' => ImportStatus::Completed,
+                'total_rows' => count($rows),
+                'mapped_rows' => 0,
+                'processed_at' => now(),
+            ]);
+        });
+    }
+
+    /**
+     * Normalize a structured row from CSV/XLSX to the expected transaction format.
+     *
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    protected function normalizeStructuredRow(array $row): array
+    {
+        $normalized = [];
+        foreach ($row as $key => $value) {
+            $normalized[strtolower(trim((string) $key))] = $value;
+        }
+
+        return [
+            'date' => $this->extractField($normalized, ['date', 'transaction_date', 'txn_date', 'value_date', 'posting_date']),
+            'description' => $this->extractField($normalized, ['description', 'narration', 'particulars', 'details', 'transaction_description']),
+            'reference' => $this->extractField($normalized, ['reference', 'ref', 'reference_number', 'ref_no', 'cheque_no', 'chq_no']),
+            'debit' => $this->extractNumericField($normalized, ['debit', 'debit_amount', 'withdrawal', 'withdrawals', 'dr']),
+            'credit' => $this->extractNumericField($normalized, ['credit', 'credit_amount', 'deposit', 'deposits', 'cr']),
+            'balance' => $this->extractNumericField($normalized, ['balance', 'closing_balance', 'running_balance', 'available_balance']),
+        ];
+    }
+
+    /**
+     * Extract a field value by trying multiple possible column names.
+     *
+     * @param  array<string, mixed>  $row
+     * @param  array<int, string>  $possibleKeys
+     */
+    protected function extractField(array $row, array $possibleKeys): mixed
+    {
+        foreach ($possibleKeys as $key) {
+            if (isset($row[$key]) && $row[$key] !== '') {
+                return $row[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract a numeric field, cleaning currency formatting.
+     *
+     * @param  array<string, mixed>  $row
+     * @param  array<int, string>  $possibleKeys
+     */
+    protected function extractNumericField(array $row, array $possibleKeys): ?string
+    {
+        $value = $this->extractField($row, $possibleKeys);
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value) && (float) $value === 0.0) {
+            return null;
+        }
+
+        $cleaned = preg_replace('/[^0-9.\-]/', '', (string) $value);
+
+        return $cleaned !== '' && $cleaned !== '0' ? $cleaned : null;
+    }
+
+    /**
+     * Parse PDF files by routing to the appropriate AI agent based on statement type.
+     */
+    protected function parsePdf(ImportedFile $file): void
+    {
+        /** @var StatementType $statementType */
+        $statementType = $file->statement_type;
+
+        match ($statementType) {
+            StatementType::Bank, StatementType::CreditCard => $this->parsePdfStatement($file),
+            StatementType::Invoice => throw new \RuntimeException(
+                'Invoice parsing is not yet implemented. See issue #42.'
+            ),
+        };
+    }
+
+    /**
+     * Parse a PDF bank/credit card statement via the StatementParser agent.
+     */
+    protected function parsePdfStatement(ImportedFile $file): void
+    {
+        $response = (new StatementParser)->prompt(
+            'Parse all transactions from this bank statement. Extract every single transaction row.',
+            attachments: [
+                Document::fromStorage($file->file_path),
+            ]
+        );
+
+        if (! isset($response['transactions']) || ! is_array($response['transactions'])) {
+            Log::warning('StatementParser returned invalid response', [
+                'file_id' => $file->id,
+                'response' => $response,
+            ]);
+
+            throw new \RuntimeException(
+                'StatementParser response missing valid transactions array.'
+            );
+        }
+
+        $bankName = $response['bank_name'] ?? null;
+        $accountNumber = $response['account_number'] ?? null;
+        $transactions = $response['transactions'];
+
+        if (empty($transactions)) {
+            $file->update([
+                'status' => ImportStatus::Failed,
+                'error_message' => 'No transactions found in the statement.',
+            ]);
+
+            return;
+        }
+
+        DB::transaction(function () use ($file, $bankName, $accountNumber, $transactions) {
+            if ($bankName) {
+                $file->update(['bank_name' => $bankName]);
+            }
+
+            if ($accountNumber) {
+                $file->update(['account_number' => $accountNumber]);
+            }
+
+            foreach ($transactions as $row) {
+                Transaction::create([
+                    'imported_file_id' => $file->id,
+                    'date' => Carbon::parse($row['date']),
+                    'description' => $row['description'] ?? '',
+                    'reference_number' => $row['reference'] ?? null,
+                    'debit' => isset($row['debit']) ? (string) $row['debit'] : null,
+                    'credit' => isset($row['credit']) ? (string) $row['credit'] : null,
+                    'balance' => isset($row['balance']) ? (string) $row['balance'] : null,
+                    'mapping_type' => MappingType::Unmapped,
+                    'raw_data' => $row,
+                    'bank_format' => $bankName,
+                ]);
+            }
+
+            $file->update([
+                'status' => ImportStatus::Completed,
+                'total_rows' => count($transactions),
+                'mapped_rows' => 0,
+                'processed_at' => now(),
+            ]);
+        });
+    }
+}

--- a/app/Services/DocumentProcessor/StructuredFileImport.php
+++ b/app/Services/DocumentProcessor/StructuredFileImport.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\DocumentProcessor;
+
+use Maatwebsite\Excel\Concerns\ToArray;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+
+class StructuredFileImport implements ToArray, WithHeadingRow
+{
+    /** @var array<int, array<string, mixed>> */
+    protected array $rows = [];
+
+    /**
+     * @param  array<int, array<string, mixed>>  $rows
+     */
+    public function array(array $rows): void
+    {
+        $this->rows = array_filter($rows, function (array $row) {
+            return count(array_filter($row, fn ($value) => $value !== null && $value !== '')) > 0;
+        });
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getRows(): array
+    {
+        return $this->rows;
+    }
+}

--- a/database/factories/ImportedFileFactory.php
+++ b/database/factories/ImportedFileFactory.php
@@ -68,6 +68,31 @@ class ImportedFileFactory extends Factory
         ]);
     }
 
+    public function invoice(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'statement_type' => StatementType::Invoice,
+            'file_path' => 'statements/'.fake()->uuid().'.pdf',
+            'original_filename' => 'invoice_'.fake()->date('Y_m').'.pdf',
+        ]);
+    }
+
+    public function csv(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'file_path' => 'statements/'.fake()->uuid().'.csv',
+            'original_filename' => ($attributes['bank_name'] ?? 'Bank').'_statement.csv',
+        ]);
+    }
+
+    public function xlsx(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'file_path' => 'statements/'.fake()->uuid().'.xlsx',
+            'original_filename' => ($attributes['bank_name'] ?? 'Bank').'_statement.xlsx',
+        ]);
+    }
+
     public function forBank(string $bank): static
     {
         return $this->state(fn (array $attributes) => [

--- a/tests/Feature/Enums/EnumTest.php
+++ b/tests/Feature/Enums/EnumTest.php
@@ -55,6 +55,7 @@ describe('MatchType', function () {
 describe('StatementType', function () {
     it('has correct labels', function () {
         expect(StatementType::Bank->getLabel())->toBe('Bank Statement')
-            ->and(StatementType::CreditCard->getLabel())->toBe('Credit Card Statement');
+            ->and(StatementType::CreditCard->getLabel())->toBe('Credit Card Statement')
+            ->and(StatementType::Invoice->getLabel())->toBe('Invoice');
     });
 });

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -7,6 +7,7 @@ use App\Jobs\MatchTransactionHeads;
 use App\Jobs\ProcessImportedFile;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
+use App\Services\DocumentProcessor\DocumentProcessor;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -28,7 +29,7 @@ describe('ProcessImportedFile job', function () {
         $job = new ProcessImportedFile($file);
 
         try {
-            $job->handle();
+            $job->handle(app(DocumentProcessor::class));
         } catch (\Throwable) {
             // Expected — job rethrows after logging
         }
@@ -103,7 +104,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
         ]);
 
         $job = new ProcessImportedFile($file);
-        $job->handle();
+        $job->handle(app(DocumentProcessor::class));
 
         $file->refresh();
         expect($file->status)->toBe(ImportStatus::Completed)
@@ -140,7 +141,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
         ]);
 
         $job = new ProcessImportedFile($file);
-        $job->handle();
+        $job->handle(app(DocumentProcessor::class));
 
         Queue::assertPushed(MatchTransactionHeads::class, function ($job) use ($file) {
             return $job->importedFile->id === $file->id;
@@ -166,7 +167,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
         ]);
 
         $job = new ProcessImportedFile($file);
-        $job->handle();
+        $job->handle(app(DocumentProcessor::class));
 
         $file->refresh();
         expect($file->status)->toBe(ImportStatus::Failed)
@@ -194,7 +195,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
         $job = new ProcessImportedFile($file);
 
         try {
-            $job->handle();
+            $job->handle(app(DocumentProcessor::class));
         } catch (\Throwable) {
             // Expected — missing transactions key
         }

--- a/tests/Feature/Services/DocumentProcessorTest.php
+++ b/tests/Feature/Services/DocumentProcessorTest.php
@@ -1,0 +1,306 @@
+<?php
+
+use App\Ai\Agents\StatementParser;
+use App\Enums\ImportStatus;
+use App\Enums\MappingType;
+use App\Enums\StatementType;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\DocumentProcessor\DocumentProcessor;
+use Illuminate\Support\Facades\Storage;
+
+describe('DocumentProcessor', function () {
+    beforeEach(function () {
+        Storage::fake('local');
+        $this->processor = new DocumentProcessor;
+    });
+
+    describe('detectFormat', function () {
+        it('detects PDF format from filename', function () {
+            $file = ImportedFile::factory()->create([
+                'original_filename' => 'statement.pdf',
+            ]);
+
+            expect($this->processor->detectFormat($file))->toBe('pdf');
+        });
+
+        it('detects CSV format from filename', function () {
+            $file = ImportedFile::factory()->csv()->create();
+
+            expect($this->processor->detectFormat($file))->toBe('csv');
+        });
+
+        it('detects XLSX format from filename', function () {
+            $file = ImportedFile::factory()->xlsx()->create();
+
+            expect($this->processor->detectFormat($file))->toBe('xlsx');
+        });
+
+        it('throws for unsupported file extensions', function () {
+            $file = ImportedFile::factory()->create([
+                'original_filename' => 'document.docx',
+            ]);
+
+            $this->processor->detectFormat($file);
+        })->throws(\RuntimeException::class, 'Unsupported file extension: .docx');
+
+        it('is case-insensitive for extensions', function () {
+            $file = ImportedFile::factory()->create([
+                'original_filename' => 'STATEMENT.PDF',
+            ]);
+
+            expect($this->processor->detectFormat($file))->toBe('pdf');
+        });
+    });
+
+    describe('CSV parsing', function () {
+        it('parses a CSV file and creates transactions', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+            $csvContent .= "2024-01-05,SALARY JAN 2024,,50000,150000\n";
+            $csvContent .= "2024-01-10,RENT PAYMENT,15000,,135000\n";
+            $csvContent .= "2024-01-15,EMI HDFC,8500,,126500\n";
+
+            Storage::put('statements/test.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/test.csv',
+                'original_filename' => 'HDFC_statement.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->total_rows)->toBe(3)
+                ->and($file->mapped_rows)->toBe(0)
+                ->and($file->processed_at)->not->toBeNull();
+
+            $transactions = Transaction::where('imported_file_id', $file->id)->get();
+            expect($transactions)->toHaveCount(3);
+
+            $first = $transactions->first();
+            expect($first->description)->toBe('SALARY JAN 2024')
+                ->and($first->mapping_type)->toBe(MappingType::Unmapped);
+        });
+
+        it('handles CSV with alternative column names', function () {
+            $csvContent = "Txn Date,Narration,Withdrawal,Deposit,Closing Balance\n";
+            $csvContent .= "2024-02-01,UPI PAYMENT,500,,9500\n";
+
+            Storage::put('statements/alt.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/alt.csv',
+                'original_filename' => 'bank_export.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->total_rows)->toBe(1);
+        });
+
+        it('marks file as failed when CSV has no data rows', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+
+            Storage::put('statements/empty.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/empty.csv',
+                'original_filename' => 'empty.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Failed)
+                ->and($file->error_message)->toContain('No data rows found');
+        });
+
+        it('skips completely empty rows in CSV', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+            $csvContent .= "2024-01-05,SALARY,,50000,150000\n";
+            $csvContent .= ",,,,\n";
+            $csvContent .= "2024-01-10,RENT,15000,,135000\n";
+
+            Storage::put('statements/gaps.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/gaps.csv',
+                'original_filename' => 'gaps.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->total_rows)->toBe(2);
+        });
+
+        it('cleans currency formatting from numeric fields', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+            $csvContent .= "2024-01-05,TRANSFER,\"1,500.00\",,\"98,500.00\"\n";
+
+            Storage::put('statements/currency.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/currency.csv',
+                'original_filename' => 'currency.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $transaction = Transaction::where('imported_file_id', $file->id)->first();
+            expect($transaction->debit)->toBe('1500.00')
+                ->and($transaction->balance)->toBe('98500.00');
+        });
+
+        it('stores original row data in raw_data field', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+            $csvContent .= "2024-01-05,SALARY,,50000,150000\n";
+
+            Storage::put('statements/raw.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/raw.csv',
+                'original_filename' => 'raw.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $transaction = Transaction::where('imported_file_id', $file->id)->first();
+            expect($transaction->raw_data)->toBeArray()
+                ->and($transaction->raw_data)->toHaveKey('description');
+        });
+
+        it('sets status to processing before parsing', function () {
+            $csvContent = "Date,Description,Debit,Credit,Balance\n";
+            $csvContent .= "2024-01-05,TEST,,100,100\n";
+
+            Storage::put('statements/proc.csv', $csvContent);
+
+            $file = ImportedFile::factory()->csv()->create([
+                'file_path' => 'statements/proc.csv',
+                'original_filename' => 'proc.csv',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            // After process completes, it should be Completed (went through Processing)
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed);
+        });
+    });
+
+    describe('PDF routing', function () {
+        it('routes bank statement PDFs to StatementParser agent', function () {
+            Storage::put('statements/bank.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'HDFC Bank',
+                    'account_number' => '1234567890',
+                    'statement_period' => '2024-01-01 to 2024-01-31',
+                    'transactions' => [
+                        ['date' => '2024-01-05', 'description' => 'SALARY', 'credit' => 50000, 'balance' => 150000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/bank.pdf',
+                'original_filename' => 'bank_statement.pdf',
+                'statement_type' => StatementType::Bank,
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            StatementParser::assertPrompted('Parse all transactions from this bank statement. Extract every single transaction row.');
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->bank_name)->toBe('HDFC Bank')
+                ->and($file->total_rows)->toBe(1);
+        });
+
+        it('routes credit card statement PDFs to StatementParser agent', function () {
+            Storage::put('statements/cc.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'ICICI CC',
+                    'transactions' => [
+                        ['date' => '2024-01-05', 'description' => 'AMAZON', 'debit' => 2000, 'balance' => 2000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->creditCard()->create([
+                'file_path' => 'statements/cc.pdf',
+                'original_filename' => 'cc_statement.pdf',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            StatementParser::assertPrompted('Parse all transactions from this bank statement. Extract every single transaction row.');
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed);
+        });
+
+        it('throws for invoice PDFs since InvoiceParser is not yet implemented', function () {
+            Storage::put('statements/invoice.pdf', 'fake-pdf-content');
+
+            $file = ImportedFile::factory()->invoice()->create([
+                'file_path' => 'statements/invoice.pdf',
+                'original_filename' => 'vendor_invoice.pdf',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+        })->throws(\RuntimeException::class, 'Invoice parsing is not yet implemented');
+
+        it('marks file as failed when PDF has no transactions', function () {
+            Storage::put('statements/empty.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'SBI',
+                    'transactions' => [],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/empty.pdf',
+                'original_filename' => 'empty.pdf',
+                'statement_type' => StatementType::Bank,
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Failed)
+                ->and($file->error_message)->toContain('No transactions found');
+        });
+    });
+
+    describe('unsupported formats', function () {
+        it('throws for unsupported file extensions', function () {
+            $file = ImportedFile::factory()->create([
+                'original_filename' => 'document.txt',
+            ]);
+
+            $this->processor->process($file);
+        })->throws(\RuntimeException::class, 'Unsupported file extension');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `DocumentProcessor` service as single entry point for all file processing, routing by file type
- CSV/XLSX files parsed programmatically via Maatwebsite Excel (no AI cost, deterministic)
- PDF bank/CC statements delegate to existing `StatementParser` agent
- PDF invoices throw clear error (InvoiceParser is #42, not yet built)
- `ProcessImportedFile` job refactored to delegate to `DocumentProcessor`
- Column name normalization handles variations across bank CSV exports (Txn Date, Narration, Withdrawal, etc.)
- Filament upload form now accepts CSV/XLSX in addition to PDF

## Test plan
- [x] 17 DocumentProcessor tests (format detection, CSV parsing, PDF routing, error handling)
- [x] 11 ProcessImportedFile tests (refactored to use DocumentProcessor DI)
- [x] Full suite: 251 tests, 580 assertions — all passing
- [x] PHPStan: no errors

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)