### PR TITLE
feat(transactions): suggest mapping rule after manual mapping

### DIFF
--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -19,9 +19,11 @@ use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Services\Reconciliation\ReconciliationService;
+use App\Services\RuleSuggestion\RuleSuggestionService;
 use App\Services\TallyExport\TallyExportService;
 use BackedEnum;
 use Filament\Actions;
+use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Notifications\Notification;
@@ -139,7 +141,7 @@ class TransactionResource extends Resource
                     ),
             ])
             ->actions([
-                Actions\Action::make('assign_head')
+                Action::make('assign_head')
                     ->label('Assign Head')
                     ->icon('heroicon-o-tag')
                     ->form([
@@ -164,10 +166,13 @@ class TransactionResource extends Resource
                                     ->count(),
                             ]);
                         });
+
+                        $record->refresh();
+                        self::sendRuleSuggestionNotification($record);
                     }),
 
                 Actions\ActionGroup::make([
-                    Actions\Action::make('create_rule')
+                    Action::make('create_rule')
                         ->label('Create Rule')
                         ->icon('heroicon-o-plus-circle')
                         ->color('info')
@@ -209,7 +214,7 @@ class TransactionResource extends Resource
                         })
                         ->visible(fn (Transaction $record) => $record->account_head_id !== null),
 
-                    Actions\Action::make('match_invoice')
+                    Action::make('match_invoice')
                         ->label('Match Invoice')
                         ->icon('heroicon-o-link')
                         ->color('warning')
@@ -292,6 +297,13 @@ class TransactionResource extends Resource
                                     }
                                 }
                             });
+
+                            /** @var Transaction|null $first */
+                            $first = $records->first();
+                            if ($first) {
+                                $first->refresh();
+                                self::sendRuleSuggestionNotification($first);
+                            }
                         })
                         ->deselectRecordsAfterCompletion(),
 
@@ -360,7 +372,7 @@ class TransactionResource extends Resource
                 ]),
             ])
             ->headerActions([
-                Actions\Action::make('run_ai_matching')
+                Action::make('run_ai_matching')
                     ->label('Run AI Matching')
                     ->icon('heroicon-o-cpu-chip')
                     ->color('warning')
@@ -384,7 +396,7 @@ class TransactionResource extends Resource
                     }),
 
                 Actions\ActionGroup::make([
-                    Actions\Action::make('export_tally')
+                    Action::make('export_tally')
                         ->label('Tally XML')
                         ->icon('heroicon-o-document-text')
                         ->form([
@@ -421,7 +433,7 @@ class TransactionResource extends Resource
                             );
                         }),
 
-                    Actions\Action::make('export_csv')
+                    Action::make('export_csv')
                         ->label('CSV')
                         ->icon('heroicon-o-table-cells')
                         ->form([
@@ -443,7 +455,7 @@ class TransactionResource extends Resource
                             );
                         }),
 
-                    Actions\Action::make('export_excel')
+                    Action::make('export_excel')
                         ->label('Excel')
                         ->icon('heroicon-o-document-arrow-down')
                         ->form([
@@ -473,6 +485,46 @@ class TransactionResource extends Resource
             ->emptyStateHeading('No transactions yet')
             ->emptyStateDescription('Transactions appear here after you upload and process a bank statement or invoice.')
             ->emptyStateIcon('heroicon-o-banknotes');
+    }
+
+    private static function sendRuleSuggestionNotification(Transaction $record): void
+    {
+        $user = Auth::user();
+        /** @var \App\Models\Company|null $tenant */
+        $tenant = Filament::getTenant();
+
+        if (! $user || ! $tenant) {
+            return;
+        }
+
+        $suggestion = app(RuleSuggestionService::class)->suggest($record, $user, $tenant->id);
+
+        if (! $suggestion) {
+            return;
+        }
+
+        Notification::make()
+            ->title('Create a mapping rule?')
+            ->body("{$suggestion->matchCount} similar unmapped transaction(s) found for '{$suggestion->pattern}' → '{$suggestion->accountHeadName}'.")
+            ->info()
+            ->actions([
+                Action::make('create_rule')
+                    ->label('Create Rule')
+                    ->button()
+                    ->dispatchSelf('openRuleSuggestion', [[
+                        'pattern' => $suggestion->pattern,
+                        'accountHeadId' => $suggestion->accountHeadId,
+                        'importedFileId' => $suggestion->importedFileId,
+                        'matchCount' => $suggestion->matchCount,
+                    ]])
+                    ->close(),
+                Action::make('dismiss')
+                    ->label('Dismiss')
+                    ->color('gray')
+                    ->dispatchSelf('dismissRuleSuggestion', [$suggestion->pattern, $tenant->id])
+                    ->close(),
+            ])
+            ->send();
     }
 
     /** @return Builder<Transaction>|null */

--- a/app/Filament/Resources/TransactionResource/Pages/ListTransactions.php
+++ b/app/Filament/Resources/TransactionResource/Pages/ListTransactions.php
@@ -2,11 +2,23 @@
 
 namespace App\Filament\Resources\TransactionResource\Pages;
 
+use App\Enums\MappingType;
+use App\Enums\MatchType;
 use App\Filament\Resources\TransactionResource;
 use App\Filament\Widgets\TransactionStatsOverview;
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Models\User;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\On;
 
 class ListTransactions extends ListRecords
 {
@@ -27,6 +39,60 @@ class ListTransactions extends ListRecords
                 ->extraAttributes([
                     'x-on:click.prevent' => "\$dispatch('start-page-tour')",
                 ]),
+
+            Action::make('suggestRule')
+                ->label('Create Mapping Rule')
+                ->icon('heroicon-o-sparkles')
+                ->color('info')
+                ->form([
+                    Forms\Components\TextInput::make('pattern')
+                        ->label('Pattern')
+                        ->required(),
+
+                    Forms\Components\Select::make('match_type')
+                        ->options(MatchType::class)
+                        ->default(MatchType::Contains)
+                        ->required(),
+
+                    Forms\Components\Select::make('account_head_id')
+                        ->label('Account Head')
+                        ->options(fn () => AccountHead::where('is_active', true)->pluck('name', 'id'))
+                        ->searchable()
+                        ->required(),
+
+                    Forms\Components\Hidden::make('imported_file_id'),
+
+                    Forms\Components\Toggle::make('apply_immediately')
+                        ->label('Apply to matching transactions in this import')
+                        ->default(true),
+                ])
+                ->action(function (array $data): void {
+                    /** @var \App\Models\Company|null $tenant */
+                    $tenant = Filament::getTenant();
+                    $companyId = $tenant?->id;
+
+                    HeadMapping::create([
+                        'pattern' => $data['pattern'],
+                        'match_type' => $data['match_type'],
+                        'account_head_id' => $data['account_head_id'],
+                        'company_id' => $companyId,
+                        'created_by' => Auth::id(),
+                    ]);
+
+                    if ($data['apply_immediately'] && ! empty($data['imported_file_id'])) {
+                        $this->applyRuleToImport(
+                            pattern: $data['pattern'],
+                            matchType: $data['match_type'] instanceof MatchType ? $data['match_type'] : MatchType::from($data['match_type']),
+                            accountHeadId: $data['account_head_id'],
+                            importedFileId: (int) $data['imported_file_id'],
+                        );
+                    }
+
+                    Notification::make()
+                        ->title('Mapping rule created')
+                        ->success()
+                        ->send();
+                }),
         ];
     }
 
@@ -40,5 +106,71 @@ class ListTransactions extends ListRecords
     public function getFooter(): ?View
     {
         return view('livewire.page-tour-embed', ['pageId' => 'transactions']);
+    }
+
+    /** @param array<string, mixed> $data */
+    #[On('openRuleSuggestion')]
+    public function openRuleSuggestion(array $data): void
+    {
+        $this->mountAction('suggestRule', [
+            'pattern' => $data['pattern'] ?? '',
+            'match_type' => MatchType::Contains->value,
+            'account_head_id' => $data['accountHeadId'] ?? null,
+            'imported_file_id' => $data['importedFileId'] ?? null,
+            'apply_immediately' => true,
+        ]);
+    }
+
+    #[On('dismissRuleSuggestion')]
+    public function dismissRuleSuggestion(string $pattern, int $companyId): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $dismissed = $user->dismissed_suggestions ?? [];
+        $key = "{$companyId}:{$pattern}";
+
+        if (! in_array($key, $dismissed)) {
+            $dismissed[] = $key;
+            $user->update(['dismissed_suggestions' => $dismissed]);
+        }
+    }
+
+    private function applyRuleToImport(string $pattern, MatchType $matchType, int $accountHeadId, int $importedFileId): void
+    {
+        $file = ImportedFile::find($importedFileId);
+
+        if (! $file) {
+            return;
+        }
+
+        // Descriptions are encrypted; matching must be done in PHP after loading.
+        $rule = new HeadMapping(['pattern' => $pattern, 'match_type' => $matchType]);
+
+        $toUpdate = Transaction::where('imported_file_id', $importedFileId)
+            ->where('mapping_type', MappingType::Unmapped)
+            ->get()
+            ->filter(fn (Transaction $t) => $rule->matches($t->description));
+
+        foreach ($toUpdate as $t) {
+            $t->update([
+                'account_head_id' => $accountHeadId,
+                'mapping_type' => MappingType::Auto,
+            ]);
+        }
+
+        $count = $toUpdate->count();
+
+        $file->update([
+            'mapped_rows' => $file->transactions()
+                ->where('mapping_type', '!=', MappingType::Unmapped)
+                ->count(),
+        ]);
+
+        if ($count > 0) {
+            Notification::make()
+                ->title("Rule applied to {$count} transaction(s)")
+                ->success()
+                ->send();
+        }
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,6 +33,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         'password',
         'role',
         'toured_pages',
+        'dismissed_suggestions',
     ];
 
     protected $hidden = [
@@ -47,6 +48,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
             'password' => 'hashed',
             'role' => UserRole::class,
             'toured_pages' => 'array',
+            'dismissed_suggestions' => 'array',
         ];
     }
 

--- a/app/Services/RuleSuggestion/RuleSuggestion.php
+++ b/app/Services/RuleSuggestion/RuleSuggestion.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\RuleSuggestion;
+
+readonly class RuleSuggestion
+{
+    public function __construct(
+        public string $pattern,
+        public int $matchCount,
+        public int $accountHeadId,
+        public string $accountHeadName,
+        public int $importedFileId,
+    ) {}
+}

--- a/app/Services/RuleSuggestion/RuleSuggestionService.php
+++ b/app/Services/RuleSuggestion/RuleSuggestionService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\RuleSuggestion;
+
+use App\Enums\MappingType;
+use App\Models\AccountHead;
+use App\Models\Transaction;
+use App\Models\User;
+
+class RuleSuggestionService
+{
+    /**
+     * Extract the first meaningful alphabetic keyword from a transaction description.
+     * Skips short words and purely numeric tokens.
+     */
+    public function extractKeyword(string $description): string
+    {
+        $tokens = preg_split('/[\s\-\/]+/', $description) ?: [$description];
+
+        foreach ($tokens as $token) {
+            $clean = preg_replace('/[^a-zA-Z]/', '', $token) ?? '';
+
+            if (strlen($clean) >= 4) {
+                return $clean;
+            }
+        }
+
+        return mb_substr($description, 0, 20);
+    }
+
+    /**
+     * Count unmapped transactions in the same import whose description contains the keyword.
+     * Descriptions are encrypted, so matching is done in PHP after loading.
+     * Excludes the source transaction itself.
+     */
+    public function countSimilarUnmapped(Transaction $transaction, string $keyword): int
+    {
+        return Transaction::where('imported_file_id', $transaction->imported_file_id)
+            ->where('id', '!=', $transaction->id)
+            ->where('mapping_type', MappingType::Unmapped)
+            ->get()
+            ->filter(fn (Transaction $t) => str_contains(strtolower($t->description), strtolower($keyword)))
+            ->count();
+    }
+
+    /**
+     * Return a rule suggestion if there are similar unmapped transactions
+     * and the pattern hasn't been dismissed by the user.
+     */
+    public function suggest(Transaction $transaction, User $user, int $companyId): ?RuleSuggestion
+    {
+        if ($transaction->account_head_id === null) {
+            return null;
+        }
+
+        $keyword = $this->extractKeyword($transaction->description);
+        $dismissKey = "{$companyId}:{$keyword}";
+
+        $dismissed = $user->dismissed_suggestions ?? [];
+
+        if (in_array($dismissKey, $dismissed)) {
+            return null;
+        }
+
+        $count = $this->countSimilarUnmapped($transaction, $keyword);
+
+        if ($count === 0) {
+            return null;
+        }
+
+        $transaction->loadMissing('accountHead');
+
+        /** @var AccountHead|null $accountHead */
+        $accountHead = $transaction->accountHead;
+
+        return new RuleSuggestion(
+            pattern: $keyword,
+            matchCount: $count,
+            accountHeadId: $transaction->account_head_id,
+            accountHeadName: $accountHead?->name ?? '',
+            importedFileId: $transaction->imported_file_id,
+        );
+    }
+}

--- a/database/migrations/2026_03_18_111948_add_dismissed_suggestions_to_users_table.php
+++ b/database/migrations/2026_03_18_111948_add_dismissed_suggestions_to_users_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->jsonb('dismissed_suggestions')->nullable()->after('toured_pages');
+        });
+    }
+};

--- a/tests/Feature/Filament/RuleSuggestionTest.php
+++ b/tests/Feature/Filament/RuleSuggestionTest.php
@@ -1,0 +1,330 @@
+<?php
+
+use App\Enums\MappingType;
+use App\Enums\MatchType;
+use App\Filament\Resources\TransactionResource\Pages\ListTransactions;
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\RuleSuggestion\RuleSuggestionService;
+
+use function Pest\Livewire\livewire;
+
+describe('RuleSuggestionService', function () {
+    it('extracts keyword from description', function () {
+        $service = app(RuleSuggestionService::class);
+
+        expect($service->extractKeyword('SALARY MARCH'))->toBe('SALARY')
+            ->and($service->extractKeyword('NEFT-123456-ACME CORP'))->toBe('NEFT')
+            ->and($service->extractKeyword('UPI/123456/John Smith'))->toBe('John')
+            ->and($service->extractKeyword('CC PAYMENT'))->toBe('PAYMENT');
+    });
+
+    it('counts similar unmapped transactions in the same import', function () {
+        asUser();
+
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        // Similar unmapped transactions in the same import
+        Transaction::factory()->count(3)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        // Different import — should not count
+        Transaction::factory()->unmapped()->create([
+            'description' => 'SALARY MAY',
+            'company_id' => tenant()->id,
+        ]);
+
+        $service = app(RuleSuggestionService::class);
+        $count = $service->countSimilarUnmapped($transaction, 'SALARY');
+
+        expect($count)->toBe(3);
+    });
+
+    it('returns null suggestion when no similar unmapped transactions exist', function () {
+        $user = asUser();
+
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->mapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        $service = app(RuleSuggestionService::class);
+        $suggestion = $service->suggest($transaction, $user, tenant()->id);
+
+        expect($suggestion)->toBeNull();
+    });
+
+    it('returns a suggestion with pattern and match count when similar transactions exist', function () {
+        $user = asUser();
+
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->mapped($head)
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        Transaction::factory()->count(2)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        $service = app(RuleSuggestionService::class);
+        $suggestion = $service->suggest($transaction, $user, tenant()->id);
+
+        expect($suggestion)->not->toBeNull()
+            ->and($suggestion->pattern)->toBe('SALARY')
+            ->and($suggestion->matchCount)->toBe(2)
+            ->and($suggestion->accountHeadId)->toBe($head->id);
+    });
+
+    it('returns null for dismissed patterns', function () {
+        $user = asUser();
+        $companyId = tenant()->id;
+        $user->update([
+            'dismissed_suggestions' => ["{$companyId}:SALARY"],
+        ]);
+
+        $file = ImportedFile::factory()->create(['company_id' => $companyId]);
+        $head = AccountHead::factory()->create(['company_id' => $companyId]);
+
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->mapped($head)
+            ->create(['description' => 'SALARY MARCH', 'company_id' => $companyId]);
+
+        Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => $companyId]);
+
+        $service = app(RuleSuggestionService::class);
+        $suggestion = $service->suggest($transaction, $user, $companyId);
+
+        expect($suggestion)->toBeNull();
+    });
+});
+
+describe('Rule suggestion after assign_head action', function () {
+    beforeEach(fn () => asUser());
+
+    it('sends a suggestion notification when similar unmapped transactions exist', function () {
+        $file = ImportedFile::factory()->completed(totalRows: 3, mappedRows: 0)->create(['company_id' => tenant()->id]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        Transaction::factory()->count(2)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callTableAction('assign_head', $transaction, [
+                'account_head_id' => $head->id,
+            ])
+            ->assertNotified('Create a mapping rule?');
+    });
+
+    it('does not send suggestion notification when no similar unmapped transactions exist', function () {
+        $file = ImportedFile::factory()->completed(totalRows: 1, mappedRows: 0)->create(['company_id' => tenant()->id]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callTableAction('assign_head', $transaction, [
+                'account_head_id' => $head->id,
+            ])
+            ->assertNotNotified('Create a mapping rule?');
+    });
+
+    it('does not send suggestion notification for dismissed patterns', function () {
+        $user = auth()->user();
+        $companyId = tenant()->id;
+        $user->update(['dismissed_suggestions' => ["{$companyId}:SALARY"]]);
+
+        $file = ImportedFile::factory()->completed(totalRows: 2, mappedRows: 0)->create(['company_id' => $companyId]);
+        $head = AccountHead::factory()->create(['company_id' => $companyId]);
+
+        $transaction = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => $companyId]);
+
+        Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => $companyId]);
+
+        livewire(ListTransactions::class)
+            ->callTableAction('assign_head', $transaction, [
+                'account_head_id' => $head->id,
+            ])
+            ->assertNotNotified('Create a mapping rule?');
+    });
+});
+
+describe('Rule suggestion after bulk assign_head action', function () {
+    beforeEach(fn () => asUser());
+
+    it('sends a suggestion notification after bulk assign when similar unmapped transactions exist', function () {
+        $file = ImportedFile::factory()->completed(totalRows: 5, mappedRows: 0)->create(['company_id' => tenant()->id]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+
+        $selected = Transaction::factory()->count(2)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY MARCH', 'company_id' => tenant()->id]);
+
+        // Additional similar unmapped transactions not being mapped in this batch
+        Transaction::factory()->count(3)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callTableBulkAction('bulk_assign_head', $selected, [
+                'account_head_id' => $head->id,
+            ])
+            ->assertNotified('Create a mapping rule?');
+    });
+});
+
+describe('dismissRuleSuggestion listener', function () {
+    it('stores dismissed pattern in user dismissed_suggestions', function () {
+        $user = asUser();
+        $companyId = tenant()->id;
+
+        livewire(ListTransactions::class)
+            ->dispatch('dismissRuleSuggestion', pattern: 'SALARY', companyId: $companyId);
+
+        $user->refresh();
+        expect($user->dismissed_suggestions)->toContain("{$companyId}:SALARY");
+    });
+
+    it('does not duplicate dismissed patterns', function () {
+        $user = asUser();
+        $companyId = tenant()->id;
+        $user->update(['dismissed_suggestions' => ["{$companyId}:SALARY"]]);
+
+        livewire(ListTransactions::class)
+            ->dispatch('dismissRuleSuggestion', pattern: 'SALARY', companyId: $companyId);
+
+        $user->refresh();
+        expect(array_count_values($user->dismissed_suggestions)["{$companyId}:SALARY"])->toBe(1);
+    });
+});
+
+describe('openRuleSuggestion listener mounts suggestRule action', function () {
+    it('mounts the suggest rule action with pre-filled data', function () {
+        asUser();
+
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->dispatch('openRuleSuggestion', [
+                'pattern' => 'SALARY',
+                'accountHeadId' => $head->id,
+                'importedFileId' => $file->id,
+                'matchCount' => 3,
+            ])
+            ->assertActionMounted('suggestRule');
+    });
+});
+
+describe('suggestRule action creates rule and optionally applies it', function () {
+    beforeEach(fn () => asUser());
+
+    it('creates a HeadMapping when the suggest rule form is submitted', function () {
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callAction('suggestRule', [
+                'pattern' => 'SALARY',
+                'match_type' => MatchType::Contains->value,
+                'account_head_id' => $head->id,
+                'apply_immediately' => false,
+                'imported_file_id' => $file->id,
+            ])
+            ->assertHasNoActionErrors();
+
+        expect(HeadMapping::where('pattern', 'SALARY')->exists())->toBeTrue();
+    });
+
+    it('applies rule immediately to unmapped transactions when apply_immediately is true', function () {
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+
+        $unmapped = Transaction::factory()->count(2)
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        // One that should NOT be matched
+        $other = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'AMAZON PAYMENT', 'company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callAction('suggestRule', [
+                'pattern' => 'SALARY',
+                'match_type' => MatchType::Contains->value,
+                'account_head_id' => $head->id,
+                'apply_immediately' => true,
+                'imported_file_id' => $file->id,
+            ])
+            ->assertHasNoActionErrors();
+
+        foreach ($unmapped as $t) {
+            $t->refresh();
+            expect($t->account_head_id)->toBe($head->id)
+                ->and($t->mapping_type)->toBe(MappingType::Auto);
+        }
+
+        $other->refresh();
+        expect($other->account_head_id)->toBeNull();
+    });
+
+    it('does not apply rule when apply_immediately is false', function () {
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        $file = ImportedFile::factory()->create(['company_id' => tenant()->id]);
+
+        $unmapped = Transaction::factory()
+            ->for($file, 'importedFile')
+            ->unmapped()
+            ->create(['description' => 'SALARY APRIL', 'company_id' => tenant()->id]);
+
+        livewire(ListTransactions::class)
+            ->callAction('suggestRule', [
+                'pattern' => 'SALARY',
+                'match_type' => MatchType::Contains->value,
+                'account_head_id' => $head->id,
+                'apply_immediately' => false,
+                'imported_file_id' => $file->id,
+            ])
+            ->assertHasNoActionErrors();
+
+        $unmapped->refresh();
+        expect($unmapped->account_head_id)->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- After manually mapping a transaction (or bulk-mapping), the system checks for similar unmapped transactions in the same import and shows a dismissible toast notification suggesting a reusable mapping rule
- One-click "Create Rule" pre-fills pattern, match type, and account head; rule can be applied immediately to remaining unmapped transactions
- Dismissed suggestions are persisted per user+company in a new `dismissed_suggestions` JSONB column so users are never nagged twice for the same pattern

## Test plan

- [ ] Map a transaction → expect toast "Create a mapping rule?" if similar unmapped exist
- [ ] Click "Create Rule" → suggestRule modal pre-filled with pattern + account head
- [ ] Toggle "Apply to matching transactions" → verifies existing unmapped are updated
- [ ] Dismiss toast → pattern not shown again for this user+company
- [ ] Map when no similar transactions exist → no toast shown
- [ ] All 15 new tests pass: `php artisan test --filter=RuleSuggestion --compact`

Closes #147