### PR TITLE
perf(db): add composite indexes for tenant-scoped queries

### DIFF
--- a/database/migrations/2026_03_02_190815_add_composite_indexes_for_tenant_scoped_queries.php
+++ b/database/migrations/2026_03_02_190815_add_composite_indexes_for_tenant_scoped_queries.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            // Add composite indexes matching tenant-scoped query patterns
+            $table->index(['company_id', 'date'], 'transactions_company_date_idx');
+            $table->index(['company_id', 'mapping_type'], 'transactions_company_mapping_idx');
+            $table->index(['company_id', 'reconciliation_status'], 'transactions_company_recon_idx');
+            $table->index(['company_id', 'account_head_id'], 'transactions_company_head_idx');
+
+            // Drop single-column indexes now superseded by composites above
+            $table->dropIndex('transactions_date_index');
+            $table->dropIndex('transactions_mapping_type_index');
+            $table->dropIndex('transactions_reconciliation_status_index');
+            $table->dropIndex('transactions_account_head_id_index');
+        });
+
+        Schema::table('imported_files', function (Blueprint $table) {
+            // Tenant + status for pending/failed/needs_password file lists
+            $table->index(['company_id', 'status'], 'imported_files_company_status_idx');
+
+            // Drop single-column status index now superseded
+            $table->dropIndex('imported_files_status_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->index('status');
+            $table->dropIndex('imported_files_company_status_idx');
+        });
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->index('date');
+            $table->index('mapping_type');
+            $table->index('reconciliation_status');
+            $table->index('account_head_id');
+
+            $table->dropIndex('transactions_company_date_idx');
+            $table->dropIndex('transactions_company_mapping_idx');
+            $table->dropIndex('transactions_company_recon_idx');
+            $table->dropIndex('transactions_company_head_idx');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Add composite indexes on `transactions` and `imported_files` with `company_id` as leading column, matching actual Filament tenant-scoped query patterns
- Drop 5 redundant single-column indexes now superseded by the composites
- Keep `transactions_company_id_index` (standalone tenant queries) and `transactions_imported_file_id_index` (FK cascade)

Closes #91

## Changes

### Composite indexes added
| Index | Columns | Use case |
|-------|---------|----------|
| `transactions_company_date_idx` | `(company_id, date)` | Dashboard, reports, export, date filters |
| `transactions_company_mapping_idx` | `(company_id, mapping_type)` | Unmapped list, stats overview, bulk assign |
| `transactions_company_recon_idx` | `(company_id, reconciliation_status)` | Reconciliation page |
| `transactions_company_head_idx` | `(company_id, account_head_id)` | Reports by head, P&L views |
| `imported_files_company_status_idx` | `(company_id, status)` | Pending/failed/needs_password file lists |

### Single-column indexes dropped
- `transactions_date_index`, `transactions_mapping_type_index`, `transactions_reconciliation_status_index`, `transactions_account_head_id_index`, `imported_files_status_index`

## Test plan
- [x] Migration up creates all 5 composite indexes
- [x] Migration up drops all 5 redundant single-column indexes
- [x] Migration down reverses cleanly (rollback + re-apply verified)
- [x] All 733 existing tests pass (no behavioral changes)
- [x] PHPStan clean, Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)