### PR TITLE
feat(ui): allow manual statement type override

### DIFF
--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -187,6 +187,30 @@ class ImportedFileResource extends Resource
                         })
                         ->visible(fn (ImportedFile $record) => $record->status === ImportStatus::NeedsPassword),
 
+                    Actions\Action::make('changeType')
+                        ->label('Change Type')
+                        ->icon('heroicon-o-arrow-path-rounded-square')
+                        ->color('gray')
+                        ->schema([
+                            Forms\Components\Select::make('statement_type')
+                                ->label('Statement Type')
+                                ->options(StatementType::class)
+                                ->required(),
+                        ])
+                        ->fillForm(fn (ImportedFile $record): array => [
+                            'statement_type' => $record->statement_type,
+                        ])
+                        ->modalHeading('Change Statement Type')
+                        ->modalDescription('Change the statement type for this file. This will not trigger reprocessing — use Re-process separately if needed.')
+                        ->modalSubmitActionLabel('Update Type')
+                        ->action(fn (ImportedFile $record, array $data) => $record->update([
+                            'statement_type' => $data['statement_type'],
+                        ]))
+                        ->visible(fn (ImportedFile $record) => in_array($record->status, [
+                            ImportStatus::Completed,
+                            ImportStatus::Failed,
+                        ])),
+
                     Actions\Action::make('reprocess')
                         ->label('Re-process')
                         ->icon('heroicon-o-arrow-path')

--- a/tests/Feature/Filament/ImportedFileResourceTest.php
+++ b/tests/Feature/Filament/ImportedFileResourceTest.php
@@ -304,4 +304,67 @@ describe('ImportedFileResource', function () {
         livewire(ListImportedFiles::class)
             ->assertSuccessful();
     });
+
+    it('changeType action is visible only for completed and failed files', function () {
+        $completedFile = ImportedFile::factory()->completed()->create();
+        $failedFile = ImportedFile::factory()->failed()->create();
+        $pendingFile = ImportedFile::factory()->create(['status' => ImportStatus::Pending]);
+        $processingFile = ImportedFile::factory()->processing()->create();
+        $needsPasswordFile = ImportedFile::factory()->create(['status' => ImportStatus::NeedsPassword]);
+
+        livewire(ListImportedFiles::class)
+            ->assertTableActionVisible('changeType', $completedFile)
+            ->assertTableActionVisible('changeType', $failedFile)
+            ->assertTableActionHidden('changeType', $pendingFile)
+            ->assertTableActionHidden('changeType', $processingFile)
+            ->assertTableActionHidden('changeType', $needsPasswordFile);
+    });
+
+    it('changeType action updates statement_type on the record', function () {
+        $file = ImportedFile::factory()->completed()->create([
+            'statement_type' => StatementType::Bank,
+        ]);
+
+        livewire(ListImportedFiles::class)
+            ->callTableAction('changeType', $file, data: [
+                'statement_type' => StatementType::CreditCard->value,
+            ]);
+
+        $file->refresh();
+        expect($file->statement_type)->toBe(StatementType::CreditCard);
+    });
+
+    it('changeType action does not auto-reprocess the file', function () {
+        Queue::fake();
+
+        $file = ImportedFile::factory()->completed()->create([
+            'statement_type' => StatementType::Bank,
+        ]);
+
+        livewire(ListImportedFiles::class)
+            ->callTableAction('changeType', $file, data: [
+                'statement_type' => StatementType::CreditCard->value,
+            ]);
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Completed);
+
+        Queue::assertNotPushed(ProcessImportedFile::class);
+    });
+
+    it('changeType action logs the change via activity log', function () {
+        $file = ImportedFile::factory()->completed()->create([
+            'statement_type' => StatementType::Bank,
+        ]);
+
+        livewire(ListImportedFiles::class)
+            ->callTableAction('changeType', $file, data: [
+                'statement_type' => StatementType::CreditCard->value,
+            ]);
+
+        $activity = $file->activities()->where('description', 'updated')->latest()->first();
+        expect($activity)->not->toBeNull()
+            ->and($activity->properties['old']['statement_type'])->toBe('bank')
+            ->and($activity->properties['attributes']['statement_type'])->toBe('credit_card');
+    });
 });


### PR DESCRIPTION
## Summary
- Added "Change Type" table action on ImportedFileResource
- Select dropdown with StatementType enum options, pre-fills current type
- Visible only for completed/failed files
- Does NOT auto-trigger reprocessing (user controls when to reprocess)
- Changes logged via activity log

Closes #143

## Test plan
- [x] Action visible only for completed/failed files
- [x] Changing type updates the record
- [x] Does not auto-reprocess
- [x] Activity log records the change
- [x] All ImportedFileResource tests pass
- [x] PHPStan clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)