### PR TITLE
feat(tenancy): pending invitations table with resend/revoke actions

### DIFF
--- a/app/Filament/Pages/TeamMembers.php
+++ b/app/Filament/Pages/TeamMembers.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Enums\UserRole;
+use App\Filament\Widgets\PendingInvitations;
 use App\Mail\InvitationMail;
 use App\Models\Company;
 use App\Models\Invitation;
@@ -37,6 +38,14 @@ class TeamMembers extends Page implements HasTable
     protected static ?int $navigationSort = 10;
 
     protected string $view = 'filament.pages.team-members';
+
+    /** @return array<class-string> */
+    protected function getFooterWidgets(): array
+    {
+        return [
+            PendingInvitations::class,
+        ];
+    }
 
     public static function canAccess(): bool
     {
@@ -98,7 +107,7 @@ class TeamMembers extends Page implements HasTable
                             'expires_at' => now()->addDays(7),
                         ]);
 
-                        Mail::to($data['email'])->send(new InvitationMail($existing->fresh()));
+                        Mail::to($data['email'])->queue(new InvitationMail($existing->fresh()));
 
                         RateLimiter::hit($rateLimitKey, 3600);
 
@@ -120,7 +129,7 @@ class TeamMembers extends Page implements HasTable
                         'expires_at' => now()->addDays(7),
                     ]);
 
-                    Mail::to($data['email'])->send(new InvitationMail($invitation));
+                    Mail::to($data['email'])->queue(new InvitationMail($invitation));
 
                     RateLimiter::hit($rateLimitKey, 3600);
 

--- a/app/Filament/Widgets/PendingInvitations.php
+++ b/app/Filament/Widgets/PendingInvitations.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Mail\InvitationMail;
+use App\Models\Invitation;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Facades\Mail;
+
+class PendingInvitations extends BaseWidget
+{
+    protected static bool $isDiscovered = false;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Pending Invitations';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                Invitation::query()
+                    ->with('inviter')
+                    ->whereNull('accepted_at')
+                    ->where('company_id', Filament::getTenant()->getKey())
+                    ->latest()
+                    ->limit(25)
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('email')
+                    ->label('Email')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('role')
+                    ->badge(),
+
+                Tables\Columns\TextColumn::make('inviter.name')
+                    ->label('Invited by'),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Sent')
+                    ->since(),
+
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->label('Expires')
+                    ->since()
+                    ->color(fn (Invitation $record): string => $record->isExpired() ? 'danger' : 'gray'),
+
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->state(fn (Invitation $record): string => $record->isExpired() ? 'Expired' : 'Pending')
+                    ->color(fn (Invitation $record): string => $record->isExpired() ? 'danger' : 'warning'),
+            ])
+            ->actions([
+                Action::make('resend')
+                    ->label('Resend')
+                    ->icon('heroicon-o-paper-airplane')
+                    ->action(function (Invitation $record): void {
+                        $record->update(['expires_at' => now()->addDays(7)]);
+
+                        Mail::to($record->email)->queue(new InvitationMail($record));
+
+                        Notification::make()
+                            ->title('Invitation resent')
+                            ->body("Invitation resent to {$record->email}.")
+                            ->success()
+                            ->send();
+                    }),
+
+                Action::make('revoke')
+                    ->label('Revoke')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->hidden(fn (Invitation $record): bool => $record->isExpired())
+                    ->action(function (Invitation $record): void {
+                        $email = $record->email;
+                        $record->delete();
+
+                        Notification::make()
+                            ->title('Invitation revoked')
+                            ->body("Invitation to {$email} has been revoked.")
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Http/Controllers/AcceptInvitationController.php
+++ b/app/Http/Controllers/AcceptInvitationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\AcceptInvitationRequest;
 use App\Models\Invitation;
 use App\Models\User;
+use Filament\Notifications\Notification;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
@@ -49,7 +50,7 @@ class AcceptInvitationController
 
     public function storeNewUser(AcceptInvitationRequest $request, string $token): RedirectResponse
     {
-        $invitation = Invitation::with('company')->where('token', $token)->firstOrFail();
+        $invitation = Invitation::with(['company', 'inviter'])->where('token', $token)->firstOrFail();
 
         if ($invitation->isAccepted() || $invitation->isExpired()) {
             return redirect('/admin/login');
@@ -65,12 +66,14 @@ class AcceptInvitationController
         $invitation->company->users()->attach($user, ['role' => $invitation->role->value]);
         $invitation->markAccepted();
 
+        $this->notifyInviter($invitation);
+
         return redirect('/admin/login')->with('status', 'Account created. Please sign in.');
     }
 
     public function storeExistingUser(string $token): RedirectResponse
     {
-        $invitation = Invitation::with('company')->where('token', $token)->firstOrFail();
+        $invitation = Invitation::with(['company', 'inviter'])->where('token', $token)->firstOrFail();
 
         if ($invitation->isAccepted() || $invitation->isExpired()) {
             return redirect('/admin/login');
@@ -84,6 +87,23 @@ class AcceptInvitationController
 
         $invitation->markAccepted();
 
+        $this->notifyInviter($invitation);
+
         return redirect('/admin/login')->with('status', 'You have been added to the team. Please sign in.');
+    }
+
+    private function notifyInviter(Invitation $invitation): void
+    {
+        if (! $invitation->inviter) {
+            return;
+        }
+
+        $invitation->loadMissing('company');
+
+        Notification::make()
+            ->title("{$invitation->email} accepted your invitation")
+            ->body("They joined {$invitation->company->name} as {$invitation->role->getLabel()}.")
+            ->success()
+            ->sendToDatabase($invitation->inviter);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -36,6 +36,7 @@ class AdminPanelProvider extends PanelProvider
                 'primary' => Color::Indigo,
             ])
             ->brandName('Virtual CFO')
+            ->databaseNotifications()
             ->tenant(Company::class)
             ->tenantRegistration(RegisterCompany::class)
             ->tenantProfile(EditCompanySettings::class)

--- a/database/migrations/2026_03_02_201530_create_notifications_table.php
+++ b/database/migrations/2026_03_02_201530_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->text('type');
+            $table->morphs('notifiable');
+            $table->json('data');
+            $table->timestampTz('read_at')->nullable();
+            $table->timestampsTz();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/tests/Feature/Filament/PendingInvitationsWidgetTest.php
+++ b/tests/Feature/Filament/PendingInvitationsWidgetTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Filament\Widgets\PendingInvitations;
+use App\Mail\InvitationMail;
+use App\Models\Company;
+use App\Models\Invitation;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Support\Facades\Mail;
+
+use function Pest\Livewire\livewire;
+
+describe('Pending Invitations Widget', function () {
+    describe('Table display', function () {
+        it('shows pending invitations for current tenant', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $pending = Invitation::factory()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertCanSeeTableRecords([$pending]);
+        });
+
+        it('shows expired invitations for current tenant', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $expired = Invitation::factory()->expired()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertCanSeeTableRecords([$expired]);
+        });
+
+        it('excludes accepted invitations', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $accepted = Invitation::factory()->accepted()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertCanNotSeeTableRecords([$accepted]);
+        });
+
+        it('excludes invitations from other tenants', function () {
+            asUser(role: UserRole::Admin);
+
+            $otherCompany = Company::factory()->create();
+            $otherInvitation = Invitation::factory()->create([
+                'company_id' => $otherCompany->id,
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertCanNotSeeTableRecords([$otherInvitation]);
+        });
+
+        it('displays email, role, inviter, sent, and expires columns', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $invitation = Invitation::factory()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+                'email' => 'test@example.com',
+                'role' => UserRole::Accountant,
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertCanSeeTableRecords([$invitation])
+                ->assertTableColumnExists('email')
+                ->assertTableColumnExists('role')
+                ->assertTableColumnExists('inviter.name')
+                ->assertTableColumnExists('created_at')
+                ->assertTableColumnExists('expires_at');
+        });
+    });
+
+    describe('Resend action', function () {
+        it('resets expiry and re-sends invitation email', function () {
+            Mail::fake();
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $invitation = Invitation::factory()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+                'expires_at' => now()->addDay(),
+            ]);
+
+            $originalExpiry = $invitation->expires_at;
+
+            livewire(PendingInvitations::class)
+                ->callAction(TestAction::make('resend')->table($invitation))
+                ->assertNotified('Invitation resent');
+
+            expect($invitation->fresh()->expires_at->gt($originalExpiry))->toBeTrue();
+
+            Mail::assertQueued(InvitationMail::class, fn (InvitationMail $mail) => $mail->hasTo($invitation->email));
+        });
+
+        it('can resend expired invitations', function () {
+            Mail::fake();
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $expired = Invitation::factory()->expired()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->callAction(TestAction::make('resend')->table($expired))
+                ->assertNotified('Invitation resent');
+
+            expect($expired->fresh()->expires_at->isFuture())->toBeTrue();
+
+            Mail::assertQueued(InvitationMail::class);
+        });
+    });
+
+    describe('Revoke action', function () {
+        it('deletes pending invitation after confirmation', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $invitation = Invitation::factory()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->callAction(TestAction::make('revoke')->table($invitation))
+                ->assertNotified('Invitation revoked');
+
+            expect(Invitation::find($invitation->id))->toBeNull();
+        });
+
+        it('is hidden for expired invitations', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $expired = Invitation::factory()->expired()->create([
+                'company_id' => $company->id,
+                'invited_by' => auth()->id(),
+            ]);
+
+            livewire(PendingInvitations::class)
+                ->assertActionHidden(TestAction::make('revoke')->table($expired));
+        });
+    });
+});

--- a/tests/Feature/InvitationFlowTest.php
+++ b/tests/Feature/InvitationFlowTest.php
@@ -5,6 +5,7 @@ use App\Filament\Pages\TeamMembers;
 use App\Mail\InvitationMail;
 use App\Models\Invitation;
 use App\Models\User;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\RateLimiter;
 
@@ -168,6 +169,44 @@ describe('Invitation Flow', function () {
 
             expect($invitation->fresh()->isAccepted())->toBeTrue();
             expect($invitation->company->users()->where('user_id', $user->id)->exists())->toBeTrue();
+        });
+    });
+
+    describe('Acceptance notifications', function () {
+        it('notifies inviter when new user accepts', function () {
+            $inviter = User::factory()->admin()->create();
+            $invitation = Invitation::factory()->create([
+                'invited_by' => $inviter->id,
+                'role' => UserRole::Viewer,
+            ]);
+
+            $this->post(route('invitations.accept.new', $invitation->token), [
+                'name' => 'New User',
+                'password' => 'password123',
+                'password_confirmation' => 'password123',
+            ]);
+
+            expect(DatabaseNotification::where('notifiable_id', $inviter->id)->count())->toBe(1);
+
+            $notification = DatabaseNotification::where('notifiable_id', $inviter->id)->first();
+            expect($notification->data['title'])->toContain('accepted');
+        });
+
+        it('notifies inviter when existing user accepts', function () {
+            $inviter = User::factory()->admin()->create();
+            $user = User::factory()->create(['email' => 'existing@example.com']);
+            $invitation = Invitation::factory()->create([
+                'email' => 'existing@example.com',
+                'invited_by' => $inviter->id,
+                'role' => UserRole::Accountant,
+            ]);
+
+            $this->post(route('invitations.accept.existing', $invitation->token));
+
+            expect(DatabaseNotification::where('notifiable_id', $inviter->id)->count())->toBe(1);
+
+            $notification = DatabaseNotification::where('notifiable_id', $inviter->id)->first();
+            expect($notification->data['title'])->toContain('accepted');
         });
     });
 


### PR DESCRIPTION
## Summary

- **PendingInvitations TableWidget** — footer widget on Team Members page showing all unaccepted invitations (pending + expired) with email, role badge, inviter, sent/expires timestamps, and status badge
- **Resend action** — resets expiry to +7 days and re-queues the invitation email (works for both pending and expired invitations)
- **Revoke action** — deletes the invitation record with confirmation dialog (hidden for expired invitations)
- **Acceptance notifications** — when a user accepts an invitation, the inviter receives a Filament database notification
- **Database notifications infrastructure** — notifications table migration (PostgreSQL-compliant) and `databaseNotifications()` enabled on the admin panel
- **Mail dispatch fix** — changed `Mail::send()` to `Mail::queue()` in TeamMembers to honor `InvitationMail`'s `ShouldQueue` contract

Closes #84

## Test plan

- [ ] `php artisan test --filter=PendingInvitationsWidget` — 9 tests (table display, scoping, resend, revoke)
- [ ] `php artisan test --filter=InvitationFlow` — 17 tests (sending, accepting, notifications, edge cases)
- [ ] `vendor/bin/phpstan analyse` — clean
- [ ] Full suite: 744 tests, 1846 assertions passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)