### PR TITLE
feat(connectors): per-tenant Zoho OAuth credentials and data center

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,6 @@ AI_MATCHING_MODEL=mistralai/mistral-large-latest
 
 DB_SSLMODE=prefer
 
-ZOHO_ACCOUNTS_URL=https://accounts.zoho.com
-ZOHO_API_URL=https://www.zohoapis.com
-ZOHO_CLIENT_ID=<your-zoho-client-id>
-ZOHO_CLIENT_SECRET=<your-zoho-client-secret>
 ZOHO_REDIRECT_URI=https://virtual-cfo.test/connectors/zoho/callback
 
 MAILGUN_SECRET=<your-mailgun-api-key>

--- a/app/Enums/ZohoDataCenter.php
+++ b/app/Enums/ZohoDataCenter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum ZohoDataCenter: string implements HasLabel
+{
+    case India = 'in';
+    case Us = 'us';
+    case Eu = 'eu';
+    case Australia = 'au';
+    case Japan = 'jp';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::India => 'India (.in)',
+            self::Us => 'United States (.com)',
+            self::Eu => 'Europe (.eu)',
+            self::Australia => 'Australia (.com.au)',
+            self::Japan => 'Japan (.jp)',
+        };
+    }
+
+    public function accountsUrl(): string
+    {
+        return match ($this) {
+            self::India => 'https://accounts.zoho.in',
+            self::Us => 'https://accounts.zoho.com',
+            self::Eu => 'https://accounts.zoho.eu',
+            self::Australia => 'https://accounts.zoho.com.au',
+            self::Japan => 'https://accounts.zoho.jp',
+        };
+    }
+
+    public function apiUrl(): string
+    {
+        return match ($this) {
+            self::India => 'https://www.zohoapis.in',
+            self::Us => 'https://www.zohoapis.com',
+            self::Eu => 'https://www.zohoapis.eu',
+            self::Australia => 'https://www.zohoapis.com.au',
+            self::Japan => 'https://www.zohoapis.jp',
+        };
+    }
+}

--- a/app/Filament/Pages/Tenancy/EditCompanySettings.php
+++ b/app/Filament/Pages/Tenancy/EditCompanySettings.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages\Tenancy;
 
 use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Models\Connector;
 use App\Services\Connectors\ZohoInvoiceService;
 use App\Support\GstinValidator;
@@ -145,9 +146,48 @@ class EditCompanySettings extends EditTenantProfile
         return [
             Action::make('connectZoho')
                 ->label('Connect Zoho Invoice')
-                ->url(fn () => route('connectors.zoho.redirect', ['company' => Filament::getTenant()]))
                 ->color('primary')
-                ->visible(fn () => $this->getZohoConnector() === null),
+                ->visible(fn () => $this->getZohoConnector() === null)
+                ->modalHeading('Connect Zoho Invoice')
+                ->modalDescription('Enter your Zoho OAuth app credentials. You can find these in the Zoho API Console.')
+                ->schema([
+                    Select::make('data_center')
+                        ->label('Data Center')
+                        ->options(ZohoDataCenter::class)
+                        ->required()
+                        ->default(ZohoDataCenter::India->value),
+                    TextInput::make('client_id')
+                        ->label('Client ID')
+                        ->required()
+                        ->placeholder('1000.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'),
+                    TextInput::make('client_secret')
+                        ->label('Client Secret')
+                        ->required()
+                        ->password()
+                        ->revealable(),
+                ])
+                ->modalSubmitActionLabel('Connect')
+                ->action(function (array $data): void {
+                    /** @var \App\Models\Company $company */
+                    $company = Filament::getTenant();
+
+                    Connector::updateOrCreate(
+                        [
+                            'company_id' => $company->id,
+                            'provider' => ConnectorProvider::Zoho,
+                        ],
+                        [
+                            'settings' => [
+                                'data_center' => $data['data_center'],
+                                'client_id' => $data['client_id'],
+                                'client_secret' => $data['client_secret'],
+                            ],
+                            'is_active' => false,
+                        ],
+                    );
+
+                    $this->redirect(route('connectors.zoho.redirect', ['company' => $company]));
+                }),
 
             Action::make('syncZoho')
                 ->label('Sync Now')

--- a/app/Http/Controllers/ZohoOAuthCallbackController.php
+++ b/app/Http/Controllers/ZohoOAuthCallbackController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Models\Connector;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -21,12 +22,17 @@ class ZohoOAuthCallbackController
             return $this->redirectToSettings($companyId, 'Zoho authorization was cancelled.');
         }
 
-        $accountsUrl = config('services.zoho.accounts_url');
+        $connector = Connector::withTrashed()
+            ->where('company_id', $companyId)
+            ->where('provider', ConnectorProvider::Zoho)
+            ->firstOrFail();
 
-        $response = Http::asForm()->post("{$accountsUrl}/oauth/v2/token", [
+        $dataCenter = ZohoDataCenter::from($connector->settings['data_center']);
+
+        $response = Http::asForm()->post("{$dataCenter->accountsUrl()}/oauth/v2/token", [
             'code' => $code,
-            'client_id' => config('services.zoho.client_id'),
-            'client_secret' => config('services.zoho.client_secret'),
+            'client_id' => $connector->settings['client_id'],
+            'client_secret' => $connector->settings['client_secret'],
             'redirect_uri' => config('services.zoho.redirect_uri'),
             'grant_type' => 'authorization_code',
         ]);
@@ -45,46 +51,33 @@ class ZohoOAuthCallbackController
             return $this->redirectToSettings($companyId, "Failed to connect to Zoho: {$zohoError}. Please try again.");
         }
 
-        $this->upsertConnector($companyId, $data);
+        $this->updateConnectorTokens($connector, $data);
 
         return $this->redirectToSettings($companyId, status: 'connected');
     }
 
     /**
-     * Create or update the Zoho connector, restoring if previously soft-deleted.
+     * Update the Zoho connector with token data, merging into existing settings.
      *
      * @param  array<string, mixed>  $data
      */
-    protected function upsertConnector(int $companyId, array $data): Connector
+    protected function updateConnectorTokens(Connector $connector, array $data): Connector
     {
-        $connector = Connector::withTrashed()
-            ->where('company_id', $companyId)
-            ->where('provider', ConnectorProvider::Zoho)
-            ->first();
+        if ($connector->trashed()) {
+            $connector->restore();
+        }
 
-        $attributes = [
+        $connector->update([
             'access_token' => $data['access_token'],
             'refresh_token' => $data['refresh_token'] ?? null,
             'token_expires_at' => now()->addSeconds($data['expires_in'] ?? 3600),
-            'settings' => ['organization_id' => $data['organization_id'] ?? null],
+            'settings' => array_merge($connector->settings ?? [], [
+                'organization_id' => $data['organization_id'] ?? null,
+            ]),
             'is_active' => true,
-        ];
-
-        if ($connector) {
-            if ($connector->trashed()) {
-                $connector->restore();
-            }
-
-            $connector->update($attributes);
-
-            return $connector;
-        }
-
-        return Connector::create([
-            'company_id' => $companyId,
-            'provider' => ConnectorProvider::Zoho,
-            ...$attributes,
         ]);
+
+        return $connector;
     }
 
     protected function redirectToSettings(int $companyId, ?string $error = null, ?string $status = null): RedirectResponse

--- a/app/Http/Controllers/ZohoOAuthRedirectController.php
+++ b/app/Http/Controllers/ZohoOAuthRedirectController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Models\Company;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Crypt;
@@ -12,9 +14,15 @@ class ZohoOAuthRedirectController
     {
         $this->authorize($company);
 
+        $connector = $company->connectors()
+            ->where('provider', ConnectorProvider::Zoho)
+            ->firstOrFail();
+
+        $dataCenter = ZohoDataCenter::from($connector->settings['data_center']);
+
         $params = http_build_query([
             'response_type' => 'code',
-            'client_id' => config('services.zoho.client_id'),
+            'client_id' => $connector->settings['client_id'],
             'scope' => 'ZohoInvoice.invoices.READ',
             'redirect_uri' => config('services.zoho.redirect_uri'),
             'state' => Crypt::encrypt($company->id),
@@ -22,9 +30,7 @@ class ZohoOAuthRedirectController
             'prompt' => 'consent',
         ]);
 
-        $accountsUrl = config('services.zoho.accounts_url');
-
-        return redirect()->away("{$accountsUrl}/oauth/v2/auth?{$params}");
+        return redirect()->away("{$dataCenter->accountsUrl()}/oauth/v2/auth?{$params}");
     }
 
     private function authorize(Company $company): void

--- a/app/Services/Connectors/ZohoInvoiceService.php
+++ b/app/Services/Connectors/ZohoInvoiceService.php
@@ -5,6 +5,7 @@ namespace App\Services\Connectors;
 use App\Enums\ImportSource;
 use App\Enums\ImportStatus;
 use App\Enums\StatementType;
+use App\Enums\ZohoDataCenter;
 use App\Jobs\ProcessImportedFile;
 use App\Models\Connector;
 use App\Models\ImportedFile;
@@ -80,12 +81,12 @@ class ZohoInvoiceService
             return;
         }
 
-        $accountsUrl = config('services.zoho.accounts_url');
+        $dataCenter = $this->dataCenter($connector);
 
-        $response = Http::asForm()->post("{$accountsUrl}/oauth/v2/token", [
+        $response = Http::asForm()->post("{$dataCenter->accountsUrl()}/oauth/v2/token", [
             'refresh_token' => $connector->refresh_token,
-            'client_id' => config('services.zoho.client_id'),
-            'client_secret' => config('services.zoho.client_secret'),
+            'client_id' => $connector->settings['client_id'],
+            'client_secret' => $connector->settings['client_secret'],
             'grant_type' => 'refresh_token',
         ]);
 
@@ -114,7 +115,7 @@ class ZohoInvoiceService
      */
     protected function fetchInvoices(Connector $connector): array
     {
-        $apiUrl = config('services.zoho.api_url');
+        $apiUrl = $this->dataCenter($connector)->apiUrl();
         $query = [];
 
         if ($connector->last_synced_at) {
@@ -147,7 +148,7 @@ class ZohoInvoiceService
      */
     protected function downloadInvoicePdf(Connector $connector, string $invoiceId): ?string
     {
-        $apiUrl = config('services.zoho.api_url');
+        $apiUrl = $this->dataCenter($connector)->apiUrl();
         $orgId = $connector->settings['organization_id'] ?? null;
 
         $response = Http::withToken($connector->access_token)
@@ -167,6 +168,11 @@ class ZohoInvoiceService
         Storage::disk('local')->put($filePath, $response->body());
 
         return $filePath;
+    }
+
+    private function dataCenter(Connector $connector): ZohoDataCenter
+    {
+        return ZohoDataCenter::from($connector->settings['data_center']);
     }
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -27,11 +27,7 @@ return [
     */
 
     'zoho' => [
-        'client_id' => env('ZOHO_CLIENT_ID'),
-        'client_secret' => env('ZOHO_CLIENT_SECRET'),
         'redirect_uri' => env('ZOHO_REDIRECT_URI'),
-        'accounts_url' => env('ZOHO_ACCOUNTS_URL', 'https://accounts.zoho.in'),
-        'api_url' => env('ZOHO_API_URL', 'https://www.zohoapis.in'),
     ],
 
 ];

--- a/database/factories/ConnectorFactory.php
+++ b/database/factories/ConnectorFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Models\Company;
 use App\Models\Connector;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -22,7 +23,12 @@ class ConnectorFactory extends Factory
             'access_token' => fake()->sha256(),
             'refresh_token' => fake()->sha256(),
             'token_expires_at' => now()->addHour(),
-            'settings' => ['organization_id' => fake()->numerify('##########')],
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => fake()->regexify('[0-9]{19}\.[A-Z0-9]{32}'),
+                'client_secret' => fake()->sha256(),
+                'organization_id' => fake()->numerify('##########'),
+            ],
             'last_synced_at' => null,
             'is_active' => true,
         ];
@@ -35,6 +41,12 @@ class ConnectorFactory extends Factory
             'access_token' => fake()->sha256(),
             'refresh_token' => fake()->sha256(),
             'token_expires_at' => now()->addHour(),
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => fake()->regexify('[0-9]{19}\.[A-Z0-9]{32}'),
+                'client_secret' => fake()->sha256(),
+                'organization_id' => fake()->numerify('##########'),
+            ],
             'is_active' => true,
             'last_synced_at' => now()->subHours(2),
         ]);

--- a/tests/Feature/Commands/SyncZohoInvoicesTest.php
+++ b/tests/Feature/Commands/SyncZohoInvoicesTest.php
@@ -22,11 +22,11 @@ describe('SyncZohoInvoices command', function () {
 
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company1->id,
-            'settings' => ['organization_id' => '111'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
         ]);
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company2->id,
-            'settings' => ['organization_id' => '222'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
         ]);
 
         $this->artisan('connectors:sync-zoho')
@@ -39,7 +39,7 @@ describe('SyncZohoInvoices command', function () {
 
         Connector::factory()->zohoConnected()->inactive()->create([
             'company_id' => $company->id,
-            'settings' => ['organization_id' => '111'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
         ]);
 
         $this->artisan('connectors:sync-zoho')
@@ -53,11 +53,11 @@ describe('SyncZohoInvoices command', function () {
 
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company1->id,
-            'settings' => ['organization_id' => '111'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
         ]);
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company2->id,
-            'settings' => ['organization_id' => '222'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
         ]);
 
         $this->artisan("connectors:sync-zoho --company={$company1->id}")
@@ -71,11 +71,11 @@ describe('SyncZohoInvoices command', function () {
 
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company1->id,
-            'settings' => ['organization_id' => '111'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
         ]);
         Connector::factory()->zohoConnected()->create([
             'company_id' => $company2->id,
-            'settings' => ['organization_id' => '222'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
         ]);
 
         $this->partialMock(ZohoInvoiceService::class, function ($mock) {

--- a/tests/Feature/Filament/ConnectorSettingsTest.php
+++ b/tests/Feature/Filament/ConnectorSettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Filament\Pages\Tenancy\EditCompanySettings;
 use App\Models\Connector;
 use App\Services\Connectors\ZohoInvoiceService;
@@ -23,7 +25,6 @@ describe('Connector settings in EditCompanySettings', function () {
     it('hides connect button when Zoho is connected', function () {
         Connector::factory()->zohoConnected()->create([
             'company_id' => tenant()->id,
-            'settings' => ['organization_id' => '12345'],
         ]);
 
         livewire(EditCompanySettings::class)
@@ -33,7 +34,6 @@ describe('Connector settings in EditCompanySettings', function () {
     it('shows disconnect and sync actions when Zoho is connected', function () {
         Connector::factory()->zohoConnected()->create([
             'company_id' => tenant()->id,
-            'settings' => ['organization_id' => '12345'],
         ]);
 
         livewire(EditCompanySettings::class)
@@ -48,10 +48,45 @@ describe('Connector settings in EditCompanySettings', function () {
             ->assertActionHidden('disconnectZoho');
     });
 
+    it('creates connector with credentials and data center when connecting Zoho', function () {
+        livewire(EditCompanySettings::class)
+            ->callAction('connectZoho', data: [
+                'data_center' => ZohoDataCenter::Us->value,
+                'client_id' => 'test-client-id',
+                'client_secret' => 'test-client-secret',
+            ])
+            ->assertHasNoActionErrors();
+
+        $connector = Connector::where('company_id', tenant()->id)
+            ->where('provider', ConnectorProvider::Zoho)
+            ->first();
+
+        expect($connector)->not->toBeNull()
+            ->and($connector->settings['data_center'])->toBe(ZohoDataCenter::Us->value)
+            ->and($connector->settings['client_id'])->toBe('test-client-id')
+            ->and($connector->settings['client_secret'])->toBe('test-client-secret')
+            ->and($connector->is_active)->toBeFalse();
+    });
+
+    it('validates required fields when connecting Zoho', function () {
+        livewire(EditCompanySettings::class)
+            ->callAction('connectZoho', data: [
+                'data_center' => '',
+                'client_id' => '',
+                'client_secret' => '',
+            ])
+            ->assertHasActionErrors([
+                'data_center' => 'required',
+                'client_id' => 'required',
+                'client_secret' => 'required',
+            ]);
+
+        expect(Connector::where('company_id', tenant()->id)->count())->toBe(0);
+    });
+
     it('can disconnect Zoho connector', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => tenant()->id,
-            'settings' => ['organization_id' => '12345'],
         ]);
 
         livewire(EditCompanySettings::class)
@@ -69,7 +104,6 @@ describe('Connector settings in EditCompanySettings', function () {
 
         Connector::factory()->zohoConnected()->create([
             'company_id' => tenant()->id,
-            'settings' => ['organization_id' => '12345'],
         ]);
 
         Http::fake([
@@ -84,7 +118,6 @@ describe('Connector settings in EditCompanySettings', function () {
     it('shows error notification when sync fails', function () {
         Connector::factory()->zohoConnected()->create([
             'company_id' => tenant()->id,
-            'settings' => ['organization_id' => '12345'],
         ]);
 
         $this->mock(ZohoInvoiceService::class, function ($mock) {

--- a/tests/Feature/Http/Controllers/ZohoOAuthControllerTest.php
+++ b/tests/Feature/Http/Controllers/ZohoOAuthControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\ConnectorProvider;
+use App\Enums\ZohoDataCenter;
 use App\Models\Connector;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
@@ -10,24 +11,56 @@ describe('ZohoOAuthRedirectController', function () {
         asUser();
         $company = tenant();
 
+        $connector = Connector::factory()->create([
+            'company_id' => $company->id,
+            'is_active' => false,
+        ]);
+
         $response = $this->get(route('connectors.zoho.redirect', ['company' => $company]));
 
         $response->assertRedirect();
 
         $redirectUrl = $response->headers->get('Location');
-        $accountsUrl = config('services.zoho.accounts_url');
+        $dataCenter = ZohoDataCenter::from($connector->settings['data_center']);
 
-        expect($redirectUrl)->toContain("{$accountsUrl}/oauth/v2/auth")
+        expect($redirectUrl)->toContain("{$dataCenter->accountsUrl()}/oauth/v2/auth")
             ->and($redirectUrl)->toContain('response_type=code')
+            ->and($redirectUrl)->toContain('client_id='.urlencode($connector->settings['client_id']))
             ->and($redirectUrl)->toContain('scope=ZohoInvoice.invoices.READ')
             ->and($redirectUrl)->toContain('access_type=offline')
             ->and($redirectUrl)->toContain('prompt=consent')
             ->and($redirectUrl)->toContain('state=');
     });
 
+    it('uses the data center URL from connector settings', function () {
+        asUser();
+        $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::Us->value,
+                'client_id' => 'us-client-id',
+                'client_secret' => 'us-secret',
+            ],
+            'is_active' => false,
+        ]);
+
+        $response = $this->get(route('connectors.zoho.redirect', ['company' => $company]));
+        $redirectUrl = $response->headers->get('Location');
+
+        expect($redirectUrl)->toContain('accounts.zoho.com/oauth/v2/auth')
+            ->and($redirectUrl)->not->toContain('accounts.zoho.in');
+    });
+
     it('encrypts company_id in state parameter', function () {
         asUser();
         $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'is_active' => false,
+        ]);
 
         $response = $this->get(route('connectors.zoho.redirect', ['company' => $company]));
         $redirectUrl = $response->headers->get('Location');
@@ -36,6 +69,26 @@ describe('ZohoOAuthRedirectController', function () {
         $decryptedState = Crypt::decrypt($queryParams['state']);
 
         expect($decryptedState)->toBe($company->id);
+    });
+
+    it('uses client_id from connector settings', function () {
+        asUser();
+        $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => 'tenant-specific-client-id',
+                'client_secret' => 'tenant-specific-secret',
+            ],
+            'is_active' => false,
+        ]);
+
+        $response = $this->get(route('connectors.zoho.redirect', ['company' => $company]));
+        $redirectUrl = $response->headers->get('Location');
+
+        expect($redirectUrl)->toContain('client_id=tenant-specific-client-id');
     });
 
     it('rejects unauthenticated access', function () {
@@ -55,12 +108,31 @@ describe('ZohoOAuthRedirectController', function () {
 
         $response->assertForbidden();
     });
+
+    it('returns 404 when no connector exists for the company', function () {
+        asUser();
+        $company = tenant();
+
+        $response = $this->get(route('connectors.zoho.redirect', ['company' => $company]));
+
+        $response->assertNotFound();
+    });
 });
 
 describe('ZohoOAuthCallbackController', function () {
-    it('exchanges code and creates a new Connector', function () {
+    it('exchanges code and updates existing connector with tokens', function () {
         $user = asUser();
         $company = tenant();
+
+        $connector = Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => 'my-client-id',
+                'client_secret' => 'my-client-secret',
+            ],
+            'is_active' => false,
+        ]);
 
         Http::fake([
             '*/oauth/v2/token' => Http::response([
@@ -80,18 +152,93 @@ describe('ZohoOAuthCallbackController', function () {
 
         $response->assertRedirect();
 
+        $connector->refresh();
+
+        expect($connector->access_token)->toBe('zoho-access-token-123')
+            ->and($connector->refresh_token)->toBe('zoho-refresh-token-456')
+            ->and($connector->is_active)->toBeTrue()
+            ->and($connector->settings['organization_id'])->toBe('98765')
+            ->and($connector->settings['client_id'])->toBe('my-client-id')
+            ->and($connector->settings['client_secret'])->toBe('my-client-secret')
+            ->and($connector->settings['data_center'])->toBe(ZohoDataCenter::India->value);
+    });
+
+    it('preserves all settings after token exchange', function () {
+        $user = asUser();
+        $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::Eu->value,
+                'client_id' => 'preserved-client-id',
+                'client_secret' => 'preserved-client-secret',
+                'organization_id' => 'old-org-id',
+            ],
+            'is_active' => false,
+        ]);
+
+        Http::fake([
+            '*/oauth/v2/token' => Http::response([
+                'access_token' => 'new-token',
+                'refresh_token' => 'new-refresh',
+                'expires_in' => 3600,
+                'organization_id' => 'new-org-id',
+            ]),
+        ]);
+
+        $state = Crypt::encrypt($company->id);
+
+        $this->get(route('connectors.zoho.callback', [
+            'code' => 'auth-code',
+            'state' => $state,
+        ]));
+
         $connector = Connector::where('company_id', $company->id)
             ->where('provider', ConnectorProvider::Zoho)
             ->first();
 
-        expect($connector)->not->toBeNull()
-            ->and($connector->access_token)->toBe('zoho-access-token-123')
-            ->and($connector->refresh_token)->toBe('zoho-refresh-token-456')
-            ->and($connector->is_active)->toBeTrue()
-            ->and($connector->settings['organization_id'])->toBe('98765');
+        expect($connector->settings['client_id'])->toBe('preserved-client-id')
+            ->and($connector->settings['client_secret'])->toBe('preserved-client-secret')
+            ->and($connector->settings['data_center'])->toBe(ZohoDataCenter::Eu->value)
+            ->and($connector->settings['organization_id'])->toBe('new-org-id');
     });
 
-    it('updates existing Connector on reconnection', function () {
+    it('sends token exchange to correct regional accounts URL', function () {
+        $user = asUser();
+        $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::Us->value,
+                'client_id' => 'us-client',
+                'client_secret' => 'us-secret',
+            ],
+            'is_active' => false,
+        ]);
+
+        Http::fake([
+            '*/oauth/v2/token' => Http::response([
+                'access_token' => 'test-token',
+                'refresh_token' => 'test-refresh',
+                'expires_in' => 3600,
+            ]),
+        ]);
+
+        $state = Crypt::encrypt($company->id);
+
+        $this->get(route('connectors.zoho.callback', [
+            'code' => 'auth-code',
+            'state' => $state,
+        ]));
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'accounts.zoho.com/oauth/v2/token');
+        });
+    });
+
+    it('updates existing connector on reconnection', function () {
         $user = asUser();
         $company = tenant();
 
@@ -124,7 +271,7 @@ describe('ZohoOAuthCallbackController', function () {
         expect(Connector::where('company_id', $company->id)->count())->toBe(1);
     });
 
-    it('reactivates a soft-deleted Connector on reconnection', function () {
+    it('reactivates a soft-deleted connector on reconnection', function () {
         $user = asUser();
         $company = tenant();
 
@@ -163,6 +310,16 @@ describe('ZohoOAuthCallbackController', function () {
         $user = asUser();
         $company = tenant();
 
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => 'my-client-id',
+                'client_secret' => 'my-client-secret',
+            ],
+            'is_active' => false,
+        ]);
+
         Http::fake([
             '*/oauth/v2/token' => Http::response(['error' => 'invalid_code'], 400),
         ]);
@@ -175,12 +332,19 @@ describe('ZohoOAuthCallbackController', function () {
         ]));
 
         $response->assertRedirect();
-        expect(Connector::where('company_id', $company->id)->count())->toBe(0);
+
+        $connector = Connector::where('company_id', $company->id)->first();
+        expect($connector->is_active)->toBeFalse();
     });
 
     it('redirects with error when no code is provided', function () {
         $user = asUser();
         $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'is_active' => false,
+        ]);
 
         $state = Crypt::encrypt($company->id);
 
@@ -189,7 +353,6 @@ describe('ZohoOAuthCallbackController', function () {
         ]));
 
         $response->assertRedirect();
-        expect(Connector::where('company_id', $company->id)->count())->toBe(0);
     });
 
     it('rejects unauthenticated access', function () {
@@ -202,9 +365,19 @@ describe('ZohoOAuthCallbackController', function () {
         expect($response->headers->get('Location'))->toContain('login');
     });
 
-    it('sends correct parameters in token exchange request', function () {
+    it('sends connector credentials in token exchange request', function () {
         $user = asUser();
         $company = tenant();
+
+        Connector::factory()->create([
+            'company_id' => $company->id,
+            'settings' => [
+                'data_center' => ZohoDataCenter::India->value,
+                'client_id' => 'tenant-client-id',
+                'client_secret' => 'tenant-client-secret',
+            ],
+            'is_active' => false,
+        ]);
 
         Http::fake([
             '*/oauth/v2/token' => Http::response([
@@ -224,7 +397,9 @@ describe('ZohoOAuthCallbackController', function () {
         Http::assertSent(function ($request) {
             return str_contains($request->url(), 'oauth/v2/token')
                 && str_contains($request->body(), 'grant_type=authorization_code')
-                && str_contains($request->body(), 'code=my-auth-code');
+                && str_contains($request->body(), 'code=my-auth-code')
+                && str_contains($request->body(), 'client_id=tenant-client-id')
+                && str_contains($request->body(), 'client_secret=tenant-client-secret');
         });
     });
 });

--- a/tests/Feature/Services/ZohoInvoiceServiceTest.php
+++ b/tests/Feature/Services/ZohoInvoiceServiceTest.php
@@ -26,7 +26,7 @@ describe('Token refresh', function () {
             'company_id' => $this->company->id,
             'token_expires_at' => now()->addMinutes(3),
             'access_token' => 'old-token',
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -48,7 +48,7 @@ describe('Token refresh', function () {
     it('does not refresh token when not expiring soon', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -66,7 +66,7 @@ describe('Token refresh', function () {
         $connector = Connector::factory()->create([
             'company_id' => $this->company->id,
             'token_expires_at' => now()->addMinutes(3),
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -82,7 +82,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('fetches invoices and creates ImportedFile records', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -118,7 +118,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('syncs multiple invoices', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -143,7 +143,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('stores PDF in private statements directory', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -165,7 +165,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('skips invoice when PDF download fails', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -184,7 +184,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('throws when invoice fetch fails', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -198,7 +198,7 @@ describe('Invoice fetch and ImportedFile creation', function () {
     it('handles empty invoice list', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -215,7 +215,7 @@ describe('Deduplication by zoho_invoice_id', function () {
     it('skips invoices already imported', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         ImportedFile::factory()->fromZoho('INV-001')->create([
@@ -239,7 +239,7 @@ describe('Deduplication by zoho_invoice_id', function () {
     it('does not treat different company invoices as duplicates', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         $otherCompany = Company::factory()->create();
@@ -264,7 +264,7 @@ describe('Job dispatch', function () {
     it('dispatches ProcessImportedFile for each new invoice', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         Http::fake([
@@ -286,7 +286,7 @@ describe('Job dispatch', function () {
     it('does not dispatch job for duplicate invoices', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
         ]);
 
         ImportedFile::factory()->fromZoho('INV-001')->create([
@@ -311,7 +311,7 @@ describe('last_synced_at update', function () {
     it('updates last_synced_at on connector after sync', function () {
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
             'last_synced_at' => null,
         ]);
 
@@ -331,7 +331,7 @@ describe('last_synced_at update', function () {
         $lastSynced = now()->subHours(2);
         $connector = Connector::factory()->zohoConnected()->create([
             'company_id' => $this->company->id,
-            'settings' => ['organization_id' => '12345678'],
+            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
             'last_synced_at' => $lastSynced,
         ]);
 

--- a/tests/Unit/Enums/ZohoDataCenterTest.php
+++ b/tests/Unit/Enums/ZohoDataCenterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Enums\ZohoDataCenter;
+
+describe('ZohoDataCenter enum', function () {
+    it('returns correct accounts URL for each data center', function (ZohoDataCenter $dataCenter, string $expectedUrl) {
+        expect($dataCenter->accountsUrl())->toBe($expectedUrl);
+    })->with([
+        'India' => [ZohoDataCenter::India, 'https://accounts.zoho.in'],
+        'US' => [ZohoDataCenter::Us, 'https://accounts.zoho.com'],
+        'EU' => [ZohoDataCenter::Eu, 'https://accounts.zoho.eu'],
+        'Australia' => [ZohoDataCenter::Australia, 'https://accounts.zoho.com.au'],
+        'Japan' => [ZohoDataCenter::Japan, 'https://accounts.zoho.jp'],
+    ]);
+
+    it('returns correct API URL for each data center', function (ZohoDataCenter $dataCenter, string $expectedUrl) {
+        expect($dataCenter->apiUrl())->toBe($expectedUrl);
+    })->with([
+        'India' => [ZohoDataCenter::India, 'https://www.zohoapis.in'],
+        'US' => [ZohoDataCenter::Us, 'https://www.zohoapis.com'],
+        'EU' => [ZohoDataCenter::Eu, 'https://www.zohoapis.eu'],
+        'Australia' => [ZohoDataCenter::Australia, 'https://www.zohoapis.com.au'],
+        'Japan' => [ZohoDataCenter::Japan, 'https://www.zohoapis.jp'],
+    ]);
+
+    it('returns human-readable labels', function (ZohoDataCenter $dataCenter) {
+        expect($dataCenter->getLabel())->toBeString()->not->toBeEmpty();
+    })->with(ZohoDataCenter::cases());
+
+    it('can be created from string value', function () {
+        expect(ZohoDataCenter::from('in'))->toBe(ZohoDataCenter::India)
+            ->and(ZohoDataCenter::from('us'))->toBe(ZohoDataCenter::Us);
+    });
+});


### PR DESCRIPTION
## Summary

- Move Zoho `client_id`, `client_secret`, and data center from shared env/config to per-tenant encrypted `connectors.settings` JSONB column
- Add `ZohoDataCenter` enum (India, US, EU, Australia, Japan) that derives `accounts_url` and `api_url` — no free-text URL fields
- Connect Zoho action now opens a modal form (data center dropdown + credentials) before initiating OAuth
- OAuth controllers and `ZohoInvoiceService` read all Zoho config from connector record instead of `config()`
- Remove `ZOHO_CLIENT_ID`, `ZOHO_CLIENT_SECRET`, `ZOHO_ACCOUNTS_URL`, `ZOHO_API_URL` from config and `.env.example`

Closes #76

## Test plan

- [x] 16 unit tests for `ZohoDataCenter` enum (URL derivation for all 5 regions)
- [x] 16 OAuth controller tests (regional URLs, credential preservation, soft-delete reactivation)
- [x] 9 Filament connector settings tests (modal form, validation, data center field)
- [x] 20 `ZohoInvoiceService` tests (token refresh, invoice sync, deduplication)
- [x] PHPStan level 6 — 0 errors
- [x] Full suite: 633 tests, 1537 assertions — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)