### PR TITLE
feat(ui): smart conditional polling with is_matching flag

### DIFF
--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -95,6 +95,7 @@ class ImportedFileResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->poll(fn (): ?string => ImportedFile::activelyProcessing()->exists() ? '10s' : null)
             ->modifyQueryUsing(fn (Builder $query) => $query->with(['creditCard']))
             ->columns([
                 Tables\Columns\TextColumn::make('original_filename')

--- a/app/Filament/Resources/ImportedFileResource/Pages/ListImportedFiles.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ListImportedFiles.php
@@ -2,10 +2,8 @@
 
 namespace App\Filament\Resources\ImportedFileResource\Pages;
 
-use App\Enums\ImportStatus;
 use App\Filament\Resources\ImportedFileResource;
 use App\Filament\Widgets\ImportedFileStatsOverview;
-use App\Models\ImportedFile;
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\View\View;
@@ -13,13 +11,6 @@ use Illuminate\Contracts\View\View;
 class ListImportedFiles extends ListRecords
 {
     protected static string $resource = ImportedFileResource::class;
-
-    protected function getTablePollingInterval(): ?string
-    {
-        return ImportedFile::whereIn('status', [ImportStatus::Pending, ImportStatus::Processing])->exists()
-            ? '10s'
-            : null;
-    }
 
     public function getSubheading(): ?string
     {

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -10,6 +10,7 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 
+/** @property ImportedFile $record */
 class ViewImportedFile extends ViewRecord
 {
     protected static string $resource = ImportedFileResource::class;
@@ -31,6 +32,7 @@ class ViewImportedFile extends ViewRecord
         return $schema
             ->schema([
                 Section::make('File Details')
+                    ->poll(fn (): ?string => $this->record->isProcessing() ? '10s' : null)
                     ->schema([
                         Infolists\Components\TextEntry::make('original_filename')
                             ->label('Filename'),

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -61,6 +61,7 @@ class TransactionResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->poll(fn (): ?string => ImportedFile::activelyProcessing()->exists() ? '10s' : null)
             ->columns([
                 Tables\Columns\TextColumn::make('date')
                     ->date('d M Y')
@@ -362,7 +363,9 @@ class TransactionResource extends Resource
                     ->action(function () {
                         $files = ImportedFile::whereHas('transactions', function (Builder $q) {
                             $q->where('mapping_type', MappingType::Unmapped);
-                        })->get();
+                        })->where('is_matching', false)->get();
+
+                        ImportedFile::whereIn('id', $files->pluck('id'))->update(['is_matching' => true]);
 
                         foreach ($files as $file) {
                             MatchTransactionHeads::dispatch($file);

--- a/app/Filament/Widgets/ImportedFileStatsOverview.php
+++ b/app/Filament/Widgets/ImportedFileStatsOverview.php
@@ -13,7 +13,7 @@ class ImportedFileStatsOverview extends BaseWidget
 
     protected function getPollingInterval(): ?string
     {
-        return ImportedFile::whereIn('status', [ImportStatus::Pending, ImportStatus::Processing])->exists()
+        return ImportedFile::activelyProcessing()->exists()
             ? '10s'
             : null;
     }

--- a/app/Jobs/MatchTransactionHeads.php
+++ b/app/Jobs/MatchTransactionHeads.php
@@ -58,6 +58,7 @@ class MatchTransactionHeads implements ShouldQueue
                 'unmatched' => $results['unmatched'],
             ]);
 
+            $this->importedFile->update(['is_matching' => false]);
             $this->notifyCompletion($results);
         } catch (\Throwable $e) {
             Log::error('Failed to match transaction heads', [
@@ -74,6 +75,8 @@ class MatchTransactionHeads implements ShouldQueue
      */
     public function failed(\Throwable $exception): void
     {
+        $this->importedFile->update(['is_matching' => false]);
+
         Log::error('MatchTransactionHeads permanently failed', [
             'file_id' => $this->importedFile->id,
             'exception' => $exception->getMessage(),

--- a/app/Models/ImportedFile.php
+++ b/app/Models/ImportedFile.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\ImportSource;
 use App\Enums\ImportStatus;
 use App\Enums\StatementType;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -67,6 +68,7 @@ class ImportedFile extends Model
         'processed_at',
         'bank_account_id',
         'credit_card_id',
+        'is_matching',
     ];
 
     public function getActivitylogOptions(): LogOptions
@@ -102,6 +104,7 @@ class ImportedFile extends Model
             'processed_at' => 'datetime',
             'total_rows' => 'integer',
             'mapped_rows' => 'integer',
+            'is_matching' => 'boolean',
         ];
     }
 
@@ -132,6 +135,23 @@ class ImportedFile extends Model
     public function transactions(): HasMany
     {
         return $this->hasMany(Transaction::class);
+    }
+
+    private const ACTIVE_STATUSES = [ImportStatus::Pending, ImportStatus::Processing];
+
+    /** @param Builder<self> $query */
+    public function scopeActivelyProcessing(Builder $query): void
+    {
+        $query->where(function (Builder $q) {
+            $q->whereIn('status', self::ACTIVE_STATUSES)
+                ->orWhere('is_matching', true);
+        });
+    }
+
+    public function isProcessing(): bool
+    {
+        return in_array($this->status, self::ACTIVE_STATUSES)
+            || $this->is_matching;
     }
 
     public function getMappedPercentageAttribute(): float

--- a/database/migrations/2026_03_10_012014_add_is_matching_to_imported_files_table.php
+++ b/database/migrations/2026_03_10_012014_add_is_matching_to_imported_files_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->boolean('is_matching')->default(false)->after('status');
+            $table->index('is_matching', 'imported_files_is_matching_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->dropIndex('imported_files_is_matching_idx');
+            $table->dropColumn('is_matching');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Polls Filament tables/widgets **only when work is in progress** (files processing or AI matching running)
- Adds `is_matching` boolean to `imported_files` table to track AI matching job lifecycle
- Adds `scopeActivelyProcessing()` and `isProcessing()` on ImportedFile model — single source of truth for all polling decisions
- Guards against concurrent dispatch for files already being matched
- Removes deprecated `getTablePollingInterval()` from ListImportedFiles

Builds on #156 (initial static polling).

## Test plan
- [x] Upload a file → table auto-refreshes while processing, stops when done
- [x] Click "Run AI Matching" → transactions table auto-refreshes while matching, stops when done
- [x] View single file page → polls only when that file is processing
- [x] Idle state → no polling on any page (check network tab)
- [x] All 1039 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)