### PR TITLE
fix(filament): reactive account selector & remove redundant bank_name

### DIFF
--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -13,6 +13,7 @@ use Filament\Actions;
 use Filament\Forms;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Filters\TrashedFilter;
@@ -54,18 +55,24 @@ class ImportedFileResource extends Resource
                             ->label('Statement Type')
                             ->options(StatementType::class)
                             ->default(StatementType::Bank)
-                            ->required(),
+                            ->required()
+                            ->live(),
 
                         Forms\Components\Select::make('bank_account_id')
-                            ->label('Bank Account')
+                            ->label('Account')
                             ->relationship('bankAccount', 'name')
                             ->searchable()
                             ->preload()
-                            ->placeholder('Auto-detect from statement'),
+                            ->placeholder('Auto-detect from statement')
+                            ->visible(fn (Get $get): bool => $get('statement_type') === StatementType::Bank),
 
-                        Forms\Components\TextInput::make('bank_name')
-                            ->label('Bank Name (optional, auto-detected)')
-                            ->maxLength(255),
+                        Forms\Components\Select::make('credit_card_id')
+                            ->label('Credit Card')
+                            ->relationship('creditCard', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->placeholder('Auto-detect from statement')
+                            ->visible(fn (Get $get): bool => $get('statement_type') === StatementType::CreditCard),
 
                         Forms\Components\TextInput::make('pdf_password')
                             ->label('PDF Password (optional)')
@@ -87,6 +94,7 @@ class ImportedFileResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with(['creditCard']))
             ->columns([
                 Tables\Columns\TextColumn::make('original_filename')
                     ->label('File')
@@ -94,8 +102,8 @@ class ImportedFileResource extends Resource
                     ->limit(40),
 
                 Tables\Columns\TextColumn::make('bankAccount.name')
-                    ->label('Bank Account')
-                    ->placeholder(fn (ImportedFile $record) => $record->bank_name ?? 'Detecting...'),
+                    ->label('Account')
+                    ->placeholder(fn (ImportedFile $record) => $record->creditCard?->name ?? $record->bank_name ?? 'Detecting...'),
 
                 Tables\Columns\TextColumn::make('bank_name')
                     ->label('Detected Bank')

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -35,8 +35,14 @@ class ViewImportedFile extends ViewRecord
                         Infolists\Components\TextEntry::make('original_filename')
                             ->label('Filename'),
                         Infolists\Components\TextEntry::make('bank_name')
-                            ->label('Bank')
+                            ->label('Detected Bank')
                             ->placeholder('Not detected'),
+                        Infolists\Components\TextEntry::make('bankAccount.name')
+                            ->label('Bank Account')
+                            ->visible(fn (ImportedFile $record): bool => $record->bank_account_id !== null),
+                        Infolists\Components\TextEntry::make('creditCard.name')
+                            ->label('Credit Card')
+                            ->visible(fn (ImportedFile $record): bool => $record->credit_card_id !== null),
                         Infolists\Components\TextEntry::make('statement_type')
                             ->label('Type')
                             ->badge(),

--- a/tests/Feature/Filament/CreateImportedFileDuplicateDetectionTest.php
+++ b/tests/Feature/Filament/CreateImportedFileDuplicateDetectionTest.php
@@ -24,7 +24,6 @@ describe('CreateImportedFile duplicate detection', function () {
             ->fillForm([
                 'file_path' => $file,
                 'statement_type' => StatementType::Bank->value,
-                'bank_name' => 'HDFC',
             ])
             ->call('create')
             ->assertHasNoFormErrors();

--- a/tests/Feature/Filament/ImportedFileResourceTest.php
+++ b/tests/Feature/Filament/ImportedFileResourceTest.php
@@ -3,12 +3,90 @@
 use App\Enums\ImportStatus;
 use App\Enums\StatementType;
 use App\Filament\Resources\ImportedFileResource;
+use App\Filament\Resources\ImportedFileResource\Pages\CreateImportedFile;
 use App\Filament\Resources\ImportedFileResource\Pages\ListImportedFiles;
+use App\Filament\Resources\ImportedFileResource\Pages\ViewImportedFile;
 use App\Jobs\ProcessImportedFile;
+use App\Models\BankAccount;
+use App\Models\CreditCard;
 use App\Models\ImportedFile;
 use Illuminate\Support\Facades\Queue;
 
 use function Pest\Livewire\livewire;
+
+describe('ImportedFileResource reactive form', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('shows bank_account_id when statement_type is Bank', function () {
+        livewire(CreateImportedFile::class)
+            ->set('data.statement_type', StatementType::Bank->value)
+            ->assertFormFieldVisible('bank_account_id')
+            ->assertFormFieldHidden('credit_card_id');
+    });
+
+    it('shows credit_card_id when statement_type is CreditCard', function () {
+        livewire(CreateImportedFile::class)
+            ->set('data.statement_type', StatementType::CreditCard->value)
+            ->assertFormFieldVisible('credit_card_id')
+            ->assertFormFieldHidden('bank_account_id');
+    });
+
+    it('hides both account fields when statement_type is Invoice', function () {
+        livewire(CreateImportedFile::class)
+            ->set('data.statement_type', StatementType::Invoice->value)
+            ->assertFormFieldHidden('bank_account_id')
+            ->assertFormFieldHidden('credit_card_id');
+    });
+
+    it('does not have bank_name field on create form', function () {
+        $component = livewire(CreateImportedFile::class);
+
+        $fields = $component->instance()
+            ->getSchema('form')
+            ->getFlatFields(withHidden: true);
+
+        expect($fields)->not->toHaveKey('bank_name');
+    });
+});
+
+describe('ImportedFileResource view page', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('shows linked bank account name', function () {
+        $account = BankAccount::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'HDFC Current Account',
+        ]);
+        $file = ImportedFile::factory()->completed()->create([
+            'bank_account_id' => $account->id,
+        ]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertSchemaStateSet([
+                'bankAccount.name' => 'HDFC Current Account',
+            ]);
+    });
+
+    it('shows linked credit card name', function () {
+        $card = CreditCard::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'ICICI Amazon Pay',
+        ]);
+        $file = ImportedFile::factory()->completed()->create([
+            'credit_card_id' => $card->id,
+            'statement_type' => StatementType::CreditCard,
+        ]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertSchemaStateSet([
+                'creditCard.name' => 'ICICI Amazon Pay',
+            ]);
+    });
+});
 
 describe('ImportedFileResource', function () {
     beforeEach(function () {


### PR DESCRIPTION
## Summary

- **Reactive form**: `statement_type` select is now `live()` — shows bank account selector for Bank, credit card selector for CreditCard, hides both for Invoice
- **Removed `bank_name` text input** from the upload form (was misleading — always overwritten by AI parsing)
- **View page**: shows linked bank account or credit card name when available
- **N+1 fix**: eager-loads `creditCard` relationship on table query for the fallback placeholder

Closes #85

## Test plan

- [x] `bank_account_id` visible when statement_type is Bank
- [x] `credit_card_id` visible when statement_type is CreditCard
- [x] Both account fields hidden when statement_type is Invoice
- [x] `bank_name` field removed from create form
- [x] View page shows linked bank account name
- [x] View page shows linked credit card name
- [x] All 26 existing tests still pass
- [x] PHPStan clean (0 errors)
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)