### PR TITLE
feat(ui): conditional polling on imported files page

### DIFF
--- a/app/Filament/Resources/ImportedFileResource/Pages/ListImportedFiles.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ListImportedFiles.php
@@ -2,8 +2,10 @@
 
 namespace App\Filament\Resources\ImportedFileResource\Pages;
 
+use App\Enums\ImportStatus;
 use App\Filament\Resources\ImportedFileResource;
 use App\Filament\Widgets\ImportedFileStatsOverview;
+use App\Models\ImportedFile;
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\View\View;
@@ -11,6 +13,13 @@ use Illuminate\Contracts\View\View;
 class ListImportedFiles extends ListRecords
 {
     protected static string $resource = ImportedFileResource::class;
+
+    protected function getTablePollingInterval(): ?string
+    {
+        return ImportedFile::whereIn('status', [ImportStatus::Pending, ImportStatus::Processing])->exists()
+            ? '10s'
+            : null;
+    }
 
     public function getSubheading(): ?string
     {

--- a/app/Filament/Widgets/ImportedFileStatsOverview.php
+++ b/app/Filament/Widgets/ImportedFileStatsOverview.php
@@ -11,6 +11,13 @@ class ImportedFileStatsOverview extends BaseWidget
 {
     protected static bool $isDiscovered = false;
 
+    protected function getPollingInterval(): ?string
+    {
+        return ImportedFile::whereIn('status', [ImportStatus::Pending, ImportStatus::Processing])->exists()
+            ? '10s'
+            : null;
+    }
+
     protected function getStats(): array
     {
         $totalFiles = ImportedFile::count();


### PR DESCRIPTION
## Summary
- Table and stats widget poll every 10s **only when files are in Pending/Processing status**
- No polling when idle — zero extra DB load during normal browsing
- Both table and widget stop polling automatically once processing completes

## Test plan
- [ ] Upload a file → verify table auto-refreshes while processing
- [ ] After processing completes → verify polling stops (check network tab)
- [ ] Page with no processing files → verify no polling requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)