### PR TITLE
fix(classification): prioritize CreditCard over Invoice patterns

### DIFF
--- a/app/Http/Controllers/Api/InboundEmailController.php
+++ b/app/Http/Controllers/Api/InboundEmailController.php
@@ -219,8 +219,8 @@ class InboundEmailController
     private function classifyText(string $text): ?StatementType
     {
         $patternMap = [
-            [StatementType::Invoice, ['inv', 'invoice', 'tax[_\-\s]?invoice', 'bill', 'debit[_\-\s]?note', 'credit[_\-\s]?note']],
             [StatementType::CreditCard, ['credit[_\-\s]?card', 'cc[_\-\s]?statement']],
+            [StatementType::Invoice, ['inv', 'invoice', 'tax[_\-\s]?invoice', 'bill', 'debit[_\-\s]?note', 'credit[_\-\s]?note']],
             [StatementType::Bank, ['statement', 'bank[_\-\s]?statement', 'account[_\-\s]?statement']],
         ];
 

--- a/tests/Feature/Http/Controllers/InboundEmailControllerTest.php
+++ b/tests/Feature/Http/Controllers/InboundEmailControllerTest.php
@@ -235,6 +235,41 @@ describe('InboundEmailController email-based classification', function () {
         expect($importedFile->statement_type)->toBe(StatementType::CreditCard);
     });
 
+    it('classifies as CreditCard when forwarded email subject mentions credit card bill', function () {
+        Company::factory()->create(['inbox_address' => 'invoices@inbox.example.com']);
+
+        $pdf = UploadedFile::fake()->create('statement.pdf', 100, 'application/pdf');
+
+        $this->postJson('/api/v1/webhooks/inbound-email', array_merge(
+            inboundPayload([
+                'attachment-count' => '1',
+                'subject' => 'Fwd: Your Credit Card Bill',
+            ]),
+            ['attachment-1' => $pdf],
+        ));
+
+        $importedFile = ImportedFile::first();
+        expect($importedFile->statement_type)->toBe(StatementType::CreditCard);
+    });
+
+    it('classifies as CreditCard when email body contains credit card and bill', function () {
+        Company::factory()->create(['inbox_address' => 'invoices@inbox.example.com']);
+
+        $pdf = UploadedFile::fake()->create('document.pdf', 100, 'application/pdf');
+
+        $this->postJson('/api/v1/webhooks/inbound-email', array_merge(
+            inboundPayload([
+                'attachment-count' => '1',
+                'subject' => 'Monthly Documents',
+                'stripped-text' => 'Please find your credit card bill attached for review.',
+            ]),
+            ['attachment-1' => $pdf],
+        ));
+
+        $importedFile = ImportedFile::first();
+        expect($importedFile->statement_type)->toBe(StatementType::CreditCard);
+    });
+
     it('falls back to filename when email has no classification signals', function () {
         Company::factory()->create(['inbox_address' => 'invoices@inbox.example.com']);
 


### PR DESCRIPTION
## Summary
- Reorder `$patternMap` in `classifyText()` to check CreditCard patterns before Invoice patterns
- Fixes email-forwarded credit card statements (e.g. "Your Credit Card Bill") being misclassified as Invoice because Invoice's `bill` pattern matched first
- Added 2 regression tests for subject and body classification with "credit card bill"

Closes #139

## Test plan
- [x] Existing classification tests pass (44/44) — no regressions
- [x] PHPStan passes on modified controller
- [ ] Verify "electricity bill" still classifies as Invoice (covered by existing test)
- [ ] Verify "credit card statement" still classifies as CreditCard (covered by existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)