### PR TITLE
feat(auth): profile editing, password reset, and MFA

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Filament\Pages\Auth;
+
+use Filament\Auth\Pages\EditProfile as BaseEditProfile;
+use Filament\Schemas\Components\Component;
+
+class EditProfile extends BaseEditProfile
+{
+    protected function getEmailFormComponent(): Component
+    {
+        return parent::getEmailFormComponent()
+            ->disabled();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,10 @@
 namespace App\Models;
 
 use App\Enums\UserRole;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
 use Filament\Facades\Filament;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasDefaultTenant;
@@ -19,9 +23,9 @@ use Illuminate\Support\Collection;
 /**
  * @property UserRole|null $role
  */
-class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
+class User extends Authenticatable implements FilamentUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasDefaultTenant, HasTenants
 {
-    use HasFactory, Notifiable;
+    use HasFactory, InteractsWithAppAuthentication, InteractsWithAppAuthenticationRecovery, Notifiable;
 
     protected $fillable = [
         'name',

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -4,11 +4,13 @@ namespace App\Providers\Filament;
 
 use App\Enums\NavigationGroup;
 use App\Filament\Pages\Auth\AcceptInvitation;
+use App\Filament\Pages\Auth\EditProfile;
 use App\Filament\Pages\Tenancy\EditCompanySettings;
 use App\Filament\Pages\Tenancy\RegisterCompany;
 use App\Http\Middleware\SetTenantDatabaseContext;
 use App\Http\Middleware\UpdateLastActiveAt;
 use App\Models\Company;
+use Filament\Auth\MultiFactor\App\AppAuthentication;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -35,6 +37,12 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
+            ->passwordReset()
+            ->profile(EditProfile::class)
+            ->multiFactorAuthentication([
+                AppAuthentication::make()
+                    ->recoverable(),
+            ])
             ->colors([
                 'primary' => Color::Indigo,
             ])

--- a/database/migrations/2026_03_07_225741_add_mfa_columns_to_users_table.php
+++ b/database/migrations/2026_03_07_225741_add_mfa_columns_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('app_authentication_secret')->nullable();
+            $table->text('app_authentication_recovery_codes')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['app_authentication_secret', 'app_authentication_recovery_codes']);
+        });
+    }
+};

--- a/tests/Feature/ProfileAndAuthTest.php
+++ b/tests/Feature/ProfileAndAuthTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Filament\Pages\Auth\EditProfile;
+use App\Models\User;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+describe('Profile page', function () {
+    it('displays current user name and email', function () {
+        $user = asUser();
+
+        Livewire::test(EditProfile::class)
+            ->assertSuccessful()
+            ->assertFormSet([
+                'name' => $user->name,
+                'email' => $user->email,
+            ]);
+    });
+
+    it('can update name', function () {
+        $user = asUser();
+
+        Livewire::test(EditProfile::class)
+            ->fillForm([
+                'name' => 'Updated Name',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        expect($user->fresh()->name)->toBe('Updated Name');
+    });
+
+    it('does not allow email changes', function () {
+        $user = asUser();
+
+        Livewire::test(EditProfile::class)
+            ->assertFormFieldIsDisabled('email');
+    });
+
+    it('can change password', function () {
+        $user = User::factory()->state([
+            'role' => UserRole::Admin,
+            'password' => Hash::make('old-password'),
+        ])->create();
+
+        asUser($user);
+
+        Livewire::test(EditProfile::class)
+            ->fillForm([
+                'name' => $user->name,
+                'currentPassword' => 'old-password',
+                'password' => 'new-password123',
+                'passwordConfirmation' => 'new-password123',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        expect(Hash::check('new-password123', $user->fresh()->password))->toBeTrue();
+    });
+
+    it('validates name is required', function () {
+        asUser();
+
+        Livewire::test(EditProfile::class)
+            ->fillForm([
+                'name' => '',
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['name' => 'required']);
+    });
+});
+
+describe('Password reset', function () {
+    it('request page renders with email field', function () {
+        Livewire::test(\Filament\Auth\Pages\PasswordReset\RequestPasswordReset::class)
+            ->assertSuccessful()
+            ->assertFormFieldExists('email');
+    });
+
+    it('sends password reset notification', function () {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'reset@example.com']);
+
+        Livewire::test(\Filament\Auth\Pages\PasswordReset\RequestPasswordReset::class)
+            ->fillForm([
+                'email' => 'reset@example.com',
+            ])
+            ->call('request')
+            ->assertNotified();
+
+        Notification::assertSentTo($user, \Filament\Auth\Notifications\ResetPassword::class);
+    });
+});
+
+describe('Multi-factor authentication', function () {
+    it('user model implements MFA contracts', function () {
+        $user = User::factory()->create();
+
+        expect($user)->toBeInstanceOf(HasAppAuthentication::class)
+            ->and($user)->toBeInstanceOf(HasAppAuthenticationRecovery::class);
+    });
+
+    it('user has MFA columns', function () {
+        $user = User::factory()->create();
+
+        expect($user->app_authentication_secret)->toBeNull()
+            ->and($user->app_authentication_recovery_codes)->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Enable Filament's built-in profile page with email editing disabled (custom `EditProfile` page)
- Add password reset flow via `->passwordReset()`
- Add TOTP-based multi-factor authentication with recovery codes
- MFA secrets encrypted at rest via Filament's built-in `encrypted` cast

Closes #128

## Changes
- `AdminPanelProvider` — add `passwordReset()`, `profile(EditProfile::class)`, `multiFactorAuthentication()`
- `EditProfile` — custom page extending Filament's base, disables email field
- `User` model — implement `HasAppAuthentication` + `HasAppAuthenticationRecovery`
- Migration — add `app_authentication_secret` and `app_authentication_recovery_codes` columns
- 9 tests covering profile CRUD, disabled email, password reset, and MFA contracts

## Test plan
- [x] Profile page renders and displays user name/email
- [x] Name can be updated, email field is disabled
- [x] Password can be changed with current password confirmation
- [x] Password reset page renders and sends notification
- [x] MFA interfaces and columns are properly configured
- [x] All 948 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)