### PR TITLE
fix(imports): sanitise database errors before storing as user-facing error_message

### DIFF
--- a/app/Jobs/ProcessImportedFile.php
+++ b/app/Jobs/ProcessImportedFile.php
@@ -13,6 +13,7 @@ use App\Services\DocumentProcessor\DocumentProcessor;
 use App\Services\DuplicateDetectionService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -68,7 +69,7 @@ class ProcessImportedFile implements ShouldQueue
 
             $this->importedFile->update([
                 'status' => ImportStatus::Failed,
-                'error_message' => 'Statement processing failed: '.mb_substr($e->getMessage(), 0, 500),
+                'error_message' => $this->sanitiseErrorMessage($e, 'Statement processing failed'),
             ]);
 
             throw $e;
@@ -82,7 +83,7 @@ class ProcessImportedFile implements ShouldQueue
     {
         $this->importedFile->update([
             'status' => ImportStatus::Failed,
-            'error_message' => 'Processing permanently failed: '.mb_substr($exception->getMessage(), 0, 500),
+            'error_message' => $this->sanitiseErrorMessage($exception, 'Processing permanently failed'),
         ]);
 
         Log::error('ProcessImportedFile permanently failed', [
@@ -123,6 +124,15 @@ class ProcessImportedFile implements ShouldQueue
         if ($statementType === StatementType::Invoice) {
             SuggestReconciliationMatches::dispatch($this->importedFile);
         }
+    }
+
+    private function sanitiseErrorMessage(\Throwable $exception, string $prefix): string
+    {
+        if ($exception instanceof QueryException || $exception instanceof \PDOException) {
+            return "{$prefix}: one or more transactions could not be saved. Please check the file format and try again.";
+        }
+
+        return "{$prefix}: ".mb_substr($exception->getMessage(), 0, 500);
     }
 
     private function scanForDuplicates(): void

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -12,6 +12,8 @@ use App\Models\AccountHead;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Services\DocumentProcessor\DocumentProcessor;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -80,7 +82,7 @@ describe('ProcessImportedFile auto-suggestion dispatch', function () {
 describe('ProcessImportedFile job', function () {
     it('implements ShouldQueue', function () {
         expect(ProcessImportedFile::class)
-            ->toImplement(Illuminate\Contracts\Queue\ShouldQueue::class);
+            ->toImplement(ShouldQueue::class);
     });
 
     it('sets status to failed with error message on exception', function () {
@@ -95,7 +97,7 @@ describe('ProcessImportedFile job', function () {
 
         try {
             $job->handle(app(DocumentProcessor::class));
-        } catch (\Throwable) {
+        } catch (Throwable) {
             // Expected — job rethrows after logging
         }
 
@@ -140,6 +142,51 @@ describe('ProcessImportedFile job', function () {
         $file->refresh();
         expect($file->status)->toBe(ImportStatus::Failed)
             ->and($file->error_message)->toContain('permanently failed');
+    });
+
+    it('does not expose raw SQL in error_message when a database error occurs during handle', function () {
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::Pending]);
+
+        $rawSql = 'insert into "transactions" ("company_id", "date") values (4, ?)';
+        $dbMessage = "SQLSTATE[23502]: Not null violation: 7 ERROR: null value in column \"date\" (Connection: pgsql, Host: 127.0.0.1, Port: 5432, Database: virtual_cfo, SQL: {$rawSql})";
+
+        $this->mock(DocumentProcessor::class, function ($mock) use ($dbMessage, $rawSql) {
+            $mock->shouldReceive('process')
+                ->andThrow(new QueryException('pgsql', $rawSql, [], new RuntimeException($dbMessage)));
+        });
+
+        Log::shouldReceive('error')->once();
+
+        $job = new ProcessImportedFile($file);
+
+        try {
+            $job->handle(app(DocumentProcessor::class));
+        } catch (Throwable) {
+            // Expected — job rethrows
+        }
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Failed)
+            ->and($file->error_message)->not->toContain('SQLSTATE')
+            ->and($file->error_message)->not->toContain('127.0.0.1')
+            ->and($file->error_message)->not->toContain('insert into');
+    });
+
+    it('does not expose raw SQL in error_message on permanent failure with a database error', function () {
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::Processing]);
+        $job = new ProcessImportedFile($file);
+
+        $rawSql = 'insert into "transactions" ("company_id", "date") values (4, ?)';
+        $dbMessage = "SQLSTATE[23502]: Not null violation: 7 ERROR: null value in column \"date\" (Connection: pgsql, Host: 127.0.0.1, Port: 5432, Database: virtual_cfo, SQL: {$rawSql})";
+        $dbException = new QueryException('pgsql', $rawSql, [], new RuntimeException($dbMessage));
+
+        $job->failed($dbException);
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Failed)
+            ->and($file->error_message)->not->toContain('SQLSTATE')
+            ->and($file->error_message)->not->toContain('127.0.0.1')
+            ->and($file->error_message)->not->toContain('insert into');
     });
 });
 
@@ -265,7 +312,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
 
         try {
             $job->handle(app(DocumentProcessor::class));
-        } catch (\Throwable) {
+        } catch (Throwable) {
             // Expected — missing transactions key
         }
 


### PR DESCRIPTION
## Summary
- Adds a private \`sanitiseErrorMessage()\` helper in \`ProcessImportedFile\` that returns a generic message when a \`QueryException\` or \`PDOException\` is thrown, preventing raw SQL, host/port details, and encrypted values from appearing in \`error_message\` on the Imported File detail page
- Deduplicates the sanitisation logic between \`handle()\` and \`failed()\`
- Full exception details continue to be logged internally

## Test plan
- [ ] \`php artisan test --filter=ProcessImportedFile\` — 24 tests pass
- [ ] Upload a CSV that triggers a null column constraint violation → error_message shows friendly text, not raw SQL
- [ ] Verify \`storage/logs/laravel.log\` still contains the full exception for debugging

Closes #159