### PR TITLE
chore(release): set up trunk-based release process with semantic versioning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@ Closes #
 ## Checklist
 - [ ] Branch follows naming: `<type>/<issue#>-<description>`
 - [ ] Commits follow format: `<type>(scope): message (#issue)`
+- [ ] PR has a `type:` label (feature, bug, refactor, docs, chore) for release notes
 - [ ] Tests added/updated for changes
 - [ ] `vendor/bin/pint --dirty` run
 - [ ] All new models have factories

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  categories:
+    - title: "New Features"
+      labels: ["type: feature"]
+    - title: "Bug Fixes"
+      labels: ["type: bug"]
+    - title: "Improvements"
+      labels: ["type: refactor"]
+    - title: "Documentation"
+      labels: ["type: docs"]
+    - title: "Maintenance"
+      labels: ["type: chore", "type: security", "type: test"]
+    - title: "Other Changes"
+      labels: ["*"]
+  exclude:
+    labels: ["duplicate", "invalid", "wontfix"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deployment placeholder
+        run: |
+          echo "========================================="
+          echo "  Deploying ${{ github.ref_name }}"
+          echo "========================================="
+          echo ""
+          echo "Configure deployment target here."
+          echo "This workflow triggers on tag creation."
+          echo ""
+          echo "Tag:    ${{ github.ref_name }}"
+          echo "SHA:    ${{ github.sha }}"
+          echo "Actor:  ${{ github.actor }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,17 @@ feature/* → master (squash merge) → CD → staging/QA → tag vX.Y.Z → pro
 
 **Merge strategy:** Always squash merge into `master`.
 **CI checks required before merge:** Syntax, Pint, PHPStan, Security, Tests
+**PR labels:** Every PR must have a `type:` label (`type: feature`, `type: bug`, `type: refactor`, `type: docs`, `type: chore`) for release notes categorization.
+
+### Releases
+
+Semantic versioning (`vX.Y.Z`). Releases are cut by tagging `master`:
+
+```bash
+gh release create vX.Y.Z --generate-notes --target master --title "vX.Y.Z"
+```
+
+See [Release Process](docs/guides/release-process.md) for full details (pre-release checklist, deployment, rollback).
 
 ## Common Mistakes (AVOID)
 
@@ -211,7 +222,7 @@ The agents use the `model()` method (laravel/ai convention) to resolve the model
 | Folder | Purpose | When to Read |
 |--------|---------|--------------|
 | `docs/architecture/` | Architecture decisions (pipeline, agents, data model, Tally XML, data privacy) | Before implementing #40–#43, #15, #54–#55 |
-| `docs/guides/` | How-to guides (AI workflow, testing) | For step-by-step workflows |
+| `docs/guides/` | How-to guides (AI workflow, testing, releases) | For step-by-step workflows |
 | `docs/PLAN.md` | Project setup plan and implementation order | For project context |
 
 ### AI-Assisted Development Workflow

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -1,0 +1,181 @@
+# Release Process
+
+**Last Updated:** 2026-03-02
+**Audience:** Developers, DevOps
+
+---
+
+## Overview
+
+Virtual CFO uses trunk-based development with semantic versioning. All work merges into `master` via squash merge. Releases are cut by tagging `master` with a version number.
+
+```
+feature/* --> master (squash merge, CI) --> staging (auto) --> tag vX.Y.Z --> production
+```
+
+---
+
+## Semantic Versioning
+
+| Bump | When | Example |
+|------|------|---------|
+| **Patch** `vX.Y.Z+1` | Bug fixes, minor tweaks | Fix PDF parsing edge case |
+| **Minor** `vX.Y+1.0` | New features, non-breaking changes | Add reports page, notifications |
+| **Major** `vX+1.0.0` | Breaking changes | Major schema changes, API breaks |
+
+---
+
+## Cutting a Release
+
+### Pre-release Checklist
+
+- [ ] All PRs for this release are merged into `master`
+- [ ] CI is green on `master` (syntax, pint, phpstan, security, tests, type coverage)
+- [ ] No open `priority: critical` or `priority: high` issues targeting this release
+- [ ] Database migrations are reviewed and reversible
+
+### Create the Release
+
+```bash
+# 1. Ensure master is up to date
+git checkout master && git pull
+
+# 2. Preview release notes (optional — creates a draft)
+gh release create vX.Y.Z --generate-notes --draft --target master
+
+# 3. Create the release (for real)
+gh release create vX.Y.Z --generate-notes --target master --title "vX.Y.Z"
+```
+
+GitHub's `--generate-notes` auto-generates release notes from merged PRs since the last tag, grouped by label categories defined in `.github/release.yml`.
+
+### Label Categories
+
+Release notes are grouped by PR labels:
+
+| Label | Section in Release Notes |
+|-------|--------------------------|
+| `type: feature` | New Features |
+| `type: bug` | Bug Fixes |
+| `type: refactor` | Improvements |
+| `type: docs` | Documentation |
+| `type: chore`, `type: security`, `type: test` | Maintenance |
+
+**Every PR should have a `type:` label** for proper release notes categorization.
+
+---
+
+## Deployment
+
+### Deploy Workflow
+
+The `.github/workflows/deploy.yml` workflow triggers automatically when a tag matching `v*` is pushed. Currently a placeholder — configure the deployment target when the hosting platform is decided.
+
+### Post-deployment Steps
+
+After deployment completes, run these commands on the production server:
+
+```bash
+# 1. Run database migrations
+php artisan migrate --force
+
+# 2. Cache configuration, routes, and views
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+
+# 3. Restart queue workers (picks up new code)
+php artisan queue:restart
+```
+
+### Smoke Test
+
+After deployment, verify:
+
+1. Login works
+2. Upload a file — PDF parsing starts
+3. Dashboard loads with correct data
+4. Queue worker is processing jobs
+
+---
+
+## Hotfix Process
+
+For urgent production fixes:
+
+```bash
+# 1. Branch from master
+git checkout master && git pull
+git checkout -b hotfix/fix-critical-bug
+
+# 2. Fix, test, push, create PR
+# (same as normal development but prioritized)
+
+# 3. After squash merge to master, tag immediately
+gh release create vX.Y.Z+1 --generate-notes --target master --title "vX.Y.Z+1"
+```
+
+No long-lived release branches. Hotfixes follow the same trunk-based flow.
+
+---
+
+## Rollback
+
+If a release introduces issues:
+
+```bash
+# Option 1: Re-deploy the previous tag
+# (via CI/CD — trigger deploy workflow with previous tag)
+
+# Option 2: Revert the problematic commit on master, then tag
+git revert <commit-sha>
+git push origin master
+gh release create vX.Y.Z+1 --generate-notes --target master
+```
+
+For database rollbacks:
+
+```bash
+# Rollback the last migration batch
+php artisan migrate:rollback --step=1 --force
+```
+
+---
+
+## Quick Reference
+
+```bash
+# See what's changed since last release
+gh api repos/:owner/:repo/compare/v1.0.0...master --jq '.commits | length'
+
+# Preview release notes before creating
+gh release create vX.Y.Z --generate-notes --draft --target master
+
+# Create release
+gh release create vX.Y.Z --generate-notes --target master --title "vX.Y.Z"
+
+# List all releases
+gh release list
+
+# View a specific release
+gh release view vX.Y.Z
+```
+
+---
+
+## Related Resources
+
+| Resource | Description |
+|----------|-------------|
+| [CLAUDE.md](../../CLAUDE.md) | Branching strategy and conventions |
+| [AI-Assisted Development Workflow](ai-assisted-development-workflow.md) | Full development process |
+| `.github/release.yml` | Release notes label configuration |
+| `.github/workflows/deploy.yml` | Deployment workflow (placeholder) |
+
+---
+
+## Changelog
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-03-02 | Team | Initial release process documentation |


### PR DESCRIPTION
## Summary
- Set up trunk-based release process with semantic versioning tooling
- Added release notes configuration, placeholder deploy workflow, and full release process documentation
- Updated CLAUDE.md and PR template to support the release workflow

Closes #90

## Type of Change
- [x] `chore` - Maintenance, dependencies

## Files Created/Modified
| Action | File | Purpose |
|--------|------|---------|
| CREATE | `.github/release.yml` | Release notes categorization using existing `type:` labels |
| CREATE | `.github/workflows/deploy.yml` | Placeholder deployment workflow triggered on `v*` tags |
| CREATE | `docs/guides/release-process.md` | Full release process (pre-release, tagging, deploy, hotfix, rollback) |
| MODIFY | `CLAUDE.md` | Added Releases subsection, PR label requirement, updated docs table |
| MODIFY | `.github/pull_request_template.md` | Added `type:` label checklist item |

## Checklist
- [x] Branch follows naming: `<type>/<issue#>-<description>`
- [x] Commits follow format: `<type>(scope): message (#issue)`
- [x] PR has a `type:` label (feature, bug, refactor, docs, chore) for release notes
- [ ] Tests added/updated for changes — N/A (config/docs only)
- [ ] `vendor/bin/pint --dirty` run — N/A (no PHP changes)
- [ ] All new models have factories — N/A
- [ ] Migrations are reversible — N/A
- [ ] Encrypted fields handled properly — N/A

## Post-merge
After merging this PR, create the first release tag on `master`:
```bash
gh release create v1.0.0 --generate-notes --target master --title "v1.0.0 — Initial Release"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)