### PR TITLE
fix(ai): increase agent timeouts for Mistral API

### DIFF
--- a/app/Ai/Agents/HeadMatcher.php
+++ b/app/Ai/Agents/HeadMatcher.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
@@ -14,6 +15,7 @@ use Stringable;
 #[Provider('mistral')]
 #[MaxTokens(4096)]
 #[Temperature(0.2)]
+#[Timeout(120)]
 class HeadMatcher implements Agent, HasStructuredOutput
 {
     use Promptable;

--- a/app/Ai/Agents/InvoiceParser.php
+++ b/app/Ai/Agents/InvoiceParser.php
@@ -15,7 +15,7 @@ use Stringable;
 #[Provider('mistral')]
 #[MaxTokens(8192)]
 #[Temperature(0.1)]
-#[Timeout(120)]
+#[Timeout(180)]
 class InvoiceParser implements Agent, HasStructuredOutput
 {
     use Promptable;

--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -15,7 +15,7 @@ use Stringable;
 #[Provider('mistral')]
 #[MaxTokens(8192)]
 #[Temperature(0.1)]
-#[Timeout(120)]
+#[Timeout(300)]
 class StatementParser implements Agent, HasStructuredOutput
 {
     use Promptable;

--- a/app/Services/DocumentProcessor/OcrService.php
+++ b/app/Services/DocumentProcessor/OcrService.php
@@ -32,7 +32,7 @@ class OcrService
         $response = Http::withHeaders([
             'Authorization' => 'Bearer '.config('ai.providers.mistral.key'),
             'Content-Type' => 'application/json',
-        ])->timeout(120)->post('https://api.mistral.ai/v1/ocr', [
+        ])->timeout(180)->post('https://api.mistral.ai/v1/ocr', [
             'model' => config('ai.models.ocr', 'mistral-ocr-latest'),
             'document' => $documentField,
         ]);

--- a/tests/Feature/Ai/AgentsTest.php
+++ b/tests/Feature/Ai/AgentsTest.php
@@ -40,6 +40,16 @@ describe('StatementParser agent', function () {
     });
 });
 
+describe('StatementParser timeout', function () {
+    it('has a 300 second timeout', function () {
+        $attributes = (new ReflectionClass(StatementParser::class))
+            ->getAttributes(Laravel\Ai\Attributes\Timeout::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe(300);
+    });
+});
+
 describe('HeadMatcher agent', function () {
     it('implements Agent interface', function () {
         expect(HeadMatcher::class)->toImplement(Laravel\Ai\Contracts\Agent::class);
@@ -82,6 +92,14 @@ describe('HeadMatcher agent', function () {
         $agent = new HeadMatcher;
 
         expect($agent->model())->toBe('codestral-latest');
+    });
+
+    it('has a 120 second timeout', function () {
+        $attributes = (new ReflectionClass(HeadMatcher::class))
+            ->getAttributes(Laravel\Ai\Attributes\Timeout::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe(120);
     });
 });
 

--- a/tests/Feature/Ai/InvoiceParserTest.php
+++ b/tests/Feature/Ai/InvoiceParserTest.php
@@ -40,6 +40,16 @@ describe('InvoiceParser agent', function () {
     });
 });
 
+describe('InvoiceParser timeout', function () {
+    it('has a 180 second timeout', function () {
+        $attributes = (new ReflectionClass(InvoiceParser::class))
+            ->getAttributes(Laravel\Ai\Attributes\Timeout::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe(180);
+    });
+});
+
 describe('InvoiceParser with Agent::fake()', function () {
     it('returns structured response with intra-state invoice data', function () {
         Storage::fake('local');


### PR DESCRIPTION
## Summary
- **StatementParser** timeout: 120s → 300s — large bank statements with 100+ transactions were timing out on Mistral chat completions API (`cURL error 28`)
- **InvoiceParser** timeout: 120s → 180s — added headroom for complex multi-page invoices
- **HeadMatcher** timeout: **added missing `#[Timeout(120)]`** — was defaulting to 60s (Closes #51)
- **OcrService** HTTP timeout: 120s → 180s — large multi-page PDF OCR needs more time

## Test plan
- [x] New tests verify timeout attributes via reflection for all 3 agents
- [x] All 43 agent/job tests pass
- [x] PHPStan clean
- [x] Pint clean

Closes #56
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)