### PR TITLE
feat(export): Tally XML export with proper voucher structure

### DIFF
--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -2,28 +2,31 @@
 
 namespace App\Services\TallyExport;
 
+use App\Models\Company;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use Illuminate\Support\Collection;
 
 class TallyExportService
 {
+    /** @var array<string, int> */
+    private array $voucherCounters = [];
+
     /**
      * Generate Tally-compatible XML for transactions in an imported file.
-     *
-     * Note: XML format is a placeholder. Will be updated when Tally XML reference is provided.
      */
     public function exportForFile(ImportedFile $importedFile): string
     {
-        $importedFile->loadMissing('company');
+        $importedFile->loadMissing(['company', 'bankAccount']);
 
+        /** @var \Illuminate\Support\Collection<int, Transaction> $transactions */
         $transactions = $importedFile->transactions()
             ->whereNotNull('account_head_id')
             ->with('accountHead')
             ->orderBy('date')
             ->get();
 
-        return $this->generateXml($transactions, $importedFile);
+        return $this->generateXml($transactions, $importedFile->company, $importedFile->bankAccount?->name);
     }
 
     /**
@@ -33,39 +36,51 @@ class TallyExportService
      */
     public function exportTransactions(Collection $transactions): string
     {
-        $importedFile = $transactions->first()?->importedFile;
+        /** @var Transaction|null $firstTransaction */
+        $firstTransaction = $transactions->first();
+        /** @var ImportedFile|null $importedFile */
+        $importedFile = $firstTransaction?->importedFile;
+        $importedFile?->loadMissing(['company', 'bankAccount']);
 
-        return $this->generateXml($transactions, $importedFile);
+        return $this->generateXml(
+            $transactions,
+            $importedFile?->company,
+            $importedFile?->bankAccount?->name,
+        );
     }
 
     /**
-     * Generate the Tally XML structure.
+     * Generate the complete Tally XML envelope.
      *
-     * TODO: Replace with actual Tally XML format when reference file is provided.
+     * @param  Collection<int, Transaction>  $transactions
      */
-    protected function generateXml(Collection $transactions, ?ImportedFile $importedFile): string
+    private function generateXml(Collection $transactions, ?Company $company, ?string $bankLedgerName): string
     {
-        $companyName = $importedFile?->company?->name;
+        $this->voucherCounters = [];
+        $companyName = $company?->name ?? '';
+        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
         $xml .= '<ENVELOPE>'."\n";
         $xml .= '  <HEADER>'."\n";
         $xml .= '    <TALLYREQUEST>Import Data</TALLYREQUEST>'."\n";
-
-        if ($companyName) {
-            $xml .= '    <COMPANYNAME>'.htmlspecialchars($companyName, ENT_XML1).'</COMPANYNAME>'."\n";
-        }
-
         $xml .= '  </HEADER>'."\n";
         $xml .= '  <BODY>'."\n";
         $xml .= '    <IMPORTDATA>'."\n";
         $xml .= '      <REQUESTDESC>'."\n";
-        $xml .= '        <REPORTNAME>Vouchers</REPORTNAME>'."\n";
+        $xml .= '        <REPORTNAME>All Masters</REPORTNAME>'."\n";
+        $xml .= '        <STATICVARIABLES>'."\n";
+        $xml .= '          <SVCURRENTCOMPANY>'.$e($companyName).'</SVCURRENTCOMPANY>'."\n";
+        $xml .= '        </STATICVARIABLES>'."\n";
         $xml .= '      </REQUESTDESC>'."\n";
         $xml .= '      <REQUESTDATA>'."\n";
 
         foreach ($transactions as $transaction) {
-            $xml .= $this->generateVoucher($transaction);
+            $xml .= $this->generateVoucher($transaction, $company, $bankLedgerName);
+        }
+
+        if ($company && $transactions->isNotEmpty()) {
+            $xml .= $this->generateCompanyFooter($company);
         }
 
         $xml .= '      </REQUESTDATA>'."\n";
@@ -77,31 +92,165 @@ class TallyExportService
     }
 
     /**
-     * Generate a single Tally voucher XML element.
-     *
-     * TODO: Replace with actual voucher format from Tally XML reference.
+     * Generate a single Tally voucher XML element (Payment or Receipt).
      */
-    protected function generateVoucher(Transaction $transaction): string
+    private function generateVoucher(Transaction $transaction, ?Company $company, ?string $bankLedgerName): string
     {
-        $date = $transaction->date->format('Ymd');
-        $headName = htmlspecialchars($transaction->accountHead?->name ?? 'Unknown', ENT_XML1);
-        $amount = htmlspecialchars((string) ($transaction->debit ?? $transaction->credit ?? '0'), ENT_XML1);
-        $voucherType = $transaction->debit ? 'Payment' : 'Receipt';
-        $description = htmlspecialchars($transaction->description ?? '', ENT_XML1);
+        $isPayment = $transaction->debit !== null;
+        $voucherType = $isPayment ? 'Payment' : 'Receipt';
+        $amount = (float) ($isPayment ? $transaction->debit : $transaction->credit);
+        /** @var \Illuminate\Support\Carbon $transactionDate */
+        $transactionDate = $transaction->date;
+        $date = $transactionDate->format('Ymd');
+        /** @var \App\Models\AccountHead|null $accountHead */
+        $accountHead = $transaction->accountHead;
+        $headName = $accountHead?->name ?? 'Unknown';
+        $bankName = $bankLedgerName ?? 'Bank Account';
+        $voucherNumber = $this->nextVoucherNumber($voucherType);
+
+        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
-        $xml .= '          <VOUCHER VCHTYPE="'.$voucherType.'" ACTION="Create">'."\n";
+        $xml .= '          <VOUCHER VCHTYPE="'.$e($voucherType).'" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
         $xml .= '            <DATE>'.$date.'</DATE>'."\n";
-        $xml .= '            <NARRATION>'.$description.'</NARRATION>'."\n";
-        $xml .= '            <VOUCHERTYPENAME>'.$voucherType.'</VOUCHERTYPENAME>'."\n";
-        $xml .= '            <PARTYLEDGERNAME>'.$headName.'</PARTYLEDGERNAME>'."\n";
-        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$headName.'</LEDGERNAME>'."\n";
-        $xml .= '              <AMOUNT>'.$amount.'</AMOUNT>'."\n";
-        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '            <VCHSTATUSDATE>'.$date.'</VCHSTATUSDATE>'."\n";
+        $xml .= '            <NARRATION>'.$e($transaction->description ?? '').'</NARRATION>'."\n";
+        $xml .= '            <VOUCHERTYPENAME>'.$e($voucherType).'</VOUCHERTYPENAME>'."\n";
+        $xml .= '            <VOUCHERNUMBER>'.$voucherNumber.'</VOUCHERNUMBER>'."\n";
+        $xml .= '            <PARTYLEDGERNAME>'.$e($headName).'</PARTYLEDGERNAME>'."\n";
+
+        if ($company) {
+            $xml .= '            <CMPGSTIN>'.$e($company->gstin ?? '').'</CMPGSTIN>'."\n";
+            $xml .= '            <CMPGSTREGISTRATIONTYPE>'.$e($company->gst_registration_type ?? 'Regular').'</CMPGSTREGISTRATIONTYPE>'."\n";
+            $xml .= '            <CMPGSTSTATE>'.$e($company->state ?? '').'</CMPGSTSTATE>'."\n";
+        }
+
+        $xml .= '            <EFFECTIVEDATE>'.$date.'</EFFECTIVEDATE>'."\n";
+
+        // Boilerplate boolean flags
+        $xml .= '            <ISDELETED>No</ISDELETED>'."\n";
+        $xml .= '            <ISCANCELLED>No</ISCANCELLED>'."\n";
+        $xml .= '            <ISONHOLD>No</ISONHOLD>'."\n";
+        $xml .= '            <ISOPTIONAL>No</ISOPTIONAL>'."\n";
+        $xml .= '            <AUDITED>No</AUDITED>'."\n";
+        $xml .= '            <HASCASHFLOW>Yes</HASCASHFLOW>'."\n";
+
+        // Ledger entries
+        if ($isPayment) {
+            $xml .= $this->generatePaymentLedgerEntries($headName, $bankName, $amount, $date, $e);
+        } else {
+            $xml .= $this->generateReceiptLedgerEntries($headName, $bankName, $amount, $date, $e);
+        }
+
         $xml .= '          </VOUCHER>'."\n";
         $xml .= '        </TALLYMESSAGE>'."\n";
 
         return $xml;
+    }
+
+    /**
+     * Generate ledger entries for a Payment voucher.
+     * Debit: expense/party (negative amount, ISDEEMEDPOSITIVE=Yes)
+     * Credit: bank (positive amount, ISDEEMEDPOSITIVE=No)
+     *
+     * @param  \Closure(string): string  $e
+     */
+    private function generatePaymentLedgerEntries(string $headName, string $bankName, float $amount, string $date, \Closure $e): string
+    {
+        $formattedAmount = number_format($amount, 2, '.', '');
+
+        $xml = '';
+
+        // Debit leg: Expense/Party
+        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$e($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        // Credit leg: Bank
+        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$e($bankName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
+        $xml .= '                <DATE>'.$date.'</DATE>'."\n";
+        $xml .= '                <INSTRUMENTDATE>'.$date.'</INSTRUMENTDATE>'."\n";
+        $xml .= '                <BANKERSDATE>'.$date.'</BANKERSDATE>'."\n";
+        $xml .= '                <TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>'."\n";
+        $xml .= '                <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '              </BANKALLOCATIONS.LIST>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        return $xml;
+    }
+
+    /**
+     * Generate ledger entries for a Receipt voucher.
+     * Debit: bank (negative amount, ISDEEMEDPOSITIVE=Yes)
+     * Credit: party/income (positive amount, ISDEEMEDPOSITIVE=No)
+     *
+     * @param  \Closure(string): string  $e
+     */
+    private function generateReceiptLedgerEntries(string $headName, string $bankName, float $amount, string $date, \Closure $e): string
+    {
+        $formattedAmount = number_format($amount, 2, '.', '');
+
+        $xml = '';
+
+        // Debit leg: Bank
+        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$e($bankName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
+        $xml .= '                <DATE>'.$date.'</DATE>'."\n";
+        $xml .= '                <INSTRUMENTDATE>'.$date.'</INSTRUMENTDATE>'."\n";
+        $xml .= '                <BANKERSDATE>'.$date.'</BANKERSDATE>'."\n";
+        $xml .= '                <TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>'."\n";
+        $xml .= '                <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '              </BANKALLOCATIONS.LIST>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        // Credit leg: Party/Income
+        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$e($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        return $xml;
+    }
+
+    /**
+     * Generate the company identity footer block.
+     */
+    private function generateCompanyFooter(Company $company): string
+    {
+        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+
+        $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
+        $xml .= '          <COMPANY>'."\n";
+        $xml .= '            <REMOTECMPINFO.LIST MERGE="Yes">'."\n";
+        $xml .= '              <NAME>'.$e($company->gstin ?? '').'</NAME>'."\n";
+        $xml .= '              <REMOTECMPNAME>'.$e($company->name ?? '').'</REMOTECMPNAME>'."\n";
+        $xml .= '              <REMOTECMPSTATE>'.$e($company->state ?? '').'</REMOTECMPSTATE>'."\n";
+        $xml .= '            </REMOTECMPINFO.LIST>'."\n";
+        $xml .= '          </COMPANY>'."\n";
+        $xml .= '        </TALLYMESSAGE>'."\n";
+
+        return $xml;
+    }
+
+    /**
+     * Get the next sequential voucher number for a given type.
+     */
+    private function nextVoucherNumber(string $voucherType): int
+    {
+        if (! isset($this->voucherCounters[$voucherType])) {
+            $this->voucherCounters[$voucherType] = 0;
+        }
+
+        return ++$this->voucherCounters[$voucherType];
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -372,29 +372,6 @@ parameters:
 			count: 1
 			path: app/Services/HeadMatcher/RuleBasedMatcher.php
 
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/TallyExport/TallyExportService.php
-
-		-
-			message: '#^Cannot call method format\(\) on string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/Services/TallyExport/TallyExportService.php
-
-		-
-			message: '#^Method App\\Services\\TallyExport\\TallyExportService\:\:generateXml\(\) has parameter \$transactions with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: app/Services/TallyExport/TallyExportService.php
-
-		-
-			message: '#^Parameter \#2 \$importedFile of method App\\Services\\TallyExport\\TallyExportService\:\:generateXml\(\) expects App\\Models\\ImportedFile\|null, Illuminate\\Database\\Eloquent\\Model\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Services/TallyExport/TallyExportService.php
 
 		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Support\\Collection\<int,Illuminate\\Database\\Eloquent\\Model\>\:\:reject\(\) expects bool\|\(callable\(Illuminate\\Database\\Eloquent\\Model, int\)\: bool\)\|Illuminate\\Database\\Eloquent\\Model, Closure\(App\\Models\\Transaction\)\: bool given\.$#'

--- a/tests/Feature/Services/TallyExportServiceTest.php
+++ b/tests/Feature/Services/TallyExportServiceTest.php
@@ -1,90 +1,378 @@
 <?php
 
 use App\Models\AccountHead;
+use App\Models\BankAccount;
 use App\Models\Company;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Services\TallyExport\TallyExportService;
 
-describe('TallyExportService::exportForFile()', function () {
-    it('generates XML with mapped transactions only', function () {
-        $head = AccountHead::factory()->create(['name' => 'Salary Account']);
-        $file = ImportedFile::factory()->create();
-
-        Transaction::factory()->mapped($head)->debit(5000)->for($file)->create([
-            'description' => 'SALARY JUNE',
-            'date' => '2024-06-15',
+describe('TallyExportService', function () {
+    beforeEach(function () {
+        $this->company = Company::factory()->zysk()->create();
+        $this->bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Icici Bank',
         ]);
-        Transaction::factory()->unmapped()->for($file)->create();
-
-        $service = new TallyExportService;
-        $xml = $service->exportForFile($file);
-
-        expect($xml)->toContain('<ENVELOPE>')
-            ->and($xml)->toContain('<REPORTNAME>Vouchers</REPORTNAME>')
-            ->and($xml)->toContain('Salary Account')
-            ->and($xml)->toContain('20240615')
-            ->and($xml)->toContain('VCHTYPE="Payment"');
+        $this->file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => $this->bankAccount->id,
+            'bank_name' => 'ICICI',
+        ]);
+        $this->service = new TallyExportService;
     });
 
-    it('generates receipt voucher for credits', function () {
-        $head = AccountHead::factory()->create(['name' => 'Income']);
-        $file = ImportedFile::factory()->create();
+    describe('envelope structure', function () {
+        it('generates valid XML with proper envelope structure', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Salary Account',
+            ]);
+            Transaction::factory()->mapped($head)->debit(5000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'description' => 'SALARY JUNE',
+                'date' => '2024-06-15',
+            ]);
 
-        Transaction::factory()->mapped($head)->credit(10000)->for($file)->create([
-            'description' => 'Client Payment',
-            'date' => '2024-07-01',
-        ]);
+            $xml = $this->service->exportForFile($this->file);
 
-        $service = new TallyExportService;
-        $xml = $service->exportForFile($file);
+            expect($xml)->toContain('<?xml version="1.0" encoding="UTF-8"?>')
+                ->and($xml)->toContain('<ENVELOPE>')
+                ->and($xml)->toContain('<TALLYREQUEST>Import Data</TALLYREQUEST>')
+                ->and($xml)->toContain('<IMPORTDATA>')
+                ->and($xml)->toContain('<REQUESTDESC>')
+                ->and($xml)->toContain('<REPORTNAME>All Masters</REPORTNAME>')
+                ->and($xml)->toContain('<SVCURRENTCOMPANY>Zysk Technologies Private Limited - 2025 - 2026</SVCURRENTCOMPANY>')
+                ->and($xml)->toContain('<REQUESTDATA>')
+                ->and($xml)->toContain('</ENVELOPE>');
+        });
 
-        expect($xml)->toContain('VCHTYPE="Receipt"');
+        it('returns empty XML structure when no mapped transactions', function () {
+            Transaction::factory()->unmapped()->for($this->file)->count(3)->create([
+                'company_id' => $this->company->id,
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<ENVELOPE>')
+                ->and($xml)->toContain('<REQUESTDATA>')
+                ->and($xml)->not->toContain('<TALLYMESSAGE');
+        });
     });
 
-    it('returns empty XML structure when no mapped transactions', function () {
-        $file = ImportedFile::factory()->create();
-        Transaction::factory()->unmapped()->for($file)->count(3)->create();
+    describe('payment vouchers', function () {
+        it('generates payment voucher for debit transactions', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'TATA CAPITAL LIMITED',
+            ]);
+            Transaction::factory()->mapped($head)->debit(88609.51)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'description' => 'ACH/TATACAPFINSERLTD',
+                'date' => '2025-04-01',
+            ]);
 
-        $service = new TallyExportService;
-        $xml = $service->exportForFile($file);
+            $xml = $this->service->exportForFile($this->file);
 
-        expect($xml)->toContain('<ENVELOPE>')
-            ->and($xml)->toContain('<REQUESTDATA>')
-            ->and($xml)->not->toContain('<TALLYMESSAGE');
+            expect($xml)->toContain('VCHTYPE="Payment"')
+                ->and($xml)->toContain('ACTION="Create"')
+                ->and($xml)->toContain('<DATE>20250401</DATE>')
+                ->and($xml)->toContain('<VOUCHERTYPENAME>Payment</VOUCHERTYPENAME>')
+                ->and($xml)->toContain('<NARRATION>ACH/TATACAPFINSERLTD</NARRATION>')
+                ->and($xml)->toContain('<PARTYLEDGERNAME>TATA CAPITAL LIMITED</PARTYLEDGERNAME>')
+                ->and($xml)->toContain('<CMPGSTIN>29AABCZ5012F1ZG</CMPGSTIN>')
+                ->and($xml)->toContain('<CMPGSTREGISTRATIONTYPE>Regular</CMPGSTREGISTRATIONTYPE>')
+                ->and($xml)->toContain('<CMPGSTSTATE>Karnataka</CMPGSTSTATE>');
+        });
+
+        it('generates correct ledger entries for payment voucher', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Rent Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(50000.00)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-15',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            // Debit leg: expense head, negative amount, ISDEEMEDPOSITIVE=Yes
+            expect($xml)->toContain('<LEDGERNAME>Rent Expense</LEDGERNAME>')
+                ->and($xml)->toContain('<ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>')
+                ->and($xml)->toContain('<AMOUNT>-50000.00</AMOUNT>');
+
+            // Credit leg: bank account, positive amount, ISDEEMEDPOSITIVE=No
+            expect($xml)->toContain('<LEDGERNAME>Icici Bank</LEDGERNAME>')
+                ->and($xml)->toContain('<ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>')
+                ->and($xml)->toContain('<AMOUNT>50000.00</AMOUNT>');
+        });
+
+        it('includes BANKALLOCATIONS.LIST on bank credit leg', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Office Supplies',
+            ]);
+            Transaction::factory()->mapped($head)->debit(15000.00)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-10',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<BANKALLOCATIONS.LIST>')
+                ->and($xml)->toContain('<TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>');
+        });
     });
-});
 
-describe('TallyExportService::exportTransactions()', function () {
-    it('exports a collection of transactions', function () {
-        $head = AccountHead::factory()->create(['name' => 'Rent']);
-        $transactions = Transaction::factory()->mapped($head)->debit(15000)->count(2)->create([
-            'date' => '2024-08-01',
-        ]);
+    describe('receipt vouchers', function () {
+        it('generates receipt voucher for credit transactions', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'METAFIRST TECHNOLOGIES',
+            ]);
+            Transaction::factory()->mapped($head)->credit(150000.00)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'description' => 'Client Payment',
+                'date' => '2025-04-20',
+            ]);
 
-        $service = new TallyExportService;
-        $xml = $service->exportTransactions($transactions);
+            $xml = $this->service->exportForFile($this->file);
 
-        expect($xml)->toContain('<ENVELOPE>')
-            ->and($xml)->toContain('Rent')
-            ->and(substr_count($xml, '<TALLYMESSAGE'))->toBe(2);
+            expect($xml)->toContain('VCHTYPE="Receipt"')
+                ->and($xml)->toContain('<VOUCHERTYPENAME>Receipt</VOUCHERTYPENAME>');
+        });
+
+        it('generates correct ledger entries for receipt voucher', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Client Income',
+            ]);
+            Transaction::factory()->mapped($head)->credit(200000.00)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-25',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            // Receipt: Bank is debit (negative, ISDEEMEDPOSITIVE=Yes)
+            expect($xml)->toContain('<LEDGERNAME>Icici Bank</LEDGERNAME>')
+                ->and($xml)->toContain('<AMOUNT>-200000.00</AMOUNT>');
+
+            // Receipt: Party is credit (positive, ISDEEMEDPOSITIVE=No)
+            expect($xml)->toContain('<LEDGERNAME>Client Income</LEDGERNAME>')
+                ->and($xml)->toContain('<AMOUNT>200000.00</AMOUNT>');
+        });
     });
-});
 
-describe('TallyExportService with Company', function () {
-    it('includes company name in XML header', function () {
-        $company = Company::factory()->create(['name' => 'Zysk Technologies']);
-        $head = AccountHead::factory()->create(['company_id' => $company->id]);
-        $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+    describe('voucher numbering', function () {
+        it('generates sequential voucher numbers per voucher type', function () {
+            $head1 = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Expense A',
+            ]);
+            $head2 = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Income B',
+            ]);
 
-        Transaction::factory()->mapped($head)->debit(5000)->for($file)->create([
-            'company_id' => $company->id,
-            'date' => '2024-06-15',
-        ]);
+            // Two payments
+            Transaction::factory()->mapped($head1)->debit(1000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+            Transaction::factory()->mapped($head1)->debit(2000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-02',
+            ]);
+            // One receipt
+            Transaction::factory()->mapped($head2)->credit(5000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-03',
+            ]);
 
-        $service = new TallyExportService;
-        $xml = $service->exportForFile($file);
+            $xml = $this->service->exportForFile($this->file);
 
-        expect($xml)->toContain('Zysk Technologies');
+            // Payment vouchers numbered 1, 2
+            expect(substr_count($xml, '<VOUCHERNUMBER>1</VOUCHERNUMBER>'))->toBeGreaterThanOrEqual(1)
+                ->and(substr_count($xml, '<VOUCHERNUMBER>2</VOUCHERNUMBER>'))->toBeGreaterThanOrEqual(1);
+        });
+    });
+
+    describe('voucher balance', function () {
+        it('generates balanced vouchers where amounts sum to zero', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Test Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(25000.50)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            // Payment: debit leg = -25000.50, credit leg = 25000.50, sum = 0
+            expect($xml)->toContain('<AMOUNT>-25000.50</AMOUNT>')
+                ->and($xml)->toContain('<AMOUNT>25000.50</AMOUNT>');
+        });
+    });
+
+    describe('company footer', function () {
+        it('includes company identity block at the end', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(1000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<COMPANY>')
+                ->and($xml)->toContain('<REMOTECMPNAME>Zysk Technologies Private Limited - 2025 - 2026</REMOTECMPNAME>')
+                ->and($xml)->toContain('<REMOTECMPSTATE>Karnataka</REMOTECMPSTATE>');
+        });
+    });
+
+    describe('XML escaping', function () {
+        it('escapes special XML characters in descriptions and names', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'R&D Expenses',
+            ]);
+            Transaction::factory()->mapped($head)->debit(5000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'description' => 'Payment for <Project Alpha> & "Beta"',
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('R&amp;D Expenses')
+                ->and($xml)->toContain('&lt;Project Alpha&gt;')
+                ->and($xml)->toContain('&amp; &quot;Beta&quot;');
+        });
+    });
+
+    describe('exportForFile', function () {
+        it('only exports mapped transactions', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Mapped Head',
+            ]);
+
+            Transaction::factory()->mapped($head)->debit(5000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+            Transaction::factory()->unmapped()->for($this->file)->create([
+                'company_id' => $this->company->id,
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect(substr_count($xml, '<VOUCHER '))->toBe(1)
+                ->and($xml)->toContain('Mapped Head');
+        });
+    });
+
+    describe('exportTransactions', function () {
+        it('exports a collection of transactions', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Rent',
+            ]);
+            $transactions = Transaction::factory()
+                ->mapped($head)
+                ->debit(15000)
+                ->for($this->file)
+                ->count(2)
+                ->create([
+                    'company_id' => $this->company->id,
+                    'date' => '2025-04-01',
+                ]);
+
+            $xml = $this->service->exportTransactions($transactions);
+
+            expect($xml)->toContain('<ENVELOPE>')
+                ->and($xml)->toContain('Rent')
+                ->and(substr_count($xml, '<VOUCHER '))->toBe(2);
+        });
+    });
+
+    describe('boilerplate fields', function () {
+        it('includes standard boilerplate boolean flags', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(1000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<ISDELETED>No</ISDELETED>')
+                ->and($xml)->toContain('<ISCANCELLED>No</ISCANCELLED>');
+        });
+    });
+
+    describe('date formatting', function () {
+        it('formats dates as YYYYMMDD without separators', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(1000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-12-31',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<DATE>20251231</DATE>')
+                ->and($xml)->toContain('<EFFECTIVEDATE>20251231</EFFECTIVEDATE>');
+        });
+    });
+
+    describe('valid XML output', function () {
+        it('produces well-formed XML that can be parsed', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Test Head',
+            ]);
+            Transaction::factory()->mapped($head)->debit(5000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            $doc = new DOMDocument;
+            $result = $doc->loadXML($xml);
+
+            expect($result)->toBeTrue();
+        });
+    });
+
+    describe('OBJVIEW attribute', function () {
+        it('includes Accounting Voucher View on voucher element', function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(1000)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2025-04-01',
+            ]);
+
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('OBJVIEW="Accounting Voucher View"');
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Rewrites `TallyExportService` with proper Tally-compatible XML envelope structure (ENVELOPE > HEADER > BODY > IMPORTDATA > REQUESTDESC + REQUESTDATA)
- Implements Payment/Receipt voucher generation with correct 2-leg accounting entries (debit/credit signs, ISDEEMEDPOSITIVE, BANKALLOCATIONS.LIST)
- Adds company GST fields (CMPGSTIN, CMPGSTREGISTRATIONTYPE, CMPGSTSTATE), sequential voucher numbers, company footer block, and boilerplate flags
- Adds date range filter on the Filament export action for selective exports
- Comprehensive test suite: 17 Pest tests covering envelope, payment/receipt vouchers, numbering, balance verification, XML escaping, and well-formedness

Closes #15

## Test plan
- [x] `php artisan test --compact --filter=TallyExport` -- 17 tests, 58 assertions all pass
- [x] `vendor/bin/phpstan analyse --memory-limit=512M` -- no errors
- [x] `vendor/bin/pint --dirty --format agent` -- clean
- [ ] Verify XML output can be imported into Tally ERP (manual validation)
- [ ] Test date range filter in Filament UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)