### PR TITLE
fix(ui): redirect to list after save/create on all resource pages

### DIFF
--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages\Auth;
 
 use Filament\Auth\Pages\EditProfile as BaseEditProfile;
+use Filament\Facades\Filament;
 use Filament\Schemas\Components\Component;
 
 class EditProfile extends BaseEditProfile
@@ -11,5 +12,10 @@ class EditProfile extends BaseEditProfile
     {
         return parent::getEmailFormComponent()
             ->disabled();
+    }
+
+    protected function getRedirectUrl(): ?string
+    {
+        return Filament::getHomeUrl();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -51,6 +51,8 @@ class AdminPanelProvider extends PanelProvider
             ->tenant(Company::class)
             ->tenantRegistration(RegisterCompany::class)
             ->tenantProfile(EditCompanySettings::class)
+            ->resourceCreatePageRedirect('index')
+            ->resourceEditPageRedirect('index')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([])

--- a/tests/Feature/Filament/AccountHeadResourceTest.php
+++ b/tests/Feature/Filament/AccountHeadResourceTest.php
@@ -118,6 +118,26 @@ describe('AccountHeadResource', function () {
             ->assertCanNotSeeTableRecords([$inactive]);
     });
 
+    it('redirects to the list after creating an account head', function () {
+        livewire(CreateAccountHead::class)
+            ->fillForm([
+                'name' => 'Redirect Test Head',
+                'group_name' => 'Current Assets',
+                'is_active' => true,
+            ])
+            ->call('create')
+            ->assertRedirect(AccountHeadResource::getUrl('index'));
+    });
+
+    it('redirects to the list after editing an account head', function () {
+        $head = AccountHead::factory()->create();
+
+        livewire(EditAccountHead::class, ['record' => $head->getRouteKey()])
+            ->fillForm(['name' => 'Updated Name'])
+            ->call('save')
+            ->assertRedirect(AccountHeadResource::getUrl('index'));
+    });
+
     it('shows empty state with import guidance when no heads exist', function () {
         livewire(ListAccountHeads::class)
             ->assertSee('No account heads yet')

--- a/tests/Feature/Filament/EditProfileTest.php
+++ b/tests/Feature/Filament/EditProfileTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Filament\Pages\Auth\EditProfile;
+use Filament\Facades\Filament;
+
+use function Pest\Livewire\livewire;
+
+describe('EditProfile page', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render the profile page', function () {
+        livewire(EditProfile::class)->assertSuccessful();
+    });
+
+    it('redirects after saving the profile', function () {
+        livewire(EditProfile::class)
+            ->fillForm(['name' => 'Updated Name'])
+            ->call('save')
+            ->assertRedirect(Filament::getHomeUrl());
+    });
+});

--- a/tests/Feature/Filament/HeadMappingResourceTest.php
+++ b/tests/Feature/Filament/HeadMappingResourceTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use App\Enums\MatchType;
+use App\Filament\Resources\HeadMappingResource;
 use App\Filament\Resources\HeadMappingResource\Pages\CreateHeadMapping;
 use App\Filament\Resources\HeadMappingResource\Pages\EditHeadMapping;
 use App\Filament\Resources\HeadMappingResource\Pages\ListHeadMappings;
 use App\Models\AccountHead;
+use App\Models\BankAccount;
 use App\Models\HeadMapping;
 
 use function Pest\Livewire\livewire;
@@ -91,6 +93,28 @@ describe('HeadMappingResource', function () {
         expect($mapping->fresh()->pattern)->toBe('NEW_PATTERN');
     });
 
+    it('redirects to the list after creating a head mapping', function () {
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+
+        livewire(CreateHeadMapping::class)
+            ->fillForm([
+                'pattern' => 'REDIRECT_TEST',
+                'match_type' => MatchType::Contains->value,
+                'account_head_id' => $head->id,
+            ])
+            ->call('create')
+            ->assertRedirect(HeadMappingResource::getUrl('index'));
+    });
+
+    it('redirects to the list after editing a head mapping', function () {
+        $mapping = HeadMapping::factory()->create(['company_id' => tenant()->id]);
+
+        livewire(EditHeadMapping::class, ['record' => $mapping->getRouteKey()])
+            ->fillForm(['pattern' => 'UPDATED_PATTERN'])
+            ->call('save')
+            ->assertRedirect(HeadMappingResource::getUrl('index'));
+    });
+
     it('can delete a head mapping from the table', function () {
         $mapping = HeadMapping::factory()->create(['company_id' => tenant()->id]);
 
@@ -154,7 +178,7 @@ describe('HeadMappingResource', function () {
 
     it('can create a mapping with bank name from select', function () {
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
-        \App\Models\BankAccount::factory()->create(['company_id' => tenant()->id, 'name' => 'ICICI Bank']);
+        BankAccount::factory()->create(['company_id' => tenant()->id, 'name' => 'ICICI Bank']);
 
         livewire(CreateHeadMapping::class)
             ->fillForm([


### PR DESCRIPTION
## Summary
- Adds `resourceCreatePageRedirect('index')` and `resourceEditPageRedirect('index')` to `AdminPanelProvider` — a single panel-level config covering all Edit/Create resource pages (AccountHeads, HeadMappings, BankAccounts, CreditCards, RecurringPatterns)
- Adds `getRedirectUrl()` override to `EditProfile` to redirect to the dashboard (`Filament::getHomeUrl()`) after saving profile/password

## Test plan
- [ ] `php artisan test --filter=AccountHeadResourceTest` — redirects to list after create and edit
- [ ] `php artisan test --filter=HeadMappingResourceTest` — redirects to list after create and edit
- [ ] `php artisan test --filter=EditProfileTest` — redirects to dashboard after profile save
- [ ] Navigate to `/account-heads/{id}/edit`, save — confirm redirected to `/account-heads`
- [ ] Create a mapping rule — confirm redirected to list
- [ ] Update profile — confirm redirected to dashboard

Closes #163