### PR TITLE
feat(dashboard): add analytics chart widgets

### DIFF
--- a/app/Filament/Widgets/ImportsOverTimeChart.php
+++ b/app/Filament/Widgets/ImportsOverTimeChart.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\ImportedFile;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Carbon;
+
+class ImportsOverTimeChart extends ChartWidget
+{
+    protected ?string $heading = 'Imports Over Time';
+
+    protected static ?int $sort = 3;
+
+    protected ?string $pollingInterval = null;
+
+    protected function getData(): array
+    {
+        $months = collect(range(11, 0))->map(fn (int $i) => now()->subMonths($i)->startOfMonth());
+
+        $counts = ImportedFile::query()
+            ->where('created_at', '>=', $months->first())
+            ->get()
+            ->groupBy(fn (ImportedFile $file) => Carbon::parse($file->created_at)->format('Y-m'))
+            ->map->count();
+
+        $labels = $months->map(fn (Carbon $date) => $date->format('M Y'))->toArray();
+        $data = $months->map(fn (Carbon $date) => $counts->get($date->format('Y-m'), 0))->toArray();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Imports',
+                    'data' => $data,
+                    'borderColor' => '#6366f1',
+                    'backgroundColor' => 'rgba(99, 102, 241, 0.1)',
+                    'fill' => true,
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Widgets/MappingStatusChart.php
+++ b/app/Filament/Widgets/MappingStatusChart.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\MappingType;
+use App\Models\Transaction;
+use Filament\Widgets\ChartWidget;
+
+class MappingStatusChart extends ChartWidget
+{
+    protected ?string $heading = 'Mapping Status Distribution';
+
+    protected static ?int $sort = 4;
+
+    protected ?string $pollingInterval = null;
+
+    protected function getData(): array
+    {
+        $counts = Transaction::query()
+            ->selectRaw('mapping_type, count(*) as total')
+            ->groupBy('mapping_type')
+            ->pluck('total', 'mapping_type');
+
+        $labels = [];
+        $data = [];
+        $colors = [];
+
+        foreach (MappingType::cases() as $type) {
+            $labels[] = $type->getLabel();
+            $data[] = (int) ($counts->get($type->value, 0));
+            $colors[] = match ($type) {
+                MappingType::Unmapped => '#9ca3af',
+                MappingType::Auto => '#3b82f6',
+                MappingType::Manual => '#22c55e',
+                MappingType::Ai => '#f59e0b',
+            };
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'data' => $data,
+                    'backgroundColor' => $colors,
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'doughnut';
+    }
+}

--- a/app/Filament/Widgets/MonthlyDebitCreditChart.php
+++ b/app/Filament/Widgets/MonthlyDebitCreditChart.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Transaction;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Carbon;
+
+class MonthlyDebitCreditChart extends ChartWidget
+{
+    protected ?string $heading = 'Monthly Debit / Credit Totals';
+
+    protected static ?int $sort = 6;
+
+    protected ?string $pollingInterval = null;
+
+    protected function getData(): array
+    {
+        $months = collect(range(11, 0))->map(fn (int $i) => now()->subMonths($i)->startOfMonth());
+
+        $startDate = $months->first();
+
+        // Load all transactions from the last 12 months via Eloquent
+        // (debit/credit are encrypted -- cannot SUM in SQL)
+        $transactions = Transaction::query()
+            ->where('date', '>=', $startDate)
+            ->get();
+
+        $grouped = $transactions->groupBy(fn (Transaction $t) => Carbon::parse($t->date)->format('Y-m'));
+
+        $debitData = [];
+        $creditData = [];
+        $labels = [];
+
+        foreach ($months as $month) {
+            $key = $month->format('Y-m');
+            $labels[] = $month->format('M Y');
+
+            $monthTransactions = $grouped->get($key, collect());
+
+            $debitData[] = round(
+                $monthTransactions->sum(fn (Transaction $t) => $t->debit !== null ? (float) $t->debit : 0),
+                2,
+            );
+
+            $creditData[] = round(
+                $monthTransactions->sum(fn (Transaction $t) => $t->credit !== null ? (float) $t->credit : 0),
+                2,
+            );
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Debits',
+                    'data' => $debitData,
+                    'backgroundColor' => '#ef4444',
+                ],
+                [
+                    'label' => 'Credits',
+                    'data' => $creditData,
+                    'backgroundColor' => '#22c55e',
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/app/Filament/Widgets/TopAccountHeadsChart.php
+++ b/app/Filament/Widgets/TopAccountHeadsChart.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\AccountHead;
+use Filament\Widgets\ChartWidget;
+
+class TopAccountHeadsChart extends ChartWidget
+{
+    protected ?string $heading = 'Top 10 Account Heads by Volume';
+
+    protected static ?int $sort = 5;
+
+    protected ?string $pollingInterval = null;
+
+    protected function getData(): array
+    {
+        $heads = AccountHead::query()
+            ->withCount('transactions')
+            ->has('transactions')
+            ->orderByDesc('transactions_count')
+            ->limit(10)
+            ->get();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Transactions',
+                    'data' => $heads->pluck('transactions_count')->toArray(),
+                    'backgroundColor' => '#6366f1',
+                ],
+            ],
+            'labels' => $heads->pluck('name')->toArray(),
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+}

--- a/tests/Feature/Filament/ChartWidgetTest.php
+++ b/tests/Feature/Filament/ChartWidgetTest.php
@@ -1,0 +1,271 @@
+<?php
+
+use App\Filament\Widgets\ImportsOverTimeChart;
+use App\Filament\Widgets\MappingStatusChart;
+use App\Filament\Widgets\MonthlyDebitCreditChart;
+use App\Filament\Widgets\TopAccountHeadsChart;
+use App\Models\AccountHead;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * Helper to call protected getData() on a ChartWidget via reflection.
+ *
+ * @return array<string, mixed>
+ */
+function getChartData(string $widgetClass): array
+{
+    $widget = new $widgetClass;
+    $method = new ReflectionMethod($widget, 'getData');
+
+    return $method->invoke($widget);
+}
+
+describe('ImportsOverTimeChart widget', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render', function () {
+        livewire(ImportsOverTimeChart::class)->assertSuccessful();
+    });
+
+    it('is a line chart', function () {
+        $widget = new ImportsOverTimeChart;
+        $method = new ReflectionMethod($widget, 'getType');
+
+        expect($method->invoke($widget))->toBe('line');
+    });
+
+    it('returns chart data with 12 months of labels and one dataset', function () {
+        ImportedFile::factory()->count(3)->create([
+            'company_id' => tenant()->id,
+            'created_at' => now(),
+        ]);
+
+        $data = getChartData(ImportsOverTimeChart::class);
+
+        expect($data)
+            ->toHaveKey('datasets')
+            ->toHaveKey('labels')
+            ->and($data['labels'])->toHaveCount(12)
+            ->and($data['datasets'])->toHaveCount(1)
+            ->and($data['datasets'][0])->toHaveKey('label')
+            ->and($data['datasets'][0])->toHaveKey('data')
+            ->and($data['datasets'][0]['data'])->toHaveCount(12);
+    });
+
+    it('counts imports grouped by month for last 12 months', function () {
+        $company = tenant();
+
+        ImportedFile::factory()->count(3)->create([
+            'company_id' => $company->id,
+            'created_at' => now(),
+        ]);
+
+        ImportedFile::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'created_at' => now()->subMonth(),
+        ]);
+
+        $data = getChartData(ImportsOverTimeChart::class);
+
+        // Last element = current month count
+        $lastValue = end($data['datasets'][0]['data']);
+        expect($lastValue)->toBe(3);
+
+        // Second-to-last = previous month count
+        $values = $data['datasets'][0]['data'];
+        expect($values[count($values) - 2])->toBe(2);
+    });
+});
+
+describe('MappingStatusChart widget', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render', function () {
+        livewire(MappingStatusChart::class)->assertSuccessful();
+    });
+
+    it('is a doughnut chart', function () {
+        $widget = new MappingStatusChart;
+        $method = new ReflectionMethod($widget, 'getType');
+
+        expect($method->invoke($widget))->toBe('doughnut');
+    });
+
+    it('returns labels for all four mapping types', function () {
+        $company = tenant();
+
+        Transaction::factory()->unmapped()->count(5)->create(['company_id' => $company->id]);
+        Transaction::factory()->mapped()->count(3)->create(['company_id' => $company->id]);
+        Transaction::factory()->autoMapped()->count(2)->create(['company_id' => $company->id]);
+        Transaction::factory()->aiMapped()->count(4)->create(['company_id' => $company->id]);
+
+        $data = getChartData(MappingStatusChart::class);
+
+        expect($data)
+            ->toHaveKey('datasets')
+            ->toHaveKey('labels')
+            ->and($data['labels'])->toHaveCount(4)
+            ->and($data['datasets'])->toHaveCount(1)
+            ->and($data['datasets'][0]['data'])->toHaveCount(4);
+    });
+
+    it('counts transactions per mapping type', function () {
+        $company = tenant();
+
+        Transaction::factory()->unmapped()->count(5)->create(['company_id' => $company->id]);
+        Transaction::factory()->mapped()->count(3)->create(['company_id' => $company->id]);
+        Transaction::factory()->autoMapped()->count(2)->create(['company_id' => $company->id]);
+        Transaction::factory()->aiMapped()->count(4)->create(['company_id' => $company->id]);
+
+        $data = getChartData(MappingStatusChart::class);
+
+        $labels = $data['labels'];
+        $values = $data['datasets'][0]['data'];
+        $map = array_combine($labels, $values);
+
+        expect($map['Unmapped'])->toBe(5)
+            ->and($map['Auto (Rule)'])->toBe(2)
+            ->and($map['Manual'])->toBe(3)
+            ->and($map['AI Matched'])->toBe(4);
+    });
+});
+
+describe('TopAccountHeadsChart widget', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render', function () {
+        livewire(TopAccountHeadsChart::class)->assertSuccessful();
+    });
+
+    it('is a bar chart', function () {
+        $widget = new TopAccountHeadsChart;
+        $method = new ReflectionMethod($widget, 'getType');
+
+        expect($method->invoke($widget))->toBe('bar');
+    });
+
+    it('returns top 10 account heads by transaction count', function () {
+        $company = tenant();
+
+        $heads = AccountHead::factory()->count(12)->create(['company_id' => $company->id]);
+
+        // Assign decreasing transaction counts: 12, 11, 10, ..., 1
+        $heads->each(function (AccountHead $head, int $index) use ($company) {
+            Transaction::factory()
+                ->count(12 - $index)
+                ->mapped($head)
+                ->create(['company_id' => $company->id]);
+        });
+
+        $data = getChartData(TopAccountHeadsChart::class);
+
+        expect($data['labels'])->toHaveCount(10)
+            ->and($data['datasets'][0]['data'])->toHaveCount(10)
+            ->and($data['datasets'][0]['data'][0])->toBe(12)
+            ->and($data['datasets'][0]['data'][9])->toBe(3);
+    });
+
+    it('handles fewer than 10 account heads', function () {
+        $company = tenant();
+
+        $head = AccountHead::factory()->create(['company_id' => $company->id]);
+        Transaction::factory()->count(5)->mapped($head)->create(['company_id' => $company->id]);
+
+        $data = getChartData(TopAccountHeadsChart::class);
+
+        expect($data['labels'])->toHaveCount(1)
+            ->and($data['datasets'][0]['data'])->toHaveCount(1)
+            ->and($data['datasets'][0]['data'][0])->toBe(5);
+    });
+});
+
+describe('MonthlyDebitCreditChart widget', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render', function () {
+        livewire(MonthlyDebitCreditChart::class)->assertSuccessful();
+    });
+
+    it('is a bar chart', function () {
+        $widget = new MonthlyDebitCreditChart;
+        $method = new ReflectionMethod($widget, 'getType');
+
+        expect($method->invoke($widget))->toBe('bar');
+    });
+
+    it('returns two datasets for debits and credits', function () {
+        $company = tenant();
+
+        Transaction::factory()->debit(1000)->create([
+            'company_id' => $company->id,
+            'date' => now(),
+        ]);
+        Transaction::factory()->credit(2000)->create([
+            'company_id' => $company->id,
+            'date' => now(),
+        ]);
+
+        $data = getChartData(MonthlyDebitCreditChart::class);
+
+        expect($data)
+            ->toHaveKey('datasets')
+            ->toHaveKey('labels')
+            ->and($data['labels'])->toHaveCount(12)
+            ->and($data['datasets'])->toHaveCount(2);
+
+        $datasetLabels = array_column($data['datasets'], 'label');
+        expect($datasetLabels)->toContain('Debits')
+            ->toContain('Credits');
+    });
+
+    it('sums debit and credit amounts per month via Eloquent', function () {
+        $company = tenant();
+
+        // Current month: 2 debits and 1 credit
+        Transaction::factory()->debit(1000.50)->create([
+            'company_id' => $company->id,
+            'date' => now(),
+        ]);
+        Transaction::factory()->debit(500.25)->create([
+            'company_id' => $company->id,
+            'date' => now(),
+        ]);
+        Transaction::factory()->credit(3000.75)->create([
+            'company_id' => $company->id,
+            'date' => now(),
+        ]);
+
+        // 2 months ago: 1 credit
+        Transaction::factory()->credit(5000)->create([
+            'company_id' => $company->id,
+            'date' => now()->subMonths(2),
+        ]);
+
+        $data = getChartData(MonthlyDebitCreditChart::class);
+
+        $debitDataset = collect($data['datasets'])->firstWhere('label', 'Debits');
+        $creditDataset = collect($data['datasets'])->firstWhere('label', 'Credits');
+
+        // Current month (last element)
+        $lastDebit = end($debitDataset['data']);
+        $lastCredit = end($creditDataset['data']);
+
+        expect($lastDebit)->toBe(1500.75)
+            ->and($lastCredit)->toBe(3000.75);
+
+        // 2 months ago
+        $idx = count($creditDataset['data']) - 3;
+        expect($creditDataset['data'][$idx])->toBe(5000.0);
+    });
+});


### PR DESCRIPTION
## Summary
- Add 4 Filament chart widgets to the admin dashboard: Imports Over Time (line), Mapping Status Distribution (doughnut), Top 10 Account Heads by Volume (bar), Monthly Debit/Credit Totals (bar)
- MonthlyDebitCreditChart loads transactions via Eloquent and sums in PHP since debit/credit fields are encrypted (cannot use SQL SUM)
- Includes 16 Pest tests covering widget rendering, chart types, data structure, and data correctness

Closes #18

## Test plan
- [x] `php artisan test --compact --filter=ChartWidget` -- 16 tests pass (42 assertions)
- [x] `vendor/bin/phpstan analyse` -- no new errors on widget files
- [x] `vendor/bin/pint --dirty --format agent` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)