### PR TITLE
feat(export): CSV/Excel export for mapped transactions

### DIFF
--- a/app/Exports/TransactionCsvExport.php
+++ b/app/Exports/TransactionCsvExport.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\AccountHead;
+use App\Models\Company;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+/**
+ * @implements WithMapping<Transaction>
+ */
+class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
+{
+    public function __construct(
+        public ?string $from = null,
+        public ?string $until = null,
+    ) {}
+
+    /**
+     * @return Builder<Transaction>
+     */
+    public function query(): Builder
+    {
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+
+        $query = Transaction::query()
+            ->where('company_id', $tenant->id)
+            ->whereNotNull('account_head_id')
+            ->with(['accountHead', 'importedFile'])
+            ->orderBy('date');
+
+        if ($this->from) {
+            $query->whereDate('date', '>=', $this->from);
+        }
+
+        if ($this->until) {
+            $query->whereDate('date', '<=', $this->until);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function headings(): array
+    {
+        return [
+            'Date',
+            'Description',
+            'Reference',
+            'Debit',
+            'Credit',
+            'Balance',
+            'Account Head',
+            'Account Head Group',
+            'Bank/Source',
+            'Mapping Type',
+        ];
+    }
+
+    /**
+     * @param  Transaction  $row
+     * @return array<int, string|float|null>
+     */
+    public function map($row): array
+    {
+        /** @var Carbon $date */
+        $date = $row->date;
+        /** @var AccountHead|null $accountHead */
+        $accountHead = $row->accountHead;
+        /** @var ImportedFile|null $importedFile */
+        $importedFile = $row->importedFile;
+
+        return [
+            $date->format('d M Y'),
+            $row->description,
+            $row->reference_number,
+            $row->debit !== null ? (float) $row->debit : null,
+            $row->credit !== null ? (float) $row->credit : null,
+            $row->balance !== null ? (float) $row->balance : null,
+            $accountHead?->name,
+            $accountHead?->group_name,
+            $importedFile?->bank_name,
+            $row->mapping_type,
+        ];
+    }
+}

--- a/app/Exports/TransactionDetailSheet.php
+++ b/app/Exports/TransactionDetailSheet.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Transaction;
+use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+/**
+ * @implements WithMapping<Transaction>
+ */
+class TransactionDetailSheet extends TransactionCsvExport implements FromQuery, WithHeadings, WithMapping, WithTitle
+{
+    public function title(): string
+    {
+        return 'Transactions';
+    }
+}

--- a/app/Exports/TransactionExcelExport.php
+++ b/app/Exports/TransactionExcelExport.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+
+class TransactionExcelExport implements WithMultipleSheets
+{
+    public function __construct(
+        public ?string $from = null,
+        public ?string $until = null,
+    ) {}
+
+    /**
+     * @return array<int, TransactionDetailSheet|TransactionSummarySheet>
+     */
+    public function sheets(): array
+    {
+        return [
+            new TransactionDetailSheet(from: $this->from, until: $this->until),
+            new TransactionSummarySheet(from: $this->from, until: $this->until),
+        ];
+    }
+}

--- a/app/Exports/TransactionSummarySheet.php
+++ b/app/Exports/TransactionSummarySheet.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\AccountHead;
+use App\Models\Company;
+use App\Models\Transaction;
+use Filament\Facades\Filament;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+class TransactionSummarySheet implements FromCollection, WithHeadings, WithTitle
+{
+    public function __construct(
+        public ?string $from = null,
+        public ?string $until = null,
+    ) {}
+
+    public function title(): string
+    {
+        return 'Summary';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function headings(): array
+    {
+        return [
+            'Account Head',
+            'Account Head Group',
+            'Total Debit',
+            'Total Credit',
+            'Net Amount',
+        ];
+    }
+
+    /**
+     * @return Collection<int, mixed>
+     */
+    public function collection(): Collection
+    {
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+
+        $query = Transaction::query()
+            ->where('company_id', $tenant->id)
+            ->whereNotNull('account_head_id')
+            ->with('accountHead');
+
+        if ($this->from) {
+            $query->whereDate('date', '>=', $this->from);
+        }
+
+        if ($this->until) {
+            $query->whereDate('date', '<=', $this->until);
+        }
+
+        $transactions = $query->get();
+
+        $summary = [];
+        foreach ($transactions as $transaction) {
+            $headId = $transaction->account_head_id;
+            if ($headId === null) {
+                continue;
+            }
+
+            if (! isset($summary[$headId])) {
+                /** @var AccountHead|null $accountHead */
+                $accountHead = $transaction->accountHead;
+                $summary[$headId] = [
+                    'account_head' => $accountHead?->name,
+                    'group_name' => $accountHead?->group_name,
+                    'total_debit' => 0.0,
+                    'total_credit' => 0.0,
+                    'net_amount' => 0.0,
+                ];
+            }
+
+            if ($transaction->debit !== null) {
+                $summary[$headId]['total_debit'] += (float) $transaction->debit;
+            }
+            if ($transaction->credit !== null) {
+                $summary[$headId]['total_credit'] += (float) $transaction->credit;
+            }
+        }
+
+        foreach ($summary as &$row) {
+            $row['net_amount'] = $row['total_credit'] - $row['total_debit'];
+        }
+
+        return collect(array_values($summary));
+    }
+}

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -4,6 +4,8 @@ namespace App\Filament\Resources;
 
 use App\Enums\MappingType;
 use App\Enums\MatchType;
+use App\Exports\TransactionCsvExport;
+use App\Exports\TransactionExcelExport;
 use App\Filament\Resources\TransactionResource\Pages;
 use App\Jobs\MatchTransactionHeads;
 use App\Models\AccountHead;
@@ -23,6 +25,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TransactionResource extends Resource
@@ -273,40 +277,87 @@ class TransactionResource extends Resource
                             ->send();
                     }),
 
-                Actions\Action::make('export_tally')
-                    ->label('Export to Tally XML')
+                Actions\ActionGroup::make([
+                    Actions\Action::make('export_tally')
+                        ->label('Tally XML')
+                        ->icon('heroicon-o-document-text')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')
+                                ->label('From Date'),
+                            Forms\Components\DatePicker::make('until')
+                                ->label('Until Date'),
+                        ])
+                        ->action(function (array $data): StreamedResponse {
+                            $query = Transaction::whereNotNull('account_head_id')
+                                ->with(['accountHead', 'importedFile.company', 'importedFile.bankAccount'])
+                                ->orderBy('date');
+
+                            if (! empty($data['from'])) {
+                                $query->whereDate('date', '>=', $data['from']);
+                            }
+
+                            if (! empty($data['until'])) {
+                                $query->whereDate('date', '<=', $data['until']);
+                            }
+
+                            $transactions = $query->get();
+
+                            $service = new TallyExportService;
+                            $xml = $service->exportTransactions($transactions);
+
+                            return response()->streamDownload(
+                                fn () => print ($xml),
+                                'tally-export-'.now()->format('Y-m-d-His').'.xml',
+                                ['Content-Type' => 'application/xml']
+                            );
+                        }),
+
+                    Actions\Action::make('export_csv')
+                        ->label('CSV')
+                        ->icon('heroicon-o-table-cells')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')
+                                ->label('From Date'),
+                            Forms\Components\DatePicker::make('until')
+                                ->label('Until Date'),
+                        ])
+                        ->action(function (array $data): BinaryFileResponse {
+                            $export = new TransactionCsvExport(
+                                from: $data['from'] ?? null,
+                                until: $data['until'] ?? null,
+                            );
+
+                            return Excel::download(
+                                $export,
+                                'transactions-'.now()->format('Y-m-d-His').'.csv',
+                            );
+                        }),
+
+                    Actions\Action::make('export_excel')
+                        ->label('Excel')
+                        ->icon('heroicon-o-document-arrow-down')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')
+                                ->label('From Date'),
+                            Forms\Components\DatePicker::make('until')
+                                ->label('Until Date'),
+                        ])
+                        ->action(function (array $data): BinaryFileResponse {
+                            $export = new TransactionExcelExport(
+                                from: $data['from'] ?? null,
+                                until: $data['until'] ?? null,
+                            );
+
+                            return Excel::download(
+                                $export,
+                                'transactions-'.now()->format('Y-m-d-His').'.xlsx',
+                            );
+                        }),
+                ])
+                    ->label('Export')
                     ->icon('heroicon-o-arrow-down-tray')
                     ->color('success')
-                    ->form([
-                        Forms\Components\DatePicker::make('from')
-                            ->label('From Date'),
-                        Forms\Components\DatePicker::make('until')
-                            ->label('Until Date'),
-                    ])
-                    ->action(function (array $data): StreamedResponse {
-                        $query = Transaction::whereNotNull('account_head_id')
-                            ->with(['accountHead', 'importedFile.company', 'importedFile.bankAccount'])
-                            ->orderBy('date');
-
-                        if (! empty($data['from'])) {
-                            $query->whereDate('date', '>=', $data['from']);
-                        }
-
-                        if (! empty($data['until'])) {
-                            $query->whereDate('date', '<=', $data['until']);
-                        }
-
-                        $transactions = $query->get();
-
-                        $service = new TallyExportService;
-                        $xml = $service->exportTransactions($transactions);
-
-                        return response()->streamDownload(
-                            fn () => print ($xml),
-                            'tally-export-'.now()->format('Y-m-d-His').'.xml',
-                            ['Content-Type' => 'application/xml']
-                        );
-                    }),
+                    ->button(),
             ]);
     }
 

--- a/tests/Feature/Exports/TransactionExportTest.php
+++ b/tests/Feature/Exports/TransactionExportTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Exports\TransactionCsvExport;
+use App\Exports\TransactionExcelExport;
+use App\Models\AccountHead;
+use App\Models\Transaction;
+use Maatwebsite\Excel\Facades\Excel;
+
+describe('TransactionCsvExport', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('produces file with correct headings', function () {
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->debit(1000)->create();
+
+        $export = new TransactionCsvExport;
+
+        expect($export->headings())->toBe([
+            'Date',
+            'Description',
+            'Reference',
+            'Debit',
+            'Credit',
+            'Balance',
+            'Account Head',
+            'Account Head Group',
+            'Bank/Source',
+            'Mapping Type',
+        ]);
+    });
+
+    it('maps transactions with decrypted amounts', function () {
+        $head = AccountHead::factory()->create([
+            'name' => 'Office Rent',
+            'group_name' => 'Indirect Expenses',
+        ]);
+        $transaction = Transaction::factory()->mapped($head)->debit(5000.50)->create([
+            'date' => '2025-03-15',
+            'description' => 'NEFT-RENT-PAYMENT',
+            'reference_number' => 'REF123',
+            'balance' => 45000.00,
+        ]);
+        $transaction->load(['accountHead', 'importedFile']);
+
+        $export = new TransactionCsvExport;
+        $row = $export->map($transaction);
+
+        expect($row[0])->toBe('15 Mar 2025')
+            ->and($row[1])->toBe('NEFT-RENT-PAYMENT')
+            ->and($row[2])->toBe('REF123')
+            ->and((float) $row[3])->toBe(5000.50)
+            ->and($row[4])->toBeNull()
+            ->and((float) $row[5])->toBe(45000.00)
+            ->and($row[6])->toBe('Office Rent')
+            ->and($row[7])->toBe('Indirect Expenses');
+    });
+
+    it('respects date range filter', function () {
+        $head = AccountHead::factory()->create();
+        $inRange = Transaction::factory()->mapped($head)->create(['date' => '2025-03-15']);
+        $outOfRange = Transaction::factory()->mapped($head)->create(['date' => '2025-01-01']);
+
+        $export = new TransactionCsvExport(from: '2025-03-01', until: '2025-03-31');
+        $results = $export->query()->get();
+
+        expect($results->pluck('id')->toArray())->toContain($inRange->id)
+            ->and($results->pluck('id')->toArray())->not->toContain($outOfRange->id);
+    });
+
+    it('only includes mapped transactions by default', function () {
+        $head = AccountHead::factory()->create();
+        $mapped = Transaction::factory()->mapped($head)->create();
+        $unmapped = Transaction::factory()->unmapped()->create();
+
+        $export = new TransactionCsvExport;
+        $results = $export->query()->get();
+
+        expect($results->pluck('id')->toArray())->toContain($mapped->id)
+            ->and($results->pluck('id')->toArray())->not->toContain($unmapped->id);
+    });
+
+    it('is tenant-scoped', function () {
+        $currentTenant = tenant();
+        $head = AccountHead::factory()->create();
+        $ownTransaction = Transaction::factory()->mapped($head)->create();
+
+        // Insert a transaction for a different company directly via DB
+        $otherCompany = \App\Models\Company::factory()->create();
+        $otherHead = AccountHead::factory()->create();
+        \Illuminate\Support\Facades\DB::table('transactions')->insert([
+            'company_id' => $otherCompany->id,
+            'imported_file_id' => $ownTransaction->imported_file_id,
+            'date' => now(),
+            'description' => encrypt('Other company transaction'),
+            'debit' => encrypt('1000'),
+            'account_head_id' => $otherHead->id,
+            'mapping_type' => \App\Enums\MappingType::Manual->value,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $otherTransactionId = (int) \Illuminate\Support\Facades\DB::getPdo()->lastInsertId();
+
+        $export = new TransactionCsvExport;
+        $results = $export->query()->get();
+
+        expect($results->pluck('id')->toArray())->toContain($ownTransaction->id)
+            ->and($results->pluck('id')->toArray())->not->toContain($otherTransactionId);
+    });
+
+    it('can be downloaded as CSV', function () {
+        Excel::fake();
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create();
+
+        $export = new TransactionCsvExport;
+        Excel::download($export, 'transactions.csv');
+
+        Excel::assertDownloaded('transactions.csv');
+    });
+});
+
+describe('TransactionExcelExport', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('has Transactions and Summary sheets', function () {
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create();
+
+        $export = new TransactionExcelExport;
+        $sheets = $export->sheets();
+
+        expect($sheets)->toHaveCount(2)
+            ->and($sheets[0]->title())->toBe('Transactions')
+            ->and($sheets[1]->title())->toBe('Summary');
+    });
+
+    it('summary sheet groups by account head with correct totals', function () {
+        $head1 = AccountHead::factory()->create([
+            'name' => 'Office Rent',
+            'group_name' => 'Indirect Expenses',
+        ]);
+        $head2 = AccountHead::factory()->create([
+            'name' => 'Sales Income',
+            'group_name' => 'Direct Income',
+        ]);
+
+        Transaction::factory()->mapped($head1)->debit(1000)->create();
+        Transaction::factory()->mapped($head1)->debit(2000)->create();
+        Transaction::factory()->mapped($head2)->credit(5000)->create();
+
+        $export = new TransactionExcelExport;
+        $sheets = $export->sheets();
+        $summarySheet = $sheets[1];
+
+        $data = $summarySheet->collection();
+
+        // Should have 2 rows (one per head)
+        expect($data)->toHaveCount(2);
+
+        $rentRow = $data->firstWhere('account_head', 'Office Rent');
+        $salesRow = $data->firstWhere('account_head', 'Sales Income');
+
+        expect($rentRow)->not->toBeNull()
+            ->and((float) $rentRow['total_debit'])->toBe(3000.0)
+            ->and((float) $rentRow['total_credit'])->toBe(0.0)
+            ->and((float) $rentRow['net_amount'])->toBe(-3000.0)
+            ->and($salesRow)->not->toBeNull()
+            ->and((float) $salesRow['total_debit'])->toBe(0.0)
+            ->and((float) $salesRow['total_credit'])->toBe(5000.0)
+            ->and((float) $salesRow['net_amount'])->toBe(5000.0);
+    });
+
+    it('can be downloaded as Excel', function () {
+        Excel::fake();
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create();
+
+        $export = new TransactionExcelExport;
+        Excel::download($export, 'transactions.xlsx');
+
+        Excel::assertDownloaded('transactions.xlsx');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds CSV export with `FromQuery`, decrypted amounts, date range filters, and tenant scoping
- Adds Excel export with two sheets: "Transactions" (detail) + "Summary" (grouped by account head with totals)
- Consolidates Tally XML / CSV / Excel into unified Export dropdown in TransactionResource header actions
- Summary sheet computes totals in PHP since encrypted columns cannot be aggregated in SQL

## Test plan
- [x] CSV export produces correct headings (10 columns)
- [x] CSV export maps transactions with decrypted amounts
- [x] CSV export respects date range filter
- [x] CSV export only includes mapped transactions by default
- [x] CSV export is tenant-scoped
- [x] CSV can be downloaded via Excel::download
- [x] Excel export has "Transactions" and "Summary" sheets
- [x] Summary sheet groups by account head with correct debit/credit/net totals
- [x] Excel can be downloaded via Excel::download
- [x] PHPStan passes (0 errors)
- [x] Pint passes

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)