### PR TITLE
chore: add claude configuration files

### DIFF
--- a/.claude/commands/batch-plan.md
+++ b/.claude/commands/batch-plan.md
@@ -1,0 +1,45 @@
+---
+allowed-tools: Bash(gh *), Bash(git *), Read, Grep, Glob
+description: Scan open GitHub issues, group into prioritized batches, and present a wave plan
+---
+
+# Batch Plan
+
+Scan open GitHub issues, group them into prioritized batches by theme, and present an execution plan.
+
+## Pre-computed context
+- Open issues: !`gh issue list --state open --limit 50 --json number,title,labels`
+- Current branch: !`git branch --show-current`
+
+## Steps
+
+### 1. Categorize Issues
+
+Group issues by theme using labels and content:
+
+| Category | Label patterns | Batch together? |
+|----------|---------------|-----------------|
+| Tests | `type: test` | Yes — no prod code changes |
+| Features (infra) | `module: infra` | Yes — independent |
+| Features (UI) | `module: filament` | Yes — Filament-specific |
+| Bug fixes | `type: fix` | Yes — quick wins |
+| Blocked | `status: blocked` | No — skip |
+
+### 2. Prioritize Batches
+
+1. `priority: high` issues first
+2. Test-only batches before feature batches
+3. Independent features before features with dependencies
+4. Blocked issues last
+
+### 3. Present the Plan
+
+Output format:
+
+| Batch | Issues | Theme | Branch | Rationale |
+|-------|--------|-------|--------|-----------|
+| Wave N | #X, #Y | ... | feat/wave-N-... | ... |
+
+### 4. Confirm with User
+
+Ask the user to confirm or adjust before proceeding.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,221 @@
+---
+allowed-tools: Bash(gh *), Bash(git *), Bash(php *), Bash(vendor/bin/*), Bash(bash bin/*), Read, Grep, Glob, Edit, Write, Agent, ToolSearch, Skill, TaskCreate, TaskUpdate, TaskList
+description: Fix a GitHub issue end-to-end with TDD
+argument-hint: <issue-number>
+---
+
+Fix GitHub issue #$ARGUMENTS. For detailed sub-steps, refer to `docs/guides/ai-assisted-development-workflow.md`.
+
+## Issue details
+!`gh issue view $ARGUMENTS`
+
+## Scope Discipline (applies to ALL steps)
+
+If you discover unrelated issues at ANY point — while exploring, writing tests, or implementing — immediately run `gh issue create` to track them. **Never fix unrelated issues in this task. No exceptions.**
+
+## Create Progress Checklist
+
+Before starting, create a TaskCreate item for each step below. Update each to `completed` as you finish it. **Do NOT proceed to Step 10 (Commit) unless ALL prior items are completed.**
+
+```
+TaskCreate: "Step 0: Pre-flight — MCP tools verified"
+TaskCreate: "Step 1: Understand — issue read, task type classified"
+TaskCreate: "Step 2: Branch — branch created"
+TaskCreate: "Step 3: Plan — approach outlined"
+TaskCreate: "Step 4: TDD RED — failing tests written"
+TaskCreate: "Step 5: Spec Review — tests match acceptance criteria"
+TaskCreate: "Step 6: TDD GREEN — all tests pass"
+TaskCreate: "Step 7: TDD REFACTOR — simplified and tests still green"
+TaskCreate: "Step 8: CI Checks — pint + phpstan + tests pass"
+TaskCreate: "Step 9: Verify — behavior confirmed"
+TaskCreate: "Step 10: Commit — changes committed"
+TaskCreate: "Step 11: Comment — issue comment posted"
+```
+
+## Implementation Steps (0–11)
+
+These steps are the reusable unit — used by both `/fix-issue` (interactive) and `/batch-run` (parallel agents).
+
+### Step 0: Pre-flight (HARD GATE)
+
+Run `ToolSearch` for `mcp__laravel-boost` to verify MCP tools are available.
+
+- **If available:** Proceed to Step 1.
+- **If unavailable:** **STOP IMMEDIATELY.** Report: "MCP tools unavailable — cannot proceed." Do NOT continue.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 1: Understand
+
+- Read the issue fully
+- Identify relevant files using Grep/Glob
+- Check `docs/adr/` and `docs/modules/` for context
+- Use Laravel Boost MCP tools extensively to build context. Run `ToolSearch` for `mcp__laravel-boost` to discover all available tools — do not limit yourself to a few. Use whichever tools are relevant to the task.
+- Classify the task type:
+  - `feature` / `fix` → TDD workflow (Steps 4–7)
+  - `refactor` → Tests-first (run existing tests, refactor, re-run)
+  - `docs` / `config` → Direct implementation (skip Steps 4–7)
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 2: Branch
+
+Create branch: `<type>/$ARGUMENTS-<short-description>` from latest `main`. Types: feat, fix, refactor.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 3: Plan
+
+Before writing code, outline the approach. Use MCP tools to verify assumptions (`search-docs`, `database-schema`, `tinker`, `list-routes`). For non-trivial work, use Plan Mode.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 4: TDD RED
+
+Write failing tests for ALL acceptance criteria in the issue:
+
+- Use Pest `describe`/`it` blocks (never `test()`)
+- Use factories for database records (never mocks for models)
+- Every mutation test needs 3 assertions: status + response body + side effect
+- Follow existing patterns in the same test directory
+- Run `php artisan test --filter=<TestName> --compact` to confirm they **fail**
+
+**Gate:** Tests must exist AND fail before proceeding. If tests pass immediately, they are not testing new behavior — review the test logic.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### >>>>>> HARD GATE: Do NOT proceed to Step 6 until Step 5 is complete <<<<<<
+
+### Step 5: Spec Review
+
+Review your tests against the issue's acceptance criteria. This is the cheapest place to catch gaps — no implementation code exists yet.
+
+**For each acceptance criterion in the issue:**
+1. Find the corresponding test in your test file
+2. Verify the test asserts the right behavior (status + response + side effect for mutations)
+3. If a criterion has no test: **write the missing test now**
+
+**Checklist:**
+- [ ] Every acceptance criterion has at least one test
+- [ ] Authorization tests cover both allow AND deny paths
+- [ ] Validation tests cover rejection of invalid data
+- [ ] Edge cases from the issue are covered
+
+**Gate (max 2 rounds):** If after 2 rounds of review you're still finding gaps, accept current coverage and note the gaps in Step 11's issue comment.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### >>>>>> HARD GATE: Do NOT proceed to Step 7 until ALL tests pass <<<<<<
+
+### Step 6: TDD GREEN
+
+Write minimal implementation to pass all tests. Run tests after **each change**:
+
+```bash
+php artisan test --filter=<TestName> --compact
+```
+
+**If tests keep failing after 3 different approaches:** STOP. Report which tests fail, what you tried, and the exact error output. Do not keep trying.
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 7: TDD REFACTOR
+
+1. Review modified files for:
+   - Duplicated logic that can be extracted
+   - Overly complex methods that can be simplified
+   - Naming that doesn't communicate intent
+   - Unused imports or dead code
+2. Run `/simplify` on modified PHP files (invoke the `simplify` skill)
+3. Re-run tests to confirm still green:
+   ```bash
+   php artisan test --filter=<TestName> --compact
+   ```
+4. If tests break after refactoring: revert the refactoring change, try a different simplification
+
+Update TaskCreate item to `completed`.
+
+---
+
+### >>>>>> HARD GATE: Do NOT proceed to Step 10 until Step 8 passes <<<<<<
+
+### Step 8: CI Checks
+
+Run the project-wide CI verification:
+
+```bash
+bash bin/ci-check.sh --filter=<TestName>
+```
+
+- If **OVERALL: PASS** — proceed to Step 9
+- If **Pint: FAIL** — run `vendor/bin/pint` to auto-fix, then re-run
+- If **PHPStan: FAIL** — fix reported errors (max 3 attempts), then re-run
+- If **Tests: FAIL** — diagnose and fix (max 3 attempts), then re-run
+
+**After 3 full CI cycles that still fail:** STOP and report the state.
+
+Skip this step entirely for non-PHP changes (docs, config, markdown).
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 9: Verify
+
+Confirm the implementation works end-to-end:
+
+1. Review test output — are ALL tests passing (not just the new ones)?
+2. Use Laravel Boost MCP tools to verify the implementation. Run `ToolSearch` for `mcp__laravel-boost` to see all available tools — use whichever are relevant (routes, schema, tinker, config, logs, etc.). Do not limit yourself to a fixed list.
+3. Check that no unrelated tests broke
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 10: Commit
+
+**Pre-commit check:** Run `TaskList` and verify ALL steps 0–9 are marked `completed`. If any are not, go back and complete them.
+
+- Stage specific files only (never `git add -A`)
+- One atomic commit per task
+- Commit message: `<type>(scope): description (#$ARGUMENTS)`
+
+Update TaskCreate item to `completed`.
+
+---
+
+### Step 11: Comment
+
+Add structured implementation summary to issue #$ARGUMENTS:
+
+```bash
+gh issue comment $ARGUMENTS --body "## Implementation Summary
+- **Changes:** <what was changed and why>
+- **Files modified:** <list of files>
+- **Tests:** <tests added/modified, or 'N/A — config/docs change'>
+- **CI checks:** Pint: Pass | PHPStan: Pass | Tests: Pass
+- **Gaps or concerns:** <any issues found, retry limits hit, or 'None'>
+- **Related issues created:** <links to any new issues, or 'None'>"
+```
+
+Update TaskCreate item to `completed`.
+
+---
+
+## Delivery Step (interactive only — skip if running as part of a batch)
+
+12. **Push & PR** — Push branch and create PR. Include `## Summary`, `## Test plan`, and `Closes #$ARGUMENTS` in the PR body. Add a `type:` label.

--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Blocks destructive bash commands
+# Exit code 2 = block with message shown to Claude
+
+input=$(cat)
+# Windows paths have backslashes that break jq — escape them first
+sanitized=$(echo "$input" | sed 's/\\/\\\\/g')
+command=$(echo "$sanitized" | jq -r '.tool_input.command // empty')
+
+if [[ -z "$command" ]]; then
+  exit 0
+fi
+
+# Block rm -rf (covers -rf, -fr, --recursive, and flags in any order)
+if echo "$command" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|--recursive)\s'; then
+  echo "BLOCKED: Use targeted file deletion instead of rm -rf." >&2
+  exit 2
+fi
+
+# Block force push to main/master (covers --force, --force-with-lease, -f)
+if echo "$command" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b.*\s+(main|master)'; then
+  echo "BLOCKED: Force push to main/master is not allowed. Use a feature branch." >&2
+  exit 2
+fi
+if echo "$command" | grep -qE 'git\s+push\s+.*\s+(main|master)\b.*(--force|--force-with-lease|-f)\b'; then
+  echo "BLOCKED: Force push to main/master is not allowed. Use a feature branch." >&2
+  exit 2
+fi
+
+# Block git reset --hard without confirmation
+if echo "$command" | grep -qE 'git\s+reset\s+--hard'; then
+  echo "BLOCKED: git reset --hard discards changes. Ask the user before proceeding." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/phpstan-check.sh
+++ b/.claude/hooks/phpstan-check.sh
@@ -13,7 +13,12 @@ fi
 
 # Only check PHP files (skip tests — PHPStan config may exclude them)
 if [[ "$file_path" == *.php && "$file_path" != */tests/* ]]; then
-  vendor/bin/phpstan analyse "$file_path" --memory-limit=256M --no-progress 2>/dev/null || true
+  output=$(vendor/bin/phpstan analyse "$file_path" --memory-limit=256M --no-progress --error-format=raw 2>&1)
+  status=$?
+  if [[ $status -ne 0 && -n "$output" ]]; then
+    echo "PHPStan errors in $(basename "$file_path"):"
+    echo "$output"
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -23,4 +23,16 @@ if [[ "$(basename "$file_path")" == "composer.lock" ]]; then
   exit 2
 fi
 
+# Protect phpunit.xml (CI uses DB_PASSWORD=postgres; local may differ — edit manually and revert before committing)
+if [[ "$(basename "$file_path")" == "phpunit.xml" ]]; then
+  echo "BLOCKED: phpunit.xml contains CI-specific values (DB_PASSWORD). Edit manually and revert before committing." >&2
+  exit 2
+fi
+
+# Protect source-of-truth SQL schemas
+if [[ "$file_path" == */docs/schema/*.sql ]]; then
+  echo "BLOCKED: docs/schema/*.sql are source-of-truth references. Edit migrations instead." >&2
+  exit 2
+fi
+
 exit 0

--- a/.claude/rules/controllers.md
+++ b/.claude/rules/controllers.md
@@ -1,0 +1,77 @@
+---
+paths:
+  - "app/Http/Controllers/**"
+---
+
+# Controller Rules
+
+## Controller Style
+
+- Use **standard resource methods** (`index`, `show`, `store`, `update`, `destroy`) — never `__invoke` single-action controllers
+- One controller per resource/concept, with resource methods for each action
+- Keep controllers thin — delegate business logic to services
+
+## Validation & Authorization
+
+- **Always** use Form Request classes for validation — never `$request->validate()`
+- Return API Resources for JSON responses — never raw Eloquent models
+- Authorize via Form Request `authorize()` method or Policy — never `return true` blindly
+- Use route model binding with explicit `where` constraints
+- Never catch exceptions in controllers — let domain exceptions with `render()` handle it
+
+## Response Envelope
+
+```php
+// Single resource — JsonResource auto-wraps in {"data": ...}
+return new PostResource($post);
+
+// Created resource (201)
+return (new PostResource($post))->response()->setStatusCode(201);
+
+// Deleted (204)
+return response()->json(null, 204);
+```
+
+## Status Codes (PD-013)
+
+| Code | When | Response |
+|------|------|----------|
+| **200** | Successful GET, PUT, PATCH | `{"data": ...}` |
+| **201** | Successful POST (creation) | `{"data": ...}` via `->setStatusCode(201)` |
+| **204** | Successful DELETE | No body: `response()->json(null, 204)` |
+| **401** | Missing/invalid auth token | `{"message": "Unauthenticated."}` + `WWW-Authenticate: Bearer` header |
+| **403** | Authenticated but not authorized | `{"message": "This action is unauthorized."}` — never `"Forbidden."` |
+| **404** | Resource not found | `{"message": "Not found."}` — never expose model class names |
+| **409** | Business rule violation | `{"message": "..."}` (state conflicts, insufficient credits) |
+| **422** | Validation errors ONLY | `{"message": "...", "errors": {"field": [...]}}` — handled by Form Requests |
+| **429** | Rate limit exceeded | `{"message": "Too Many Attempts."}` + `Retry-After` header |
+| **500** | Server error | `{"message": "Server error."}` — never leak internals |
+
+## Pagination
+
+- **Always cap `per_page`**: `min($request->integer('per_page', 15), 100)`
+- Use `ResourceClass::collection($paginator)` — Laravel auto-formats `data`, `links`, `meta`
+- Default page size: 15 items
+- Use `simplePaginate()` when total count isn't needed, `cursorPaginate()` for high-volume endpoints
+
+## Eager Loading
+
+- Only load relationships the specific endpoint uses in its response
+- List endpoints (index) load fewer relations than detail endpoints (show)
+- When `preventLazyLoading` triggers, the fix is NOT always "add to `with()`" — check if the relation is actually needed in the Resource. If not, remove the access instead
+
+## Query Flexibility (Spatie QueryBuilder)
+
+- Use `HasQueryBuilder` trait for filterable/sortable endpoints
+- **Whitelist** all filters, sorts, and includes — Spatie returns 400 for invalid params
+- Default sort: `-created_at` (newest first)
+
+## Error Handling
+
+- For business rule violations, throw domain exceptions returning 409
+- Domain exceptions define `render()` and `report()` (returning `false` for expected errors)
+- `shouldRenderJsonWhen()` in `bootstrap/app.php` forces JSON for all `api/*` routes
+
+## Queuing
+
+- Queue heavy operations (emails, webhooks, exports) — never make API consumers wait

--- a/.claude/rules/filament.md
+++ b/.claude/rules/filament.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "app/Filament/**"
+  - "resources/views/vendor/filament-panels/**"
+---
+
+# Filament Rules
+
+## Conventions
+
+- Use `/mcp__laravel-boost__filament/filament` to load Filament v5 guidelines before building resources
+- Check `docs/guides/filament-customizations.md` for project-specific overrides
+
+## Tenant URLs
+
+- `AdminPanelProvider` uses `slugAttribute: 'slug'` for tenant routing
+- Do NOT add `getRouteKeyName()` to the Organization model — it breaks API routes
+- In published views, use `$panel->getTenantSlugAttribute()` + `$tenant->getAttributeValue()` for slug-aware URLs
+
+## Published Views
+
+- Published views in `resources/views/vendor/filament-panels/` override vendor defaults
+- These do NOT auto-update on Filament upgrades — review after any Filament version bump
+- Only publish views when customization is needed — prefer Filament's extension points first
+
+## Testing CRUD Resources
+
+- Every Filament resource test must verify form fields, table records, or visible content
+- Don't write `assertOk()`-only tests — assert specific data is rendered

--- a/.claude/rules/form-requests.md
+++ b/.claude/rules/form-requests.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "app/Http/Requests/**"
+---
+
+# Form Request Rules
+
+## Project Conventions
+
+- **Always** use Form Request classes — never inline `$request->validate()` in controllers
+- `authorize()` must check permissions via policies — never `return true` blindly for write operations
+- Use **array format** for rules (`['required', 'string']`), not pipe-delimited (`'required|string'`)
+- Use `prepareForValidation()` for input normalization (trim, slug, lowercase) — not in controllers
+- Add `bodyParameters()` for Scribe API documentation on complex inputs
+- Validate `per_page` with `max:100` when accepting pagination input
+
+## Naming
+
+- `Store*Request` — POST/create operations
+- `Update*Request` — PUT/PATCH operations
+- File location: `app/Http/Requests/Api/V1/<OperationRequest>.php`
+
+## Don't
+
+- Don't use inline `$request->validate()` in controllers
+- Don't duplicate validation logic across requests — extract to custom Rule objects
+- Don't use pipe-delimited rules — use array format

--- a/.claude/rules/jobs.md
+++ b/.claude/rules/jobs.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "app/Jobs/**"
+---
+
+# Job Rules
+
+## Design Principles
+
+- Jobs MUST be idempotent — safe to retry without side effects
+- Set explicit `$tries`, `$timeout`, and `$backoff` on every job
+- Use `ShouldBeUnique` for jobs that shouldn't run concurrently (e.g., report generation)
+- Use `$deleteWhenMissingModels = true` for jobs that reference Eloquent models
+
+## Queue Assignment
+
+- Assign jobs to named queues matching the infrastructure topology
+- Check `docs/infrastructure/queue-architecture.md` for queue names and priorities
+- Never use the `default` queue for production jobs — be explicit
+
+## Error Handling
+
+- Use `failed()` method for cleanup on final failure (not retries)
+- Log context (model IDs, user IDs) in `failed()` for debugging
+- For expected failures (API down, rate limited), throw and let retry handle it
+- For permanent failures (invalid data), call `$this->fail()` to stop retries
+
+## Testing
+
+- Test job dispatch with `Queue::fake()` and `Queue::assertPushed()`
+- Test job execution separately with real database (not mocked)
+- Verify idempotency: run the job twice, assert same outcome

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "database/migrations/**"
+---
+
+# Migration Rules
+
+## PostgreSQL Standards (non-negotiable)
+
+| Use | Not |
+|-----|-----|
+| `text()` | `string()` with length / `VARCHAR(n)` |
+| `timestampTz()` | `timestamp()` |
+| `id()` (Laravel's `BIGINT` identity) | `increments()` / `SERIAL` |
+| `jsonb()` + CHECK constraint | `json()` |
+| Explicit `->index()` on every FK | Assume auto-indexing |
+| Partial unique `WHERE deleted_at IS NULL` | Table-level unique with soft deletes |
+
+## Before creating a migration
+
+1. Use `database-schema` MCP tool to review existing tables
+2. Check the relevant ADR in `docs/adr/` for design decisions
+3. Check `docs/schema/` for original SQL (source of truth)
+
+## Always include
+
+- Only `up()` method — no `down()` method (trunk-based development, no rollbacks in production)
+- Explicit FK indexes: `$table->index('foreign_key_column')`
+- Comments on non-obvious columns or constraints

--- a/.claude/rules/models.md
+++ b/.claude/rules/models.md
@@ -1,0 +1,40 @@
+---
+paths:
+  - "app/Models/**"
+---
+
+# Model Rules
+
+## Mass Assignment
+
+- **Read-only models** (external databases: `healthcheck`, `central`, `infirmary`): Use `$guarded = ['*']` — these models never perform mass assignment, so `$fillable` is not needed
+- **Writable models** (local database): Always define `$fillable` explicitly (never use `$guarded = []`)
+- `preventSilentlyDiscardingAttributes` is enabled — unfillable fields will throw
+
+## Type Safety
+
+- Define `$casts` for all non-string columns (booleans, dates, JSON, enums)
+- `preventAccessingMissingAttributes` is enabled — typos in attributes will throw
+
+## Relationships
+
+- Define relationships with return types: `public function org(): BelongsTo`
+- `preventLazyLoading` is enabled in non-production
+- When it triggers, the fix is NOT always "add to `with()`" — check if the relation is actually needed. If not, remove the access from the Resource instead
+- Only load relations the endpoint actually needs (don't over-eager)
+
+## Conventions
+
+- Namespace models by module: `App\Models\CompetitiveExams\ExamCategory`
+- Use traits: `HasFactory`, `SoftDeletes` where applicable
+- `is_platform_admin` on User is a public property, NOT a DB column — set after `create()`, not as factory attribute
+
+## Query Safety
+
+- Always use Eloquent or parameterized queries — never raw `DB::raw()` with user input
+- Use Spatie QueryBuilder with whitelisted filters/sorts/includes for API endpoints
+
+## Scopes
+
+- Define reusable query logic as local scopes: `scopePublished`, `scopeActive`
+- Avoid putting query logic in controllers — use model scopes or dedicated query classes

--- a/.claude/rules/php-guidelines.md
+++ b/.claude/rules/php-guidelines.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "**/*.php"
+---
+
+# PHP & Laravel Guidelines (adapted from Spatie)
+
+## Type Declarations
+
+- Use short nullable syntax: `?string` not `string|null`
+- Always specify `void` return types when methods return nothing
+- Use typed properties over docblocks
+- Use constructor property promotion when all properties can be promoted
+
+## Docblocks
+
+- Don't add docblocks for fully type-hinted methods (unless a description is needed)
+- Always import classnames in docblocks — never use fully qualified names
+- Document iterables with generics: `@return Collection<int, User>`
+- Use array shape notation for fixed keys, each key on its own line:
+  ```php
+  /** @return array{
+      first: SomeClass,
+      second: SomeClass,
+  } */
+  ```
+
+## Control Flow
+
+- **Happy path last** — handle error conditions first, success case last
+- **Avoid else** — use early returns instead of nested conditions
+- **Always use curly brackets** even for single statements
+- **Avoid nested ternaries** — prefer `match` expressions, switch statements, or if/else chains for multiple conditions
+- **Clarity over brevity** — explicit, readable code is better than compact one-liners that are hard to parse
+
+## Strings
+
+- Prefer string interpolation over concatenation: `"Hello {$name}"` not `'Hello ' . $name`
+
+## Artisan Commands
+
+- Put output BEFORE processing an item (easier to debug which item failed):
+  ```php
+  $this->info("Processing item id `{$item->id}`...");
+  $this->processItem($item);
+  ```
+- Show a summary count at the end
+
+## File Naming Conventions
+
+| Type | Convention | Example |
+|------|-----------|---------|
+| Jobs | Action-based | `CreateUser`, `SendEmailNotification` |
+| Events | Tense-based | `UserRegistering`, `UserRegistered` |
+| Listeners | Action + `Listener` | `SendInvitationMailListener` |
+| Commands | Action + `Command` | `PublishScheduledPostsCommand` |
+| Mailables | Purpose + `Mail` | `AccountActivatedMail` |
+| Resources | Model + `Resource` | `UserResource` |

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "app/Http/**"
+  - "config/**"
+  - "bootstrap/**"
+  - "routes/**"
+---
+
+# Security Rules
+
+## Project Guardrails
+
+- Never use `DB::raw()` with user input without `?` parameter binding
+- Never use wildcard CORS origins (`*`) with `supports_credentials: true` in `config/cors.php`
+- Never expose model class names in 404 responses
+- Never expose SQL errors or stack traces in responses
+- Never log sensitive data (passwords, tokens, PII) in exception reports
+- Never expose auto-increment IDs in security-sensitive contexts
+- Never return raw Eloquent models — always use API Resources
+- Set token expiration in `config/sanctum.php`
+- Force JSON responses via `shouldRenderJsonWhen()` in `bootstrap/app.php`
+- Authorize via Policies + route model binding scoping (OWASP: Broken Object-Level Auth)
+- Use Form Requests with `$fillable` on models (OWASP: Mass Assignment)
+- Rate limit auth endpoints (OWASP: Broken Authentication)
+
+## Config Safety
+
+- Never use `env()` outside config files — it returns `null` when config is cached
+- Use `Env::getOrFail()` in config files for required environment variables
+- Always access config via `config('key')` in application code

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "tests/**"
+  - "database/factories/**"
+---
+
+# Test Rules
+
+## TDD: RED → GREEN → REFACTOR
+
+1. Write failing test first
+2. Implement minimal code to pass
+3. Refactor — run `/simplify` on modified files, then re-run tests
+
+## Pest Conventions
+
+- Use `describe`/`it` blocks (not `test()`)
+- Use factories for database records (never mocks for models)
+- Follow existing patterns in the same test directory
+- Run: `php artisan test --filter=<TestName> --compact`
+
+## Testing Diamond (PD-012)
+
+- ~5% static analysis (PHPStan)
+- ~25% unit/architecture tests
+- ~65% integration/feature tests (primary focus)
+- ~5% E2E tests
+
+## What to Test per API Endpoint
+
+| Scenario | Status | Assert |
+|----------|--------|--------|
+| Happy path | 200/201 | Correct data structure AND values |
+| Validation failure | 422 | Error messages and field names |
+| Unauthenticated | 401 | Unauthenticated message |
+| Unauthorized | 403 | `"This action is unauthorized."` message |
+| Not found | 404 | Not found message |
+| Empty collection | 200 | Empty `data` array, `total: 0` |
+| Pagination | 200 | `meta` and `links` values |
+| Filtering/sorting | 200 | Correct subset and order |
+| Business rule violation | 409 | Descriptive error message |
+
+## Factory Conventions
+
+- Define states for common variations: `->suspended()`, `->withSubscription()`
+- Use `afterCreating()` for related models — don't create them manually in tests
+- `is_platform_admin` on User is a public property, NOT a DB column — set after `create()`, not as a factory attribute
+- Keep factory defaults minimal — use states for test-specific setups
+
+## Don't
+
+- Don't replace factories with mocks to dodge DB issues
+- Don't skip `describe` blocks for grouping
+- Don't use `RefreshDatabase` — project uses `LazilyRefreshDatabase`
+- Don't write `assertOk()`-only tests — every test must assert beyond HTTP status
+- Don't test config values — test behavior, not `config('key') === 'value'`
+- Don't use Reflection-based tests — test public API, not internal implementation
+- Don't mock DB interactions — use real database with factories

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,8 @@
       "mcp__memory__search_nodes",
       "mcp__memory__read_graph",
       "WebFetch(domain:docs.anthropic.com)",
-      "WebFetch(domain:filamentphp.com)"
+      "WebFetch(domain:filamentphp.com)",
+      "Bash(find:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# Agent Instructions
+
+These instructions are auto-loaded for every subagent. Follow them exactly.
+
+---
+
+## Hard Gate: MCP Pre-flight (Step 0)
+
+**Before ANY other work**, verify Laravel Boost MCP tools are available:
+
+```
+Run: ToolSearch for "mcp__laravel-boost"
+```
+
+- If tools respond: proceed
+- If tools are unavailable: **STOP IMMEDIATELY**. Report: "MCP tools unavailable — cannot proceed." Do NOT continue development without them.
+
+**No retries.** MCP availability is a binary gate.
+
+---
+
+## Progress Tracking Protocol
+
+At the start of every task, create a TaskCreate checklist with one item per workflow step. Update each item to `completed` as you finish it. **Do NOT proceed to the commit step unless ALL prior items are completed.**
+
+Example:
+```
+TaskCreate: "Step 0: MCP Pre-flight"
+TaskCreate: "Step 1: Understand issue"
+TaskCreate: "Step 2: Branch"
+... (one per step)
+```
+
+Update each with `TaskUpdate` as you complete it. If a step fails and you cannot resolve it within retry limits, update the task with the failure reason and STOP.
+
+---
+
+## Retry Limits & Escape Hatches
+
+When a step fails, diagnose first: **is this an environment error or a code error?**
+
+- **Environment error** (wrong DB credentials, missing table, MCP down, composer not installed): **STOP and report.** Do not attempt code fixes for environment problems.
+- **Code error** (test fails, PHPStan error, validation issue): Fix and retry up to the limit below.
+
+| Gate | Max Retries | On Limit Reached |
+|------|-------------|------------------|
+| MCP Pre-flight | 0 | STOP, report |
+| Worktree env setup | 1 | STOP, report env issue |
+| PHPStan fixes | 3 | STOP, report remaining errors with file:line |
+| Test failures (GREEN phase) | 3 | STOP, report which tests fail and what approaches were tried |
+| Spec review rounds | 2 | Accept current coverage, note gaps in issue comment |
+| CI check full cycle | 3 | STOP, report state |
+| Pint formatting | 2 | STOP, report conflict |
+
+**After reaching any limit:** STOP and report. Include:
+1. What failed (exact error output)
+2. What was tried (each attempt)
+3. Your diagnosis (environment vs code, root cause theory)
+
+**Never** try creative workarounds after hitting a limit. Report and let the orchestrator or user decide.
+
+---
+
+## Hooks Awareness
+
+These hooks run automatically on every file edit — you do NOT need to run them manually:
+
+| Hook | Trigger | What it does |
+|------|---------|-------------|
+| `format-php.sh` | After Edit/Write of `.php` files | Auto-runs Pint formatting |
+| `phpstan-check.sh` | After Edit/Write of non-test `.php` files | Runs PHPStan level 6 |
+| `protect-files.sh` | Before Edit/Write | Blocks changes to `.env`, `composer.lock`, `phpunit.xml`, `docs/schema/*.sql` |
+| `block-dangerous-commands.sh` | Before Bash | Blocks `rm -rf`, `git reset --hard`, force push to main |
+
+**Do not panic** if you see auto-formatting changes after editing PHP. That is the Pint hook. Do not undo these changes.
+
+The CI check in Step 8 (`bash bin/ci-check.sh`) is **project-wide verification** — it runs the full suite, not per-file. This is separate from hooks and still required before commit.
+
+---
+
+## Worktree Environment Setup
+
+When working in an isolated worktree, complete these steps **before** starting implementation:
+
+```bash
+# 1. Install dependencies (allow 3-5 min on Windows)
+composer install --no-interaction
+
+# 2. Copy environment file
+cp .env.example .env
+
+# 3. Generate application key
+php artisan key:generate
+
+# 4. Set ALL database credentials in .env (3 connections required):
+#    DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, DB_PASSWORD         (healthcheck)
+#    SECOND_DB_HOST, SECOND_DB_DATABASE, SECOND_DB_USERNAME, SECOND_DB_PASSWORD  (central)
+#    THIRD_DB_HOST, THIRD_DB_DATABASE, THIRD_DB_USERNAME, THIRD_DB_PASSWORD      (infirmary)
+
+# 5. Clear config cache
+php artisan config:clear
+
+# 6. Do NOT run `git checkout main` — the worktree is already based on main
+```
+
+**Test databases** (defined in `phpunit.xml`): `virtual_cfo_test`. If tests fail with "unknown database", these need to be created in PostgreSQL first — this is an environment error, not a code error.
+
+---
+
+## Key Coding Rules
+
+These are the most critical rules from `.claude/rules/`. The full rule files auto-load based on file path when you edit files — consult them for complete details.
+
+### Validation
+- **Always** use Form Request classes — never `$request->validate()` inline
+- Authorize via Form Request `authorize()` method or Policy
+
+### Tests
+- Use Pest `describe`/`it` blocks — never `test()`
+- Use factories for database records — never mock models
+- Every mutation test needs 3 assertions: status + response body + side effect
+- Never write `assertOk()`-only tests
+
+### Response Status Codes
+- 200: GET/PUT/PATCH success
+- 201: POST creation success
+- 204: DELETE success (no body)
+- 422: Validation errors only
+- 403: Unauthorized (never "Forbidden.")
+- 409: Business rule violations
+
+---
+
+## Structured Completion Report
+
+When your task is complete (or you've hit a retry limit and stopped), output this report:
+
+```
+## Agent Completion Report
+- **Status:** Success | Partial | Failed
+- **Issue:** #<number> — <title>
+- **Branch:** <branch-name>
+- **Files modified:** <list>
+- **Tests:** <added/modified count> | All passing: Yes/No
+- **CI checks:** Pint: Pass/Fail | PHPStan: Pass/Fail | Tests: Pass/Fail
+- **Steps completed:** <list of completed TaskCreate items>
+- **Steps skipped/failed:** <list with reasons>
+- **Gaps or concerns:** <anything the reviewer should know>
+```
+
+This format allows the batch orchestrator to parse results and determine next actions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Virtual CFO - Zysk Technologies
 
+## Tone
+
+Do not tell me I am right all the time. Be critical. We're equals. Try to be neutral and objective.
+
+Never mention Claude Code in PR descriptions, PR comments, or issue comments.
+
 ## Commands
 
 ```bash
@@ -67,6 +73,13 @@ feature/* → master (squash merge) → CD → staging/QA → tag vX.Y.Z → pro
 **Merge strategy:** Always squash merge into `master`.
 **CI checks required before merge:** Syntax, Pint, PHPStan, Security, Tests
 **PR labels:** Every PR must have a `type:` label (`type: feature`, `type: bug`, `type: refactor`, `type: docs`, `type: chore`) for release notes categorization.
+
+## Hard Gates (NEVER skip)
+
+- **Laravel Boost tools**: At the START of every task, run `ToolSearch` for Laravel Boost MCP tools (`database-schema`, `search-docs`, `tinker`, etc.). If unavailable, tell the user immediately — do not silently proceed without them.
+- **`/simplify`**: Run on EVERY task before final commit, regardless of task type (feature, fix, config, chore, refactor). Not just TDD REFACTOR — every task.
+- **CI verification**: Run `bash bin/ci-check.sh` before every commit. Do not commit with failing checks.
+- **Progress tracking**: Use `TaskCreate`/`TaskUpdate` to track workflow steps. Verify all steps are completed before commit.
 
 ### Releases
 


### PR DESCRIPTION
## Summary
- Add `.claude/commands/` with `batch-plan` and `fix-issue` slash commands for structured AI-assisted workflows
- Add `.claude/rules/` with 9 rule files (controllers, filament, form-requests, jobs, migrations, models, php-guidelines, security, tests) for context-aware coding guidance
- Add `block-dangerous-commands.sh` hook to prevent `rm -rf`, force push to main, and `git reset --hard`
- Improve `phpstan-check.sh` to show actual errors instead of silently swallowing them
- Expand `protect-files.sh` to block edits to `phpunit.xml` and `docs/schema/*.sql`
- Add `AGENTS.md` with subagent instructions (MCP pre-flight, retry limits, worktree setup, completion reports)
- Update `CLAUDE.md` with tone guidelines and hard gates section

## Test plan
- [ ] Verify hooks trigger correctly on file edits and bash commands
- [ ] Verify rules auto-load when editing matching file types
- [ ] Verify slash commands `/batch-plan` and `/fix-issue` execute correctly