### PR TITLE
fix(imports): prevent password autofill and add Set Password on view page

### DIFF
--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -8,6 +8,7 @@ use App\Enums\StatementType;
 use App\Filament\Resources\ImportedFileResource\Pages;
 use App\Jobs\ProcessImportedFile;
 use App\Models\ImportedFile;
+use App\Services\StatementClassifier;
 use BackedEnum;
 use Filament\Actions;
 use Filament\Forms;
@@ -20,6 +21,7 @@ use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Support\Facades\DB;
 
 class ImportedFileResource extends Resource
 {
@@ -79,6 +81,7 @@ class ImportedFileResource extends Resource
                             ->label('PDF Password (optional)')
                             ->password()
                             ->revealable()
+                            ->extraInputAttributes(['autocomplete' => 'new-password'])
                             ->helperText('If the PDF is password-protected, enter the password here.')
                             ->columnSpanFull(),
 
@@ -160,38 +163,7 @@ class ImportedFileResource extends Resource
                         ->url(fn (ImportedFile $record): string => route('imported-files.download', $record))
                         ->openUrlInNewTab(),
 
-                    Actions\Action::make('setPassword')
-                        ->label('Set Password')
-                        ->icon('heroicon-o-key')
-                        ->color('warning')
-                        ->schema([
-                            Forms\Components\TextInput::make('pdf_password')
-                                ->label('PDF Password')
-                                ->password()
-                                ->revealable()
-                                ->required(),
-                        ])
-                        ->modalHeading('Set PDF Password')
-                        ->modalDescription('Enter the password for this PDF. The file will be re-processed automatically.')
-                        ->modalSubmitActionLabel('Decrypt & Process')
-                        ->action(function (ImportedFile $record, array $data) {
-                            $metadata = $record->source_metadata ?? [];
-                            $metadata['manual_password'] = $data['pdf_password'];
-
-                            \Illuminate\Support\Facades\DB::transaction(function () use ($record, $metadata) {
-                                $record->transactions()->delete();
-                                $record->update([
-                                    'source_metadata' => $metadata,
-                                    'status' => ImportStatus::Pending,
-                                    'total_rows' => 0,
-                                    'mapped_rows' => 0,
-                                    'error_message' => null,
-                                ]);
-                            });
-
-                            ProcessImportedFile::dispatch($record);
-                        })
-                        ->visible(fn (ImportedFile $record) => $record->status === ImportStatus::NeedsPassword),
+                    static::makeSetPasswordAction(),
 
                     Actions\Action::make('changeType')
                         ->label('Change Type')
@@ -223,9 +195,9 @@ class ImportedFileResource extends Resource
                         ->color('warning')
                         ->requiresConfirmation()
                         ->action(function (ImportedFile $record) {
-                            $reclassified = (new \App\Services\StatementClassifier)->classifyFromMetadata($record);
+                            $reclassified = (new StatementClassifier)->classifyFromMetadata($record);
 
-                            \Illuminate\Support\Facades\DB::transaction(function () use ($record, $reclassified) {
+                            DB::transaction(function () use ($record, $reclassified) {
                                 $record->transactions()->delete();
                                 $record->update([
                                     'status' => ImportStatus::Pending,
@@ -271,6 +243,43 @@ class ImportedFileResource extends Resource
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);
+    }
+
+    public static function makeSetPasswordAction(): Actions\Action
+    {
+        return Actions\Action::make('setPassword')
+            ->label('Set Password')
+            ->icon('heroicon-o-key')
+            ->color('warning')
+            ->schema([
+                Forms\Components\TextInput::make('pdf_password')
+                    ->label('PDF Password')
+                    ->password()
+                    ->revealable()
+                    ->extraInputAttributes(['autocomplete' => 'new-password'])
+                    ->required(),
+            ])
+            ->modalHeading('Set PDF Password')
+            ->modalDescription('Enter the password for this PDF. The file will be re-processed automatically.')
+            ->modalSubmitActionLabel('Decrypt & Process')
+            ->action(function (ImportedFile $record, array $data): void {
+                $metadata = $record->source_metadata ?? [];
+                $metadata['manual_password'] = $data['pdf_password'];
+
+                DB::transaction(function () use ($record, $metadata): void {
+                    $record->transactions()->delete();
+                    $record->update([
+                        'source_metadata' => $metadata,
+                        'status' => ImportStatus::Pending,
+                        'total_rows' => 0,
+                        'mapped_rows' => 0,
+                        'error_message' => null,
+                    ]);
+                });
+
+                ProcessImportedFile::dispatch($record);
+            })
+            ->visible(fn (ImportedFile $record): bool => $record->status === ImportStatus::NeedsPassword);
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -24,6 +24,8 @@ class ViewImportedFile extends ViewRecord
                 ->color('gray')
                 ->url(fn (): string => route('imported-files.download', $this->record))
                 ->openUrlInNewTab(),
+
+            ImportedFileResource::makeSetPasswordAction(),
         ];
     }
 

--- a/tests/Feature/Filament/ImportedFileResourceTest.php
+++ b/tests/Feature/Filament/ImportedFileResourceTest.php
@@ -15,6 +15,79 @@ use Illuminate\Support\Facades\Queue;
 
 use function Pest\Livewire\livewire;
 
+describe('ImportedFileResource pdf_password autocomplete', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('pdf_password field on create form has autocomplete="new-password"', function () {
+        livewire(CreateImportedFile::class)
+            ->assertSeeHtml('autocomplete="new-password"');
+    });
+
+    it('pdf_password field in setPassword header action accepts a typed password', function () {
+        Queue::fake();
+
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::NeedsPassword]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->callAction('setPassword', data: ['pdf_password' => 'typed-password']);
+
+        $file->refresh();
+        expect($file->source_metadata['manual_password'])->toBe('typed-password');
+    });
+});
+
+describe('ImportedFileResource view page setPassword header action', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('shows setPassword header action when status is NeedsPassword', function () {
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::NeedsPassword]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertActionVisible('setPassword');
+    });
+
+    it('hides setPassword header action when status is not NeedsPassword', function () {
+        $file = ImportedFile::factory()->completed()->create();
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertActionHidden('setPassword');
+    });
+
+    it('hides setPassword header action when status is Pending', function () {
+        $file = ImportedFile::factory()->create(['status' => ImportStatus::Pending]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertActionHidden('setPassword');
+    });
+
+    it('setPassword header action saves password, resets status, and dispatches job', function () {
+        Queue::fake();
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::NeedsPassword,
+            'error_message' => 'This PDF is password-protected.',
+            'total_rows' => 5,
+            'mapped_rows' => 2,
+        ]);
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->callAction('setPassword', data: ['pdf_password' => 'secret123']);
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Pending)
+            ->and($file->error_message)->toBeNull()
+            ->and($file->total_rows)->toBe(0)
+            ->and($file->mapped_rows)->toBe(0)
+            ->and($file->source_metadata['manual_password'])->toBe('secret123');
+
+        Queue::assertPushed(ProcessImportedFile::class, fn ($job) => $job->importedFile->id === $file->id);
+    });
+});
+
 describe('ImportedFileResource reactive form', function () {
     beforeEach(function () {
         asUser();
@@ -266,7 +339,7 @@ describe('ImportedFileResource', function () {
     });
 
     it('shows linked bank account name in table', function () {
-        $account = \App\Models\BankAccount::factory()->create(['company_id' => tenant()->id, 'name' => 'HDFC Bank']);
+        $account = BankAccount::factory()->create(['company_id' => tenant()->id, 'name' => 'HDFC Bank']);
         ImportedFile::factory()->create([
             'company_id' => tenant()->id,
             'bank_account_id' => $account->id,


### PR DESCRIPTION
## Summary

- Adds `autocomplete="new-password"` to the PDF password field on the upload form and Set Password modal so browsers do not autofill login credentials
- Adds a **Set Password** header action to the file view page, visible only when status is `NeedsPassword`, so users can fix the password directly from the error screen without navigating back to the listing
- Extracts shared `makeSetPasswordAction()` static factory on `ImportedFileResource` to eliminate code duplication between the table action and the new view page action

## Test plan

- [ ] Upload a PDF — verify the PDF Password field is empty and browser does not autofill credentials
- [ ] Upload a password-protected PDF without the password — confirm status is `NeedsPassword` and view page shows a **Set Password** button in the header
- [ ] Click **Set Password**, enter the correct password, confirm the file reprocesses and status changes
- [ ] Confirm **Set Password** header action is absent on files with status other than `NeedsPassword`
- [ ] All 33 tests in `ImportedFileResourceTest` pass (6 new tests added)

Closes #187