### PR TITLE
fix(imports): handle XLSX date parsing and sanitise error messages

### DIFF
--- a/app/Jobs/ProcessImportedFile.php
+++ b/app/Jobs/ProcessImportedFile.php
@@ -132,7 +132,7 @@ class ProcessImportedFile implements ShouldQueue
             return "{$prefix}: one or more transactions could not be saved. Please check the file format and try again.";
         }
 
-        return "{$prefix}: ".mb_substr($exception->getMessage(), 0, 500);
+        return "{$prefix}: a processing error occurred. Please try again or contact support.";
     }
 
     private function scanForDuplicates(): void

--- a/app/Notifications/ImportFailedNotification.php
+++ b/app/Notifications/ImportFailedNotification.php
@@ -33,7 +33,7 @@ class ImportFailedNotification extends Notification implements ShouldQueue
     {
         return FilamentNotification::make()
             ->title('Import failed')
-            ->body("{$this->importedFile->original_filename} could not be processed: {$this->importedFile->error_message}")
+            ->body("{$this->importedFile->original_filename} could not be processed: {$this->safeErrorMessage()}")
             ->danger()
             ->getDatabaseMessage();
     }
@@ -43,11 +43,25 @@ class ImportFailedNotification extends Notification implements ShouldQueue
         $mail = (new MailMessage)
             ->subject("Import Failed — {$this->importedFile->original_filename}")
             ->line("We weren't able to process **{$this->importedFile->original_filename}**.")
-            ->line("**What went wrong:** {$this->importedFile->error_message}")
+            ->line("**What went wrong:** {$this->safeErrorMessage()}")
             ->line('This usually happens when the file format is unsupported or the statement layout could not be recognized.')
             ->action('Review Imports', url("/admin/{$this->importedFile->company_id}/imported-files"))
             ->line('You can re-upload the file or try a different format (PDF, CSV, or Excel).');
 
         return $this->brandedSalutation($this->brandedGreeting($mail, $notifiable));
+    }
+
+    /**
+     * Return a user-safe error message, stripping any raw SQL or database details.
+     */
+    private function safeErrorMessage(): string
+    {
+        $message = $this->importedFile->error_message ?? 'An unknown error occurred.';
+
+        if (str_contains($message, 'SQLSTATE') || str_contains($message, 'SQL:')) {
+            return 'One or more transactions could not be saved. Please check the file format and try again.';
+        }
+
+        return $message;
     }
 }

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -16,7 +16,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Ai\Files\Document;
+use Laravel\Ai\Responses\StructuredAgentResponse;
 use Maatwebsite\Excel\Facades\Excel;
+use PhpOffice\PhpSpreadsheet\Shared\Date as ExcelDate;
 
 class DocumentProcessor
 {
@@ -90,9 +92,20 @@ class DocumentProcessor
             return;
         }
 
-        DB::transaction(function () use ($file, $rows) {
+        $imported = 0;
+
+        DB::transaction(function () use ($file, $rows, &$imported) {
             foreach ($rows as $row) {
                 $normalized = $this->normalizeStructuredRow($row);
+
+                if ($normalized['date'] === null) {
+                    Log::warning('Skipping row with unparseable date in structured import', [
+                        'file_id' => $file->id,
+                        'row' => $row,
+                    ]);
+
+                    continue;
+                }
 
                 Transaction::create([
                     'company_id' => $file->company_id,
@@ -107,11 +120,13 @@ class DocumentProcessor
                     'raw_data' => $row,
                     'bank_format' => $file->bank_name,
                 ]);
+
+                $imported++;
             }
 
             $file->update([
                 'status' => ImportStatus::Completed,
-                'total_rows' => count($rows),
+                'total_rows' => $imported,
                 'mapped_rows' => 0,
                 'processed_at' => now(),
             ]);
@@ -131,14 +146,48 @@ class DocumentProcessor
             $normalized[strtolower(trim((string) $key))] = $value;
         }
 
+        $rawDate = $this->extractField($normalized, ['date', 'transaction_date', 'txn_date', 'value_date', 'posting_date']);
+
         return [
-            'date' => $this->extractField($normalized, ['date', 'transaction_date', 'txn_date', 'value_date', 'posting_date']),
+            'date' => $this->parseDateField($rawDate),
             'description' => $this->extractField($normalized, ['description', 'narration', 'particulars', 'details', 'transaction_description']),
             'reference' => $this->extractField($normalized, ['reference', 'ref', 'reference_number', 'ref_no', 'cheque_no', 'chq_no']),
             'debit' => $this->extractNumericField($normalized, ['debit', 'debit_amount', 'withdrawal', 'withdrawals', 'dr']),
             'credit' => $this->extractNumericField($normalized, ['credit', 'credit_amount', 'deposit', 'deposits', 'cr']),
             'balance' => $this->extractNumericField($normalized, ['balance', 'closing_balance', 'running_balance', 'available_balance']),
         ];
+    }
+
+    /**
+     * Parse a date value that may be an Excel serial number, a DateTime object, or a date string.
+     *
+     * Returns a Carbon date string (Y-m-d) on success, or null if the value cannot be parsed.
+     */
+    protected function parseDateField(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof \DateTime) {
+            return Carbon::instance($value)->toDateString();
+        }
+
+        if (is_numeric($value)) {
+            try {
+                $dateTime = ExcelDate::excelToDateTimeObject((float) $value);
+
+                return Carbon::instance($dateTime)->toDateString();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        try {
+            return Carbon::parse((string) $value)->toDateString();
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**
@@ -510,7 +559,7 @@ class DocumentProcessor
         $totalAmount = $response['total_amount'] ?? null;
         $currency = $response['currency'] ?? null;
 
-        /** @var \Laravel\Ai\Responses\StructuredAgentResponse $response */
+        /** @var StructuredAgentResponse $response */
         $rawData = $response->toArray();
 
         DB::transaction(function () use ($file, $rawData, $vendorName, $invoiceNumber, $invoiceDate, $totalAmount, $currency) {

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -11,6 +11,7 @@ use App\Jobs\SuggestReconciliationMatches;
 use App\Models\AccountHead;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
+use App\Notifications\ImportFailedNotification;
 use App\Services\DocumentProcessor\DocumentProcessor;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
@@ -187,6 +188,70 @@ describe('ProcessImportedFile job', function () {
             ->and($file->error_message)->not->toContain('SQLSTATE')
             ->and($file->error_message)->not->toContain('127.0.0.1')
             ->and($file->error_message)->not->toContain('insert into');
+    });
+
+    it('stores a sanitised error message for any generic exception type', function () {
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::Pending]);
+
+        $this->mock(DocumentProcessor::class, function ($mock) {
+            $mock->shouldReceive('process')
+                ->andThrow(new RuntimeException('Internal system detail: secret config value at /etc/app/config.php line 42'));
+        });
+
+        Log::shouldReceive('error')->once();
+
+        $job = new ProcessImportedFile($file);
+
+        try {
+            $job->handle(app(DocumentProcessor::class));
+        } catch (Throwable) {
+            // Expected — job rethrows
+        }
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Failed)
+            ->and($file->error_message)->not->toContain('RuntimeException')
+            ->and($file->error_message)->not->toContain('/etc/app/config.php')
+            ->and($file->error_message)->not->toContain('secret config value');
+    });
+});
+
+describe('ImportFailedNotification', function () {
+    it('does not expose raw DB error text in database notification body', function () {
+        $rawSql = 'insert into "transactions" values (?)';
+        $sqlState = "SQLSTATE[23502]: Not null violation (SQL: {$rawSql})";
+
+        $file = ImportedFile::factory()->failed($sqlState)->create([
+            'original_filename' => 'test.xlsx',
+        ]);
+
+        $notification = new ImportFailedNotification($file);
+        $notifiable = $file->uploader;
+
+        $databasePayload = $notification->toDatabase($notifiable);
+
+        $body = $databasePayload['body'] ?? '';
+
+        expect($body)->not->toContain('SQLSTATE')
+            ->and($body)->not->toContain('insert into');
+    });
+
+    it('does not expose raw DB error text in mail notification body', function () {
+        $rawSql = 'insert into "transactions" values (?)';
+        $sqlState = "SQLSTATE[23502]: Not null violation (SQL: {$rawSql})";
+
+        $file = ImportedFile::factory()->failed($sqlState)->create([
+            'original_filename' => 'test.xlsx',
+        ]);
+
+        $notification = new ImportFailedNotification($file);
+        $notifiable = $file->uploader;
+
+        $mail = $notification->toMail($notifiable);
+        $mailLines = implode(' ', $mail->introLines);
+
+        expect($mailLines)->not->toContain('SQLSTATE')
+            ->and($mailLines)->not->toContain('insert into');
     });
 });
 

--- a/tests/Feature/Services/DocumentProcessorTest.php
+++ b/tests/Feature/Services/DocumentProcessorTest.php
@@ -12,6 +12,9 @@ use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Services\DocumentProcessor\DocumentProcessor;
 use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
 
 describe('DocumentProcessor', function () {
     beforeEach(function () {
@@ -47,7 +50,7 @@ describe('DocumentProcessor', function () {
             ]);
 
             $this->processor->detectFormat($file);
-        })->throws(\RuntimeException::class, 'Unsupported file extension: .docx');
+        })->throws(RuntimeException::class, 'Unsupported file extension: .docx');
 
         it('is case-insensitive for extensions', function () {
             $file = ImportedFile::factory()->create([
@@ -658,6 +661,111 @@ describe('DocumentProcessor', function () {
         });
     });
 
+    describe('XLSX parsing', function () {
+        it('parses an XLSX file with string dates and creates transactions', function () {
+            $spreadsheet = new Spreadsheet;
+            $sheet = $spreadsheet->getActiveSheet();
+            $sheet->fromArray([
+                ['Date', 'Description', 'Debit', 'Credit', 'Balance'],
+                ['2024-01-05', 'SALARY JAN 2024', null, 50000, 150000],
+                ['2024-01-10', 'RENT PAYMENT', 15000, null, 135000],
+            ]);
+
+            $tempPath = sys_get_temp_dir().'/test_string_dates.xlsx';
+            (new XlsxWriter($spreadsheet))->save($tempPath);
+            Storage::put('statements/test_string_dates.xlsx', file_get_contents($tempPath));
+            unlink($tempPath);
+
+            $file = ImportedFile::factory()->xlsx()->create([
+                'file_path' => 'statements/test_string_dates.xlsx',
+                'original_filename' => 'bank_string_dates.xlsx',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->total_rows)->toBe(2);
+
+            $transactions = Transaction::where('imported_file_id', $file->id)->get();
+            expect($transactions)->toHaveCount(2)
+                ->and($transactions->first()->date->toDateString())->toBe('2024-01-05')
+                ->and($transactions->first()->description)->toBe('SALARY JAN 2024');
+        });
+
+        it('parses an XLSX file with Excel serial date numbers and creates transactions with correct dates', function () {
+            $spreadsheet = new Spreadsheet;
+            $sheet = $spreadsheet->getActiveSheet();
+
+            // Write headers
+            $sheet->setCellValue('A1', 'Date');
+            $sheet->setCellValue('B1', 'Description');
+            $sheet->setCellValue('C1', 'Debit');
+            $sheet->setCellValue('D1', 'Credit');
+            $sheet->setCellValue('E1', 'Balance');
+
+            // Write date as Excel serial number (45296 = 2024-01-05)
+            $sheet->setCellValueExplicit('A2', 45296, DataType::TYPE_NUMERIC);
+            $sheet->setCellValue('B2', 'SALARY CREDIT');
+            $sheet->setCellValue('C2', null);
+            $sheet->setCellValue('D2', 50000);
+            $sheet->setCellValue('E2', 150000);
+
+            $tempPath = sys_get_temp_dir().'/test_serial_dates.xlsx';
+            (new XlsxWriter($spreadsheet))->save($tempPath);
+            Storage::put('statements/test_serial_dates.xlsx', file_get_contents($tempPath));
+            unlink($tempPath);
+
+            $file = ImportedFile::factory()->xlsx()->create([
+                'file_path' => 'statements/test_serial_dates.xlsx',
+                'original_filename' => 'bank_serial_dates.xlsx',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->total_rows)->toBe(1);
+
+            $transaction = Transaction::where('imported_file_id', $file->id)->first();
+            expect($transaction)->not->toBeNull()
+                ->and($transaction->date->toDateString())->toBe('2024-01-05');
+        });
+
+        it('skips rows with unparseable dates and imports the rest', function () {
+            $spreadsheet = new Spreadsheet;
+            $sheet = $spreadsheet->getActiveSheet();
+            $sheet->fromArray([
+                ['Date', 'Description', 'Debit', 'Credit', 'Balance'],
+                ['2024-01-05', 'VALID TRANSACTION', null, 50000, 150000],
+                ['not-a-date', 'INVALID DATE ROW', 1000, null, 149000],
+                ['2024-01-10', 'ANOTHER VALID', 5000, null, 145000],
+            ]);
+
+            $tempPath = sys_get_temp_dir().'/test_bad_dates.xlsx';
+            (new XlsxWriter($spreadsheet))->save($tempPath);
+            Storage::put('statements/test_bad_dates.xlsx', file_get_contents($tempPath));
+            unlink($tempPath);
+
+            $file = ImportedFile::factory()->xlsx()->create([
+                'file_path' => 'statements/test_bad_dates.xlsx',
+                'original_filename' => 'bank_bad_dates.xlsx',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->status)->toBe(ImportStatus::Completed)
+                ->and($file->total_rows)->toBe(2);
+
+            $transactions = Transaction::where('imported_file_id', $file->id)->get();
+            expect($transactions)->toHaveCount(2);
+        });
+    });
+
     describe('unsupported formats', function () {
         it('throws for unsupported file extensions', function () {
             $file = ImportedFile::factory()->create([
@@ -665,6 +773,6 @@ describe('DocumentProcessor', function () {
             ]);
 
             $this->processor->process($file);
-        })->throws(\RuntimeException::class, 'Unsupported file extension');
+        })->throws(RuntimeException::class, 'Unsupported file extension');
     });
 });


### PR DESCRIPTION
## Summary

Fixes two related bugs discovered during testing:

**Issue 1 — XLSX date parsing (NOT NULL violation)**
- Added `parseDateField()` to `DocumentProcessor` that handles all three date formats from XLSX files: Excel serial numbers (numeric), `DateTime` objects (from PhpSpreadsheet), and string dates
- Rows with unparseable dates are skipped with a `Log::warning` rather than crashing the entire import on a `NOT NULL` constraint violation
- `total_rows` now counts only successfully imported rows

**Issue 2 — Raw DB errors exposed to users**
- `ProcessImportedFile::sanitiseErrorMessage()` now returns a safe generic message for ALL exception types (previously only sanitised `QueryException`/`PDOException`)
- Added `safeErrorMessage()` to `ImportFailedNotification` as defence-in-depth — strips any `SQLSTATE`/`SQL:` fragments before display in `toDatabase()` and `toMail()`

## Test plan

- [x] XLSX with string date column → transactions imported with correct dates
- [x] XLSX with Excel serial number dates → correct Y-m-d dates stored
- [x] XLSX row with unparseable date → row skipped, rest of import succeeds
- [x] Generic `RuntimeException` → `error_message` stores safe generic text (no class name)
- [x] `QueryException` in `handle()` → sanitised message stored
- [x] `QueryException` in `failed()` → sanitised message stored
- [x] `ImportFailedNotification::toDatabase()` → body contains no SQLSTATE text
- [x] `ImportFailedNotification::toMail()` → body contains no SQLSTATE text

Closes #180