### PR TITLE
fix(download): allow soft-deleted imported files to be downloaded

### DIFF
--- a/app/Http/Controllers/ImportedFileDownloadController.php
+++ b/app/Http/Controllers/ImportedFileDownloadController.php
@@ -16,14 +16,18 @@ class ImportedFileDownloadController
     {
         $this->authorize('view', $importedFile);
 
-        if (! Storage::disk('local')->exists($importedFile->file_path)) {
+        $disk = Storage::disk('local');
+
+        if (! $disk->exists($importedFile->file_path)) {
             throw new NotFoundHttpException('File not found on disk.');
         }
 
-        return Storage::disk('local')->download(
+        $mimeType = $disk->mimeType($importedFile->file_path) ?: 'application/octet-stream';
+
+        return $disk->download(
             $importedFile->file_path,
             $importedFile->original_filename,
-            ['Content-Type' => 'application/pdf']
+            ['Content-Type' => $mimeType]
         );
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,13 @@ use App\Http\Controllers\HealthCheckController;
 use App\Http\Controllers\ImportedFileDownloadController;
 use App\Http\Controllers\ZohoOAuthCallbackController;
 use App\Http\Controllers\ZohoOAuthRedirectController;
+use App\Mail\InvitationMail;
+use App\Models\ImportedFile;
+use App\Models\Invitation;
+use App\Models\User;
+use App\Notifications\ImportFailedNotification;
+use App\Notifications\InvitationAcceptedNotification;
+use App\Notifications\MemberRoleChangedNotification;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 
@@ -19,7 +26,8 @@ Route::get('/invitations/{token}/accept', fn (string $token) => redirect("/admin
 
 Route::get('/admin/imported-files/{importedFile}/download', ImportedFileDownloadController::class)
     ->middleware('auth')
-    ->name('imported-files.download');
+    ->name('imported-files.download')
+    ->withTrashed();
 
 Route::get('/connectors/zoho/{company}/redirect', ZohoOAuthRedirectController::class)
     ->middleware('auth')
@@ -33,8 +41,8 @@ if (app()->environment('local')) {
     Route::prefix('dev/mail-preview')->group(function () {
         Route::get('/invitation', function () {
             DB::beginTransaction();
-            $invitation = App\Models\Invitation::factory()->create();
-            $html = (new App\Mail\InvitationMail($invitation))->render();
+            $invitation = Invitation::factory()->create();
+            $html = (new InvitationMail($invitation))->render();
             DB::rollBack();
 
             return $html;
@@ -42,8 +50,8 @@ if (app()->environment('local')) {
 
         Route::get('/import-failed', function () {
             DB::beginTransaction();
-            $file = App\Models\ImportedFile::factory()->failed('PDF parsing error')->create();
-            $html = (new App\Notifications\ImportFailedNotification($file))
+            $file = ImportedFile::factory()->failed('PDF parsing error')->create();
+            $html = (new ImportFailedNotification($file))
                 ->toMail($file->uploader)
                 ->render();
             DB::rollBack();
@@ -53,8 +61,8 @@ if (app()->environment('local')) {
 
         Route::get('/role-changed', function () {
             DB::beginTransaction();
-            $user = App\Models\User::factory()->create();
-            $html = (new App\Notifications\MemberRoleChangedNotification(
+            $user = User::factory()->create();
+            $html = (new MemberRoleChangedNotification(
                 companyName: 'Zysk Technologies',
                 newRole: 'Admin',
             ))->toMail($user)
@@ -66,8 +74,8 @@ if (app()->environment('local')) {
 
         Route::get('/invitation-accepted', function () {
             DB::beginTransaction();
-            $invitation = App\Models\Invitation::factory()->accepted()->create();
-            $html = (new App\Notifications\InvitationAcceptedNotification($invitation))
+            $invitation = Invitation::factory()->accepted()->create();
+            $html = (new InvitationAcceptedNotification($invitation))
                 ->toMail($invitation->inviter)
                 ->render();
             DB::rollBack();

--- a/tests/Feature/Filament/ImportedFileDownloadTest.php
+++ b/tests/Feature/Filament/ImportedFileDownloadTest.php
@@ -91,6 +91,61 @@ describe('ImportedFile Download', function () {
         });
     });
 
+    describe('soft-deleted records', function () {
+        it('allows downloading a soft-deleted file', function () {
+            asUser();
+
+            Storage::disk('local')->put('statements/soft-deleted.pdf', 'fake pdf content');
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/soft-deleted.pdf',
+                'original_filename' => 'soft-deleted.pdf',
+            ]);
+
+            $file->delete();
+
+            $this->get(route('imported-files.download', $file->id))
+                ->assertOk()
+                ->assertHeader('content-type', 'application/pdf')
+                ->assertHeader('content-disposition', 'attachment; filename=soft-deleted.pdf');
+
+            Storage::disk('local')->delete('statements/soft-deleted.pdf');
+        });
+
+        it('returns 404 for soft-deleted file when physical file is gone', function () {
+            asUser();
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/gone.pdf',
+                'original_filename' => 'gone.pdf',
+            ]);
+
+            $file->delete();
+
+            $this->get(route('imported-files.download', $file->id))
+                ->assertNotFound();
+        });
+    });
+
+    describe('mime type detection', function () {
+        it('detects application/pdf for PDF files', function () {
+            asUser();
+
+            Storage::disk('local')->put('statements/mime-pdf.pdf', '%PDF-1.4 fake pdf');
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/mime-pdf.pdf',
+                'original_filename' => 'mime-pdf.pdf',
+            ]);
+
+            $this->get(route('imported-files.download', $file))
+                ->assertOk()
+                ->assertHeader('content-type', 'application/pdf');
+
+            Storage::disk('local')->delete('statements/mime-pdf.pdf');
+        });
+    });
+
     describe('table download action', function () {
         beforeEach(function () {
             asUser();


### PR DESCRIPTION
## Summary

- Add `.withTrashed()` to the download route so soft-deleted `ImportedFile` records are resolved by route model binding (was silently returning 404)
- Replace hardcoded `Content-Type: application/pdf` with dynamic mime type detection via `Storage::mimeType()`, correctly handling CSV/Excel imports
- Refactor: extract `Storage::disk('local')` to a local variable to remove repetition

## Test plan

- [x] Soft-deleted file with physical file present → 200 + correct Content-Disposition
- [x] Soft-deleted file with physical file missing → 404
- [x] Mime type detection returns correct Content-Type for PDF
- [x] Existing tests (auth, viewer role, unauthenticated, table/view actions) still pass

Closes #165