### PR TITLE
fix(export): apply active table filters to CSV, Excel and Tally exports

### DIFF
--- a/app/Exports/TransactionCsvExport.php
+++ b/app/Exports/TransactionCsvExport.php
@@ -18,9 +18,11 @@ use Maatwebsite\Excel\Concerns\WithMapping;
  */
 class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
 {
+    /** @param Builder<Transaction>|null $baseQuery */
     public function __construct(
         public ?string $from = null,
         public ?string $until = null,
+        public ?Builder $baseQuery = null,
     ) {}
 
     /**
@@ -28,14 +30,22 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
      */
     public function query(): Builder
     {
-        /** @var Company $tenant */
-        $tenant = Filament::getTenant();
+        if ($this->baseQuery) {
+            $query = $this->baseQuery
+                ->clone()
+                ->whereNotNull('account_head_id')
+                ->with(['accountHead', 'importedFile'])
+                ->orderBy('date');
+        } else {
+            /** @var Company $tenant */
+            $tenant = Filament::getTenant();
 
-        $query = Transaction::query()
-            ->where('company_id', $tenant->id)
-            ->whereNotNull('account_head_id')
-            ->with(['accountHead', 'importedFile'])
-            ->orderBy('date');
+            $query = Transaction::query()
+                ->where('company_id', $tenant->id)
+                ->whereNotNull('account_head_id')
+                ->with(['accountHead', 'importedFile'])
+                ->orderBy('date');
+        }
 
         if ($this->from) {
             $query->whereDate('date', '>=', $this->from);

--- a/app/Exports/TransactionExcelExport.php
+++ b/app/Exports/TransactionExcelExport.php
@@ -2,13 +2,17 @@
 
 namespace App\Exports;
 
+use App\Models\Transaction;
+use Illuminate\Database\Eloquent\Builder;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 
 class TransactionExcelExport implements WithMultipleSheets
 {
+    /** @param Builder<Transaction>|null $baseQuery */
     public function __construct(
         public ?string $from = null,
         public ?string $until = null,
+        public ?Builder $baseQuery = null,
     ) {}
 
     /**
@@ -17,8 +21,8 @@ class TransactionExcelExport implements WithMultipleSheets
     public function sheets(): array
     {
         return [
-            new TransactionDetailSheet(from: $this->from, until: $this->until),
-            new TransactionSummarySheet(from: $this->from, until: $this->until),
+            new TransactionDetailSheet(from: $this->from, until: $this->until, baseQuery: $this->baseQuery),
+            new TransactionSummarySheet(from: $this->from, until: $this->until, baseQuery: $this->baseQuery),
         ];
     }
 }

--- a/app/Exports/TransactionSummarySheet.php
+++ b/app/Exports/TransactionSummarySheet.php
@@ -6,6 +6,7 @@ use App\Models\AccountHead;
 use App\Models\Company;
 use App\Models\Transaction;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\WithHeadings;
@@ -13,9 +14,11 @@ use Maatwebsite\Excel\Concerns\WithTitle;
 
 class TransactionSummarySheet implements FromCollection, WithHeadings, WithTitle
 {
+    /** @param Builder<Transaction>|null $baseQuery */
     public function __construct(
         public ?string $from = null,
         public ?string $until = null,
+        public ?Builder $baseQuery = null,
     ) {}
 
     public function title(): string
@@ -42,13 +45,20 @@ class TransactionSummarySheet implements FromCollection, WithHeadings, WithTitle
      */
     public function collection(): Collection
     {
-        /** @var Company $tenant */
-        $tenant = Filament::getTenant();
+        if ($this->baseQuery) {
+            $query = $this->baseQuery
+                ->clone()
+                ->whereNotNull('account_head_id')
+                ->with('accountHead');
+        } else {
+            /** @var Company $tenant */
+            $tenant = Filament::getTenant();
 
-        $query = Transaction::query()
-            ->where('company_id', $tenant->id)
-            ->whereNotNull('account_head_id')
-            ->with('accountHead');
+            $query = Transaction::query()
+                ->where('company_id', $tenant->id)
+                ->whereNotNull('account_head_id')
+                ->with('accountHead');
+        }
 
         if ($this->from) {
             $query->whereDate('date', '>=', $this->from);

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -7,11 +7,14 @@ use App\Enums\MatchMethod;
 use App\Enums\MatchType;
 use App\Enums\ReconciliationStatus;
 use App\Enums\StatementType;
+use App\Enums\UserRole;
 use App\Exports\TransactionCsvExport;
 use App\Exports\TransactionExcelExport;
 use App\Filament\Resources\TransactionResource\Pages;
 use App\Jobs\MatchTransactionHeads;
 use App\Models\AccountHead;
+use App\Models\Company;
+use App\Models\CreditCard;
 use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
@@ -19,17 +22,20 @@ use App\Services\Reconciliation\ReconciliationService;
 use App\Services\TallyExport\TallyExportService;
 use BackedEnum;
 use Filament\Actions;
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Livewire\Component;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -298,13 +304,13 @@ class TransactionResource extends Resource
                                 ->label('Target Company')
                                 ->options(function () {
                                     $user = Auth::user();
-                                    /** @var \App\Models\Company|null $currentTenant */
-                                    $currentTenant = \Filament\Facades\Filament::getTenant();
+                                    /** @var Company|null $currentTenant */
+                                    $currentTenant = Filament::getTenant();
 
-                                    return \App\Models\Company::query()
+                                    return Company::query()
                                         ->whereHas('users', function (Builder $q) use ($user) {
                                             $q->where('users.id', $user->id)
-                                                ->where('company_user.role', \App\Enums\UserRole::Admin->value);
+                                                ->where('company_user.role', UserRole::Admin->value);
                                         })
                                         ->when($currentTenant, fn (Builder $q) => $q->where('companies.id', '!=', $currentTenant->id))
                                         ->pluck('name', 'id');
@@ -313,7 +319,7 @@ class TransactionResource extends Resource
                                 ->required(),
                         ])
                         ->action(function (Collection $records, array $data) {
-                            $targetCompany = \App\Models\Company::find($data['target_company_id']);
+                            $targetCompany = Company::find($data['target_company_id']);
 
                             $creditCardIds = $records->pluck('imported_file_id')
                                 ->map(fn ($fileId) => ImportedFile::find($fileId)?->credit_card_id)
@@ -321,7 +327,7 @@ class TransactionResource extends Resource
                                 ->unique();
 
                             $allShared = $creditCardIds->every(function ($cardId) use ($targetCompany) {
-                                $card = \App\Models\CreditCard::find($cardId);
+                                $card = CreditCard::find($cardId);
 
                                 return $card && $card->isSharedWith($targetCompany);
                             });
@@ -387,9 +393,12 @@ class TransactionResource extends Resource
                             Forms\Components\DatePicker::make('until')
                                 ->label('Until Date'),
                         ])
-                        ->action(function (array $data): StreamedResponse {
-                            $query = Transaction::whereNotNull('account_head_id')
-                                ->with(['accountHead', 'importedFile.company', 'importedFile.bankAccount'])
+                        ->action(function (array $data, Component $livewire): StreamedResponse {
+                            $query = $livewire instanceof HasTable
+                                ? $livewire->getTableQueryForExport()->whereNotNull('account_head_id')
+                                : Transaction::whereNotNull('account_head_id');
+
+                            $query->with(['accountHead', 'importedFile.company', 'importedFile.bankAccount'])
                                 ->orderBy('date');
 
                             if (! empty($data['from'])) {
@@ -402,7 +411,7 @@ class TransactionResource extends Resource
 
                             $transactions = $query->get();
 
-                            $service = new TallyExportService;
+                            $service = app(TallyExportService::class);
                             $xml = $service->exportTransactions($transactions);
 
                             return response()->streamDownload(
@@ -421,10 +430,11 @@ class TransactionResource extends Resource
                             Forms\Components\DatePicker::make('until')
                                 ->label('Until Date'),
                         ])
-                        ->action(function (array $data): BinaryFileResponse {
+                        ->action(function (array $data, Component $livewire): BinaryFileResponse {
                             $export = new TransactionCsvExport(
                                 from: $data['from'] ?? null,
                                 until: $data['until'] ?? null,
+                                baseQuery: self::resolveExportBaseQuery($livewire),
                             );
 
                             return Excel::download(
@@ -442,10 +452,11 @@ class TransactionResource extends Resource
                             Forms\Components\DatePicker::make('until')
                                 ->label('Until Date'),
                         ])
-                        ->action(function (array $data): BinaryFileResponse {
+                        ->action(function (array $data, Component $livewire): BinaryFileResponse {
                             $export = new TransactionExcelExport(
                                 from: $data['from'] ?? null,
                                 until: $data['until'] ?? null,
+                                baseQuery: self::resolveExportBaseQuery($livewire),
                             );
 
                             return Excel::download(
@@ -462,6 +473,14 @@ class TransactionResource extends Resource
             ->emptyStateHeading('No transactions yet')
             ->emptyStateDescription('Transactions appear here after you upload and process a bank statement or invoice.')
             ->emptyStateIcon('heroicon-o-banknotes');
+    }
+
+    /** @return Builder<Transaction>|null */
+    private static function resolveExportBaseQuery(Component $livewire): ?Builder
+    {
+        return $livewire instanceof HasTable
+            ? $livewire->getTableQueryForExport()
+            : null;
     }
 
     public static function getRelations(): array

--- a/tests/Feature/Exports/TransactionExportTest.php
+++ b/tests/Feature/Exports/TransactionExportTest.php
@@ -1,10 +1,74 @@
 <?php
 
+use App\Enums\MappingType;
 use App\Exports\TransactionCsvExport;
 use App\Exports\TransactionExcelExport;
+use App\Exports\TransactionSummarySheet;
 use App\Models\AccountHead;
+use App\Models\Company;
 use App\Models\Transaction;
+use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Facades\Excel;
+
+describe('export base query filtering', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('csv export scopes results to base query when provided', function () {
+        $head = AccountHead::factory()->create(['name' => 'Office Supplies']);
+        $other = AccountHead::factory()->create(['name' => 'Travel']);
+
+        Transaction::factory()->count(3)->mapped($head)->create();
+        Transaction::factory()->count(2)->mapped($other)->create();
+
+        $baseQuery = Transaction::query()->where('account_head_id', $head->id);
+        $export = new TransactionCsvExport(baseQuery: $baseQuery);
+
+        expect($export->query()->count())->toBe(3);
+    });
+
+    it('summary sheet scopes results to base query when provided', function () {
+        $head = AccountHead::factory()->create(['name' => 'Office Supplies']);
+        $other = AccountHead::factory()->create(['name' => 'Travel']);
+
+        Transaction::factory()->count(3)->mapped($head)->create();
+        Transaction::factory()->count(2)->mapped($other)->create();
+
+        $baseQuery = Transaction::query()->where('account_head_id', $head->id);
+        $sheet = new TransactionSummarySheet(baseQuery: $baseQuery);
+        $data = $sheet->collection();
+
+        expect($data)->toHaveCount(1)
+            ->and($data->first()['account_head'])->toBe('Office Supplies');
+    });
+
+    it('excel export passes base query to transaction detail sheet', function () {
+        $head = AccountHead::factory()->create();
+        $other = AccountHead::factory()->create();
+
+        Transaction::factory()->count(3)->mapped($head)->create();
+        Transaction::factory()->count(2)->mapped($other)->create();
+
+        $baseQuery = Transaction::query()->where('account_head_id', $head->id);
+        $export = new TransactionExcelExport(baseQuery: $baseQuery);
+        $sheets = $export->sheets();
+
+        expect($sheets[0]->query()->count())->toBe(3);
+    });
+
+    it('csv export still includes all mapped transactions when no base query given', function () {
+        $head = AccountHead::factory()->create();
+        $other = AccountHead::factory()->create();
+
+        Transaction::factory()->count(3)->mapped($head)->create();
+        Transaction::factory()->count(2)->mapped($other)->create();
+
+        $export = new TransactionCsvExport;
+
+        expect($export->query()->count())->toBe(5);
+    });
+});
 
 describe('TransactionCsvExport', function () {
     beforeEach(function () {
@@ -87,20 +151,20 @@ describe('TransactionCsvExport', function () {
         $ownTransaction = Transaction::factory()->mapped($head)->create();
 
         // Insert a transaction for a different company directly via DB
-        $otherCompany = \App\Models\Company::factory()->create();
+        $otherCompany = Company::factory()->create();
         $otherHead = AccountHead::factory()->create();
-        \Illuminate\Support\Facades\DB::table('transactions')->insert([
+        DB::table('transactions')->insert([
             'company_id' => $otherCompany->id,
             'imported_file_id' => $ownTransaction->imported_file_id,
             'date' => now(),
             'description' => encrypt('Other company transaction'),
             'debit' => encrypt('1000'),
             'account_head_id' => $otherHead->id,
-            'mapping_type' => \App\Enums\MappingType::Manual->value,
+            'mapping_type' => MappingType::Manual->value,
             'created_at' => now(),
             'updated_at' => now(),
         ]);
-        $otherTransactionId = (int) \Illuminate\Support\Facades\DB::getPdo()->lastInsertId();
+        $otherTransactionId = (int) DB::getPdo()->lastInsertId();
 
         $export = new TransactionCsvExport;
         $results = $export->query()->get();

--- a/tests/Feature/Filament/TransactionResourceTest.php
+++ b/tests/Feature/Filament/TransactionResourceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\MappingType;
+use App\Enums\MatchMethod;
 use App\Enums\MatchStatus;
 use App\Enums\ReconciliationStatus;
 use App\Enums\StatementType;
@@ -11,7 +12,9 @@ use App\Models\AccountHead;
 use App\Models\ImportedFile;
 use App\Models\ReconciliationMatch;
 use App\Models\Transaction;
+use App\Services\TallyExport\TallyExportService;
 use Illuminate\Support\Facades\Queue;
+use Maatwebsite\Excel\Facades\Excel;
 
 use function Pest\Livewire\livewire;
 
@@ -136,6 +139,68 @@ describe('TransactionResource', function () {
         });
     });
 
+    describe('export actions respect active table filters', function () {
+        it('tally export exports only transactions matching active account head filter', function () {
+            $head = AccountHead::factory()->create();
+            $other = AccountHead::factory()->create();
+
+            Transaction::factory()->count(3)->mapped($head)->create(['date' => now()]);
+            Transaction::factory()->count(2)->mapped($other)->create(['date' => now()]);
+
+            $capturedTransactions = null;
+            $mock = Mockery::mock(TallyExportService::class);
+            $mock->shouldReceive('exportTransactions')
+                ->once()
+                ->andReturnUsing(function ($transactions) use (&$capturedTransactions) {
+                    $capturedTransactions = $transactions;
+
+                    return '<?xml version="1.0"?><ENVELOPE></ENVELOPE>';
+                });
+            app()->instance(TallyExportService::class, $mock);
+
+            livewire(ListTransactions::class)
+                ->filterTable('account_head_id', $head->id)
+                ->callTableAction('export_tally', data: [
+                    'from' => now()->subMonth()->toDateString(),
+                    'until' => now()->addDay()->toDateString(),
+                ])
+                ->assertHasNoTableActionErrors();
+
+            expect($capturedTransactions)->toHaveCount(3)
+                ->and($capturedTransactions->pluck('account_head_id')->unique()->first())->toBe($head->id);
+        });
+
+        it('csv export action succeeds with active account head filter applied', function () {
+            Excel::fake();
+
+            $head = AccountHead::factory()->create();
+            $other = AccountHead::factory()->create();
+
+            Transaction::factory()->count(3)->mapped($head)->create();
+            Transaction::factory()->count(2)->mapped($other)->create();
+
+            livewire(ListTransactions::class)
+                ->filterTable('account_head_id', $head->id)
+                ->callTableAction('export_csv', data: ['from' => null, 'until' => null])
+                ->assertHasNoTableActionErrors();
+        });
+
+        it('excel export action succeeds with active account head filter applied', function () {
+            Excel::fake();
+
+            $head = AccountHead::factory()->create();
+            $other = AccountHead::factory()->create();
+
+            Transaction::factory()->count(3)->mapped($head)->create();
+            Transaction::factory()->count(2)->mapped($other)->create();
+
+            livewire(ListTransactions::class)
+                ->filterTable('account_head_id', $head->id)
+                ->callTableAction('export_excel', data: ['from' => null, 'until' => null])
+                ->assertHasNoTableActionErrors();
+        });
+    });
+
     it('can match a bank transaction to an invoice via match_invoice action', function () {
         $bankFile = ImportedFile::factory()->completed()->create([
             'statement_type' => StatementType::Bank,
@@ -166,7 +231,7 @@ describe('TransactionResource', function () {
         $match = ReconciliationMatch::first();
         expect($match->bank_transaction_id)->toBe($bankTxn->id)
             ->and($match->invoice_transaction_id)->toBe($invoiceTxn->id)
-            ->and($match->match_method)->toBe(\App\Enums\MatchMethod::Manual)
+            ->and($match->match_method)->toBe(MatchMethod::Manual)
             ->and($match->status)->toBe(MatchStatus::Confirmed);
 
         $bankTxn->refresh();


### PR DESCRIPTION
## Summary
- Export actions (Tally XML, CSV, Excel) ignored active Filament table filters and exported all transactions regardless of what the user had filtered
- Fixed by injecting the Livewire component into each action closure and using `getTableQueryForExport()` as the base query
- Export classes now accept an optional `?Builder<Transaction> $baseQuery` — when provided it is used instead of rebuilding from scratch

## Test plan
- [ ] Apply an Account Head filter on the Transactions page, export CSV — verify only filtered transactions appear
- [ ] Apply a Mapping Type filter, export Excel — Summary sheet should show totals only for the filtered subset
- [ ] Apply a filter, export Tally XML — verify XML only contains matching transactions
- [ ] Export with no filters active — verify behavior is unchanged (all mapped transactions exported)
- [ ] Run `php artisan test tests/Feature/Exports/TransactionExportTest.php tests/Feature/Filament/TransactionResourceTest.php --compact` — all 25 tests should pass

Closes #160