### PR TITLE
refactor(ai): migrate to OpenRouter and use container resolution

### DIFF
--- a/app/Ai/Agents/HeadMatcher.php
+++ b/app/Ai/Agents/HeadMatcher.php
@@ -12,7 +12,7 @@ use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 use Stringable;
 
-#[Provider('mistral')]
+#[Provider('openrouter')]
 #[MaxTokens(4096)]
 #[Temperature(0.2)]
 #[Timeout(120)]
@@ -27,7 +27,7 @@ class HeadMatcher implements Agent, HasStructuredOutput
      */
     public function model(): string
     {
-        return config('ai.models.matching', 'mistral-large-latest');
+        return config('ai.models.matching', 'mistralai/mistral-large-latest');
     }
 
     /**

--- a/app/Ai/Agents/InvoiceParser.php
+++ b/app/Ai/Agents/InvoiceParser.php
@@ -12,7 +12,7 @@ use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 use Stringable;
 
-#[Provider('mistral')]
+#[Provider('openrouter')]
 #[MaxTokens(8192)]
 #[Temperature(0.1)]
 #[Timeout(180)]
@@ -25,7 +25,7 @@ class InvoiceParser implements Agent, HasStructuredOutput
      */
     public function model(): string
     {
-        return config('ai.models.parsing', 'mistral-large-latest');
+        return config('ai.models.parsing', 'mistralai/mistral-large-latest');
     }
 
     public function instructions(): Stringable|string

--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -12,7 +12,7 @@ use Laravel\Ai\Contracts\HasStructuredOutput;
 use Laravel\Ai\Promptable;
 use Stringable;
 
-#[Provider('mistral')]
+#[Provider('openrouter')]
 #[MaxTokens(8192)]
 #[Temperature(0.1)]
 #[Timeout(300)]
@@ -25,7 +25,7 @@ class StatementParser implements Agent, HasStructuredOutput
      */
     public function model(): string
     {
-        return config('ai.models.parsing', 'mistral-large-latest');
+        return config('ai.models.parsing', 'mistralai/mistral-large-latest');
     }
 
     public function instructions(): Stringable|string

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -187,7 +187,7 @@ class DocumentProcessor
     {
         $extractedText = $this->ocrService->extractText($file->file_path);
 
-        $response = (new StatementParser)->prompt(
+        $response = StatementParser::make()->prompt(
             "Parse all transactions from this bank statement. Extract every single transaction row.\n\n--- STATEMENT TEXT ---\n{$extractedText}"
         );
 
@@ -275,7 +275,7 @@ class DocumentProcessor
     {
         $extractedText = $this->ocrService->extractText($file->file_path);
 
-        $response = (new InvoiceParser)->prompt(
+        $response = InvoiceParser::make()->prompt(
             "Parse all data from this vendor invoice. Extract every field including line items, GST breakup, and TDS if present.\n\n--- INVOICE TEXT ---\n{$extractedText}"
         );
 

--- a/app/Services/HeadMatcher/HeadMatcherService.php
+++ b/app/Services/HeadMatcher/HeadMatcherService.php
@@ -133,7 +133,7 @@ class HeadMatcherService
             $prompt .= "ID {$desc['id']}: {$desc['description']} ({$amount})\n";
         }
 
-        $agent = (new HeadMatcher)->withChartOfAccounts($chartOfAccounts);
+        $agent = HeadMatcher::make()->withChartOfAccounts($chartOfAccounts);
         $response = $agent->prompt($prompt);
 
         $matched = 0;

--- a/config/ai.php
+++ b/config/ai.php
@@ -8,11 +8,18 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure API keys for AI providers used by the application.
-    | The primary provider is Mistral, used for PDF parsing and head matching.
+    | OpenRouter is the primary provider for all AI agents (parsing, matching).
+    | Mistral is retained for OCR only (Mistral's /v1/ocr is not on OpenRouter).
     |
     */
 
     'providers' => [
+
+        'openrouter' => [
+            'driver' => 'openai',
+            'key' => env('OPENROUTER_API_KEY'),
+            'url' => 'https://openrouter.ai/api/v1',
+        ],
 
         'mistral' => [
             'driver' => 'mistral',
@@ -33,9 +40,9 @@ return [
 
     'models' => [
 
-        'parsing' => env('AI_PARSING_MODEL', 'mistral-large-latest'),
+        'parsing' => env('AI_PARSING_MODEL', 'mistralai/mistral-large-latest'),
 
-        'matching' => env('AI_MATCHING_MODEL', 'mistral-large-latest'),
+        'matching' => env('AI_MATCHING_MODEL', 'mistralai/mistral-large-latest'),
 
         'ocr' => env('AI_OCR_MODEL', 'mistral-ocr-latest'),
 

--- a/docs/architecture/ai-agent-design.md
+++ b/docs/architecture/ai-agent-design.md
@@ -97,7 +97,7 @@ class StatementParser implements Agent, HasStructuredOutput
 ### Invocation with File Attachment
 
 ```php
-$response = (new StatementParser)->prompt(
+$response = StatementParser::make()->prompt(
     'Parse all transactions from this bank statement.',
     attachments: [Document::fromStorage($file->file_path)]
 );
@@ -109,7 +109,7 @@ $transactions = $response['transactions']; // structured array access
 
 ```php
 // HeadMatcher accepts chart of accounts as runtime context
-$response = (new HeadMatcher)
+$response = HeadMatcher::make()
     ->withChartOfAccounts($chartString)
     ->prompt('Match these transactions to account heads: ...');
 ```

--- a/tests/Feature/Ai/AgentsTest.php
+++ b/tests/Feature/Ai/AgentsTest.php
@@ -4,6 +4,21 @@ use App\Ai\Agents\HeadMatcher;
 use App\Ai\Agents\StatementParser;
 use Illuminate\Support\Facades\Storage;
 
+describe('AI provider configuration', function () {
+    it('has an openrouter provider configured', function () {
+        $config = config('ai.providers.openrouter');
+
+        expect($config)->not->toBeNull()
+            ->and($config['driver'])->toBe('openai')
+            ->and($config)->toHaveKey('url');
+    });
+
+    it('keeps mistral provider for OCR', function () {
+        expect(config('ai.providers.mistral'))->not->toBeNull()
+            ->and(config('ai.providers.mistral.driver'))->toBe('mistral');
+    });
+});
+
 describe('StatementParser agent', function () {
     it('implements Agent interface', function () {
         expect(StatementParser::class)->toImplement(Laravel\Ai\Contracts\Agent::class);
@@ -37,6 +52,22 @@ describe('StatementParser agent', function () {
         $agent = new StatementParser;
 
         expect($agent->model())->toBe('mistral-small-latest');
+    });
+});
+
+describe('StatementParser provider', function () {
+    it('uses the openrouter provider', function () {
+        $attributes = (new ReflectionClass(StatementParser::class))
+            ->getAttributes(Laravel\Ai\Attributes\Provider::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe('openrouter');
+    });
+
+    it('can be resolved via container using make()', function () {
+        $agent = StatementParser::make();
+
+        expect($agent)->toBeInstanceOf(StatementParser::class);
     });
 });
 
@@ -100,6 +131,20 @@ describe('HeadMatcher agent', function () {
 
         expect($attributes)->toHaveCount(1)
             ->and($attributes[0]->getArguments()[0])->toBe(120);
+    });
+
+    it('uses the openrouter provider', function () {
+        $attributes = (new ReflectionClass(HeadMatcher::class))
+            ->getAttributes(Laravel\Ai\Attributes\Provider::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe('openrouter');
+    });
+
+    it('can be resolved via container using make()', function () {
+        $agent = HeadMatcher::make();
+
+        expect($agent)->toBeInstanceOf(HeadMatcher::class);
     });
 });
 

--- a/tests/Feature/Ai/InvoiceParserTest.php
+++ b/tests/Feature/Ai/InvoiceParserTest.php
@@ -40,6 +40,22 @@ describe('InvoiceParser agent', function () {
     });
 });
 
+describe('InvoiceParser provider', function () {
+    it('uses the openrouter provider', function () {
+        $attributes = (new ReflectionClass(InvoiceParser::class))
+            ->getAttributes(Laravel\Ai\Attributes\Provider::class);
+
+        expect($attributes)->toHaveCount(1)
+            ->and($attributes[0]->getArguments()[0])->toBe('openrouter');
+    });
+
+    it('can be resolved via container using make()', function () {
+        $agent = InvoiceParser::make();
+
+        expect($agent)->toBeInstanceOf(InvoiceParser::class);
+    });
+});
+
 describe('InvoiceParser timeout', function () {
     it('has a 180 second timeout', function () {
         $attributes = (new ReflectionClass(InvoiceParser::class))


### PR DESCRIPTION
## Summary
- Migrate all AI agents (StatementParser, InvoiceParser, HeadMatcher) from Mistral direct to OpenRouter provider
- Replace `new Agent()` instantiation with `Agent::make()` for proper Laravel container resolution
- Update `config/ai.php` with OpenRouter provider configuration and OpenRouter-format model defaults
- Mistral provider retained solely for OCR (`/v1/ocr` is not available via OpenRouter)

Closes #52, Closes #53

## Changes
- **`config/ai.php`** — Added `openrouter` provider (`driver: openai`, custom URL), updated model defaults to `mistralai/mistral-large-latest` format
- **3 agent classes** — `#[Provider('openrouter')]` on all agents
- **`DocumentProcessor`** — `StatementParser::make()` and `InvoiceParser::make()` instead of `new`
- **`HeadMatcherService`** — `HeadMatcher::make()` instead of `new`
- **`docs/architecture/ai-agent-design.md`** — Updated code examples to reflect `::make()` pattern

## Test plan
- [x] 148 tests pass (`php artisan test --compact`)
- [x] PHPStan level 6 — 0 errors
- [x] Pint — clean
- [ ] Manual: verify `.env` has `OPENROUTER_API_KEY` set
- [ ] Manual: upload a PDF statement and confirm it processes via OpenRouter

> **Note:** `.env.example` needs `OPENROUTER_API_KEY=` added manually (git hook blocks automated edits to `.env` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)