### PR TITLE
fix(tenancy): assign admin role to company creator

### DIFF
--- a/app/Filament/Pages/Tenancy/RegisterCompany.php
+++ b/app/Filament/Pages/Tenancy/RegisterCompany.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages\Tenancy;
 
+use App\Enums\UserRole;
 use App\Models\Company;
 use App\Support\GstinValidator;
 use Filament\Forms\Components\Select;
@@ -89,7 +90,7 @@ class RegisterCompany extends RegisterTenant
     {
         $company = Company::create($data);
 
-        $company->users()->attach(auth()->user());
+        $company->users()->attach(auth()->user(), ['role' => UserRole::Admin->value]);
 
         $company->update([
             'inbox_address' => $this->generateInboxAddress($company),

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\UserRole;
 use App\Models\Company;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -27,7 +28,9 @@ class DatabaseSeeder extends Seeder
                 'email' => 'admin@zysk.in',
             ]);
 
-            $company->users()->syncWithoutDetaching($user);
+            $company->users()->syncWithoutDetaching([
+                $user->id => ['role' => UserRole::Admin->value],
+            ]);
         }
     }
 }

--- a/tests/Feature/Filament/CompanyTenancyTest.php
+++ b/tests/Feature/Filament/CompanyTenancyTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Filament\Pages\Tenancy\EditCompanySettings;
 use App\Filament\Pages\Tenancy\RegisterCompany;
 use App\Models\AccountHead;
@@ -123,7 +124,8 @@ describe('Register Company page', function () {
         $company = Company::where('name', 'Acme Corp')->first();
         expect($company)->not->toBeNull()
             ->and($company->gstin)->toBe('29AABCZ5012F1ZG')
-            ->and($company->users->pluck('id'))->toContain($this->user->id);
+            ->and($company->users->pluck('id'))->toContain($this->user->id)
+            ->and($this->user->roleForCompany($company))->toBe(UserRole::Admin);
     });
 
     it('generates an inbox_address on company registration', function () {


### PR DESCRIPTION
## Summary
- Company creator was getting default `viewer` role instead of `admin` because `attach()` was called without a role parameter
- Fixed `RegisterCompany::handleRegistration()` to pass `['role' => UserRole::Admin->value]`
- Fixed `DatabaseSeeder` to assign admin role to seeded user
- Added test assertion verifying creator gets admin role

Closes #138

## Test plan
- [x] Existing tenancy test updated to assert admin role on registration
- [x] All 17 CompanyTenancyTest tests pass
- [x] PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)