### PR TITLE
feat(nav): reorganize sidebar navigation (#118)

### DIFF
--- a/app/Enums/NavigationGroup.php
+++ b/app/Enums/NavigationGroup.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum NavigationGroup: string implements HasLabel
+{
+    case AutomationRules = 'automation_rules';
+    case Company = 'company';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::AutomationRules => 'Automation Rules',
+            self::Company => 'Company',
+        };
+    }
+}

--- a/app/Filament/Pages/ActivityLog.php
+++ b/app/Filament/Pages/ActivityLog.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Enums\NavigationGroup;
 use App\Exports\ActivityLogExport;
 use BackedEnum;
 use Filament\Actions;
@@ -26,9 +27,9 @@ class ActivityLog extends Page implements HasTable
 
     protected static ?string $title = 'Activity Log';
 
-    protected static UnitEnum|string|null $navigationGroup = 'Settings';
+    protected static UnitEnum|string|null $navigationGroup = NavigationGroup::Company;
 
-    protected static ?int $navigationSort = 11;
+    protected static ?int $navigationSort = 6;
 
     protected string $view = 'filament.pages.activity-log';
 

--- a/app/Filament/Pages/TeamMembers.php
+++ b/app/Filament/Pages/TeamMembers.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Enums\NavigationGroup;
 use App\Enums\UserRole;
 use App\Filament\Widgets\PendingInvitations;
 use App\Mail\InvitationMail;
@@ -35,9 +36,9 @@ class TeamMembers extends Page implements HasTable
 
     protected static ?string $title = 'Team Members';
 
-    protected static UnitEnum|string|null $navigationGroup = 'Settings';
+    protected static UnitEnum|string|null $navigationGroup = NavigationGroup::Company;
 
-    protected static ?int $navigationSort = 10;
+    protected static ?int $navigationSort = 4;
 
     protected string $view = 'filament.pages.team-members';
 

--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\NavigationGroup;
 use App\Filament\Resources\AccountHeadResource\Pages;
 use App\Models\AccountHead;
 use App\Models\Company;
@@ -31,9 +32,9 @@ class AccountHeadResource extends Resource
 
     protected static ?string $navigationLabel = 'Account Heads';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::AutomationRules;
 
-    protected static ?int $navigationSort = 3;
+    protected static ?int $navigationSort = 1;
 
     public static function form(Schema $schema): Schema
     {
@@ -171,6 +172,7 @@ class AccountHeadResource extends Resource
             Forms\Components\FileUpload::make('xml_file')
                 ->label('Tally XML File')
                 ->acceptedFileTypes(['text/xml', 'application/xml', '.xml'])
+                ->maxSize(51200) // 50MB
                 ->required()
                 ->disk('local')
                 ->directory('tally-imports')

--- a/app/Filament/Resources/BankAccountResource.php
+++ b/app/Filament/Resources/BankAccountResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\AccountType;
+use App\Enums\NavigationGroup;
 use App\Filament\Resources\BankAccountResource\Pages;
 use App\Models\BankAccount;
 use BackedEnum;
@@ -26,9 +27,9 @@ class BankAccountResource extends Resource
 
     protected static ?string $navigationLabel = 'Bank Accounts';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::Company;
 
-    protected static ?int $navigationSort = 5;
+    protected static ?int $navigationSort = 2;
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/CreditCardResource.php
+++ b/app/Filament/Resources/CreditCardResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\NavigationGroup;
 use App\Enums\UserRole;
 use App\Filament\Resources\CreditCardResource\Pages;
 use App\Models\Company;
@@ -30,9 +31,9 @@ class CreditCardResource extends Resource
 
     protected static ?string $navigationLabel = 'Credit Cards';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::Company;
 
-    protected static ?int $navigationSort = 6;
+    protected static ?int $navigationSort = 3;
 
     protected static bool $isScopedToTenant = false;
 

--- a/app/Filament/Resources/HeadMappingResource.php
+++ b/app/Filament/Resources/HeadMappingResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\MatchType;
+use App\Enums\NavigationGroup;
 use App\Filament\Resources\HeadMappingResource\Pages;
 use App\Models\BankAccount;
 use App\Models\HeadMapping;
@@ -27,9 +28,9 @@ class HeadMappingResource extends Resource
 
     protected static ?string $navigationLabel = 'Mapping Rules';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::AutomationRules;
 
-    protected static ?int $navigationSort = 4;
+    protected static ?int $navigationSort = 2;
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/RecurringPatternResource.php
+++ b/app/Filament/Resources/RecurringPatternResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\NavigationGroup;
 use App\Filament\Resources\RecurringPatternResource\Pages;
 use App\Models\RecurringPattern;
 use BackedEnum;
@@ -22,9 +23,9 @@ class RecurringPatternResource extends Resource
 
     protected static ?string $navigationLabel = 'Recurring Patterns';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|UnitEnum|null $navigationGroup = NavigationGroup::AutomationRules;
 
-    protected static ?int $navigationSort = 5;
+    protected static ?int $navigationSort = 3;
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,15 +2,18 @@
 
 namespace App\Providers\Filament;
 
+use App\Enums\NavigationGroup;
 use App\Filament\Pages\Tenancy\EditCompanySettings;
 use App\Filament\Pages\Tenancy\RegisterCompany;
 use App\Http\Middleware\SetTenantDatabaseContext;
 use App\Http\Middleware\UpdateLastActiveAt;
 use App\Models\Company;
+use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\NavigationItem;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
@@ -43,6 +46,14 @@ class AdminPanelProvider extends PanelProvider
             ->pages([])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([])
+            ->navigationItems([
+                NavigationItem::make('Settings')
+                    ->url(fn (): string => EditCompanySettings::getUrl(tenant: Filament::getTenant()))
+                    ->icon('heroicon-o-cog-6-tooth')
+                    ->group(NavigationGroup::Company)
+                    ->sort(5)
+                    ->isActiveWhen(fn (): bool => request()->routeIs('filament.admin.tenant.profile')),
+            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/tests/Feature/Filament/AccountHeadResourceTest.php
+++ b/tests/Feature/Filament/AccountHeadResourceTest.php
@@ -81,7 +81,7 @@ describe('AccountHeadResource', function () {
 
     it('has correct navigation properties', function () {
         expect(AccountHeadResource::getNavigationLabel())->toBe('Account Heads')
-            ->and(AccountHeadResource::getNavigationSort())->toBe(3);
+            ->and(AccountHeadResource::getNavigationSort())->toBe(1);
     });
 
     it('soft-deletes the record and retains it in the database', function () {

--- a/tests/Feature/Filament/ActivityLogPageTest.php
+++ b/tests/Feature/Filament/ActivityLogPageTest.php
@@ -186,8 +186,8 @@ describe('Activity Log Page', function () {
     });
 
     describe('Navigation', function () {
-        it('is in the Settings navigation group', function () {
-            expect(ActivityLog::getNavigationGroup())->toBe('Settings');
+        it('is in the Company navigation group', function () {
+            expect(ActivityLog::getNavigationGroup())->toBe(\App\Enums\NavigationGroup::Company);
         });
     });
 });

--- a/tests/Feature/Filament/BankAccountResourceTest.php
+++ b/tests/Feature/Filament/BankAccountResourceTest.php
@@ -113,7 +113,7 @@ describe('BankAccountResource', function () {
 
     it('has correct navigation properties', function () {
         expect(BankAccountResource::getNavigationLabel())->toBe('Bank Accounts')
-            ->and(BankAccountResource::getNavigationSort())->toBe(5);
+            ->and(BankAccountResource::getNavigationSort())->toBe(2);
     });
 
     it('can set pdf_password on a bank account', function () {

--- a/tests/Feature/Filament/CreditCardResourceTest.php
+++ b/tests/Feature/Filament/CreditCardResourceTest.php
@@ -97,7 +97,7 @@ describe('CreditCardResource', function () {
 
     it('has correct navigation properties', function () {
         expect(CreditCardResource::getNavigationLabel())->toBe('Credit Cards')
-            ->and(CreditCardResource::getNavigationSort())->toBe(6);
+            ->and(CreditCardResource::getNavigationSort())->toBe(3);
     });
 
     it('stores pdf_password as encrypted', function () {


### PR DESCRIPTION
## Summary

- Split the catch-all "Settings" navigation group into **Automation Rules** (Account Heads, Mapping Rules, Recurring Patterns) and **Company** (Bank Accounts, Credit Cards, Team Members, Settings, Activity Log)
- Introduced `NavigationGroup` enum (`HasLabel`) for type-safe, ordered navigation groups
- Added sidebar `NavigationItem` linking to company settings (tenant profile page)
- Bumped Tally XML upload `maxSize` to 50MB for large imports

Closes #118

## Test plan

- [x] All 135 related Filament tests pass with updated navigation sort/group assertions
- [x] PHPStan clean on modified files
- [x] Pint formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)