### PR TITLE
feat(imported-files): add transactions table to ImportedFile view page

### DIFF
--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -161,7 +161,7 @@ class AccountHeadResource extends Resource
     /** @return Builder<AccountHead> */
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        return AccountHead::query()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);

--- a/app/Filament/Resources/BankAccountResource.php
+++ b/app/Filament/Resources/BankAccountResource.php
@@ -139,7 +139,7 @@ class BankAccountResource extends Resource
     /** @return Builder<BankAccount> */
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        return BankAccount::query()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);

--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -293,7 +293,9 @@ class ImportedFileResource extends Resource
 
     public static function getRelations(): array
     {
-        return [];
+        return [
+            ImportedFileResource\RelationManagers\TransactionsRelationManager::class,
+        ];
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -285,7 +285,7 @@ class ImportedFileResource extends Resource
     /** @return Builder<ImportedFile> */
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        return ImportedFile::query()
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -6,6 +6,7 @@ use App\Enums\MappingType;
 use App\Enums\MatchType;
 use App\Filament\Resources\ImportedFileResource;
 use App\Models\AccountHead;
+use App\Models\Company;
 use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
@@ -66,7 +67,7 @@ class ViewImportedFile extends ViewRecord
                         ->default(true),
                 ])
                 ->action(function (array $data): void {
-                    /** @var \App\Models\Company|null $tenant */
+                    /** @var Company|null $tenant */
                     $tenant = Filament::getTenant();
                     $companyId = $tenant?->id;
 
@@ -177,7 +178,7 @@ class ViewImportedFile extends ViewRecord
         return $schema
             ->schema([
                 Section::make('File Details')
-                    ->poll(fn (): ?string => $this->record->isProcessing() ? '10s' : null)
+                    ->poll(fn (): ?string => $this->record->isProcessing() ? '10s' : '30s')
                     ->schema([
                         Infolists\Components\TextEntry::make('display_name')
                             ->label('Display Name'),

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -101,8 +101,7 @@ class ViewImportedFile extends ViewRecord
                         ->title('Mapping rule created')
                         ->success()
                         ->send();
-                })
-                ->visible(false),
+                }),
         ];
     }
 

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -2,13 +2,26 @@
 
 namespace App\Filament\Resources\ImportedFileResource\Pages;
 
+use App\Enums\MappingType;
+use App\Enums\MatchType;
 use App\Filament\Resources\ImportedFileResource;
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
 use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Models\User;
 use Filament\Actions;
+use Filament\Facades\Filament;
+use Filament\Forms;
 use Filament\Infolists;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\On;
 
 /** @property ImportedFile $record */
 class ViewImportedFile extends ViewRecord
@@ -24,7 +37,140 @@ class ViewImportedFile extends ViewRecord
                 ->color('gray')
                 ->url(fn (): string => route('imported-files.download', $this->record))
                 ->openUrlInNewTab(),
+
+            Actions\Action::make('suggestRule')
+                ->label('Create Mapping Rule')
+                ->icon('heroicon-o-sparkles')
+                ->color('info')
+                ->fillForm(fn (array $arguments): array => $arguments)
+                ->form([
+                    Forms\Components\TextInput::make('pattern')
+                        ->label('Pattern')
+                        ->required(),
+
+                    Forms\Components\Select::make('match_type')
+                        ->options(MatchType::class)
+                        ->default(MatchType::Contains)
+                        ->required(),
+
+                    Forms\Components\Select::make('account_head_id')
+                        ->label('Account Head')
+                        ->options(fn () => AccountHead::where('is_active', true)->pluck('name', 'id'))
+                        ->searchable()
+                        ->required(),
+
+                    Forms\Components\Hidden::make('imported_file_id'),
+
+                    Forms\Components\Toggle::make('apply_immediately')
+                        ->label('Apply to matching transactions in this import')
+                        ->default(true),
+                ])
+                ->action(function (array $data): void {
+                    /** @var \App\Models\Company|null $tenant */
+                    $tenant = Filament::getTenant();
+                    $companyId = $tenant?->id;
+
+                    try {
+                        HeadMapping::create([
+                            'pattern' => $data['pattern'],
+                            'match_type' => $data['match_type'],
+                            'account_head_id' => $data['account_head_id'],
+                            'company_id' => $companyId,
+                            'created_by' => Auth::id(),
+                        ]);
+                    } catch (UniqueConstraintViolationException) {
+                        Notification::make()
+                            ->danger()
+                            ->title('Duplicate rule')
+                            ->body('A mapping rule with this pattern, match type, and account head already exists.')
+                            ->send();
+
+                        throw new Halt;
+                    }
+
+                    if ($data['apply_immediately'] && ! empty($data['imported_file_id'])) {
+                        $this->applyRuleToImport(
+                            pattern: $data['pattern'],
+                            matchType: $data['match_type'] instanceof MatchType ? $data['match_type'] : MatchType::from($data['match_type']),
+                            accountHeadId: $data['account_head_id'],
+                            importedFileId: (int) $data['imported_file_id'],
+                        );
+                    }
+
+                    Notification::make()
+                        ->title('Mapping rule created')
+                        ->success()
+                        ->send();
+                })
+                ->visible(false),
         ];
+    }
+
+    /** @param array<string, mixed> $data */
+    #[On('openRuleSuggestion')]
+    public function openRuleSuggestion(array $data): void
+    {
+        $this->mountAction('suggestRule', [
+            'pattern' => $data['pattern'] ?? '',
+            'match_type' => MatchType::Contains->value,
+            'account_head_id' => $data['accountHeadId'] ?? null,
+            'imported_file_id' => $data['importedFileId'] ?? null,
+            'apply_immediately' => true,
+        ]);
+    }
+
+    #[On('dismissRuleSuggestion')]
+    public function dismissRuleSuggestion(string $pattern, int $companyId): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $dismissed = $user->dismissed_suggestions ?? [];
+        $key = "{$companyId}:{$pattern}";
+
+        if (! in_array($key, $dismissed)) {
+            $dismissed[] = $key;
+            $user->update(['dismissed_suggestions' => $dismissed]);
+        }
+    }
+
+    private function applyRuleToImport(string $pattern, MatchType $matchType, int $accountHeadId, int $importedFileId): int
+    {
+        $file = ImportedFile::find($importedFileId);
+
+        if (! $file) {
+            return 0;
+        }
+
+        $rule = new HeadMapping(['pattern' => $pattern, 'match_type' => $matchType]);
+
+        $toUpdate = Transaction::where('imported_file_id', $importedFileId)
+            ->where('mapping_type', MappingType::Unmapped)
+            ->get()
+            ->filter(fn (Transaction $t) => $rule->matches($t->description));
+
+        foreach ($toUpdate as $t) {
+            $t->update([
+                'account_head_id' => $accountHeadId,
+                'mapping_type' => MappingType::Auto,
+            ]);
+        }
+
+        $count = $toUpdate->count();
+
+        $file->update([
+            'mapped_rows' => $file->transactions()
+                ->where('mapping_type', '!=', MappingType::Unmapped)
+                ->count(),
+        ]);
+
+        if ($count > 0) {
+            Notification::make()
+                ->title("Rule applied to {$count} transaction(s)")
+                ->success()
+                ->send();
+        }
+
+        return $count;
     }
 
     public function infolist(Schema $schema): Schema

--- a/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
+++ b/app/Filament/Resources/ImportedFileResource/Pages/ViewImportedFile.php
@@ -178,7 +178,7 @@ class ViewImportedFile extends ViewRecord
         return $schema
             ->schema([
                 Section::make('File Details')
-                    ->poll(fn (): ?string => $this->record->isProcessing() ? '10s' : '30s')
+                    ->poll(fn (): string => $this->record->isProcessing() ? '10s' : '30s')
                     ->schema([
                         Infolists\Components\TextEntry::make('display_name')
                             ->label('Display Name'),

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -47,7 +47,7 @@ class TransactionsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->poll(function (): ?string {
+            ->poll(function (): string {
                 /** @var ImportedFile $file */
                 $file = $this->getOwnerRecord();
 

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -7,11 +7,14 @@ use App\Enums\MatchMethod;
 use App\Enums\MatchType;
 use App\Enums\ReconciliationStatus;
 use App\Enums\StatementType;
+use App\Enums\UserRole;
 use App\Exports\TransactionCsvExport;
 use App\Exports\TransactionExcelExport;
 use App\Filament\Resources\Concerns\HasTransactionColumns;
 use App\Jobs\MatchTransactionHeads;
 use App\Models\AccountHead;
+use App\Models\Company;
+use App\Models\CreditCard;
 use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
@@ -44,6 +47,12 @@ class TransactionsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->poll(function (): ?string {
+                /** @var ImportedFile $file */
+                $file = $this->getOwnerRecord();
+
+                return $file->isProcessing() ? '10s' : null;
+            })
             ->columns([
                 Tables\Columns\TextColumn::make('date')
                     ->date('d M Y')
@@ -52,6 +61,10 @@ class TransactionsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('description')
                     ->limit(50)
                     ->tooltip(fn (Transaction $record) => $record->description),
+
+                Tables\Columns\TextColumn::make('reference_number')
+                    ->label('Ref #')
+                    ->toggleable(isToggledHiddenByDefault: true),
 
                 static::amountColumn(),
 
@@ -67,6 +80,12 @@ class TransactionsRelationManager extends RelationManager
                     ->placeholder('Unmapped')
                     ->searchable()
                     ->description(static::mappingTypeDescription()),
+
+                Tables\Columns\IconColumn::make('recurring_pattern_id')
+                    ->label('Recurring')
+                    ->icon(fn ($state) => $state ? 'heroicon-o-arrow-path' : null)
+                    ->color('info')
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->defaultSort('date', 'desc')
             ->filters([
@@ -258,6 +277,69 @@ class TransactionsRelationManager extends RelationManager
                             }
                         })
                         ->deselectRecordsAfterCompletion(),
+
+                    Actions\BulkAction::make('move_to_company')
+                        ->label('Move to Company')
+                        ->icon('heroicon-o-arrow-right-circle')
+                        ->color('warning')
+                        ->form([
+                            Forms\Components\Select::make('target_company_id')
+                                ->label('Target Company')
+                                ->options(function () {
+                                    $user = Auth::user();
+                                    /** @var Company|null $currentTenant */
+                                    $currentTenant = Filament::getTenant();
+
+                                    return Company::query()
+                                        ->whereHas('users', function (Builder $q) use ($user) {
+                                            $q->where('users.id', $user->id)
+                                                ->where('company_user.role', UserRole::Admin->value);
+                                        })
+                                        ->when($currentTenant, fn (Builder $q) => $q->where('companies.id', '!=', $currentTenant->id))
+                                        ->pluck('name', 'id');
+                                })
+                                ->searchable()
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data) {
+                            $targetCompany = Company::find($data['target_company_id']);
+
+                            $creditCardIds = $records->pluck('imported_file_id')
+                                ->map(fn ($fileId) => ImportedFile::find($fileId)?->credit_card_id)
+                                ->filter()
+                                ->unique();
+
+                            $allShared = $creditCardIds->every(function ($cardId) use ($targetCompany) {
+                                $card = CreditCard::find($cardId);
+
+                                return $card && $card->isSharedWith($targetCompany);
+                            });
+
+                            if (! $allShared) {
+                                Notification::make()
+                                    ->title('Card must be shared with the target company first')
+                                    ->danger()
+                                    ->send();
+
+                                return;
+                            }
+
+                            $count = 0;
+                            $records->each(function (Model $record) use ($targetCompany, &$count) {
+                                /** @var Transaction $tx */
+                                $tx = $record;
+                                $tx->moveToCompany($targetCompany);
+                                $count++;
+                            });
+
+                            Notification::make()
+                                ->title($count.' transactions moved to '.$targetCompany->name)
+                                ->success()
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion(),
+
+                    Actions\DeleteBulkAction::make(),
                 ]),
             ])
             ->headerActions([

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -2,12 +2,38 @@
 
 namespace App\Filament\Resources\ImportedFileResource\RelationManagers;
 
+use App\Enums\MappingType;
+use App\Enums\MatchMethod;
+use App\Enums\MatchType;
+use App\Enums\ReconciliationStatus;
+use App\Enums\StatementType;
+use App\Exports\TransactionCsvExport;
+use App\Exports\TransactionExcelExport;
 use App\Filament\Resources\Concerns\HasTransactionColumns;
+use App\Jobs\MatchTransactionHeads;
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
+use App\Models\ImportedFile;
 use App\Models\Transaction;
-use Filament\Actions\ViewAction;
+use App\Services\Reconciliation\ReconciliationService;
+use App\Services\RuleSuggestion\RuleSuggestionService;
+use App\Services\TallyExport\TallyExportService;
+use Filament\Actions;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TransactionsRelationManager extends RelationManager
 {
@@ -43,11 +69,346 @@ class TransactionsRelationManager extends RelationManager
                     ->description(static::mappingTypeDescription()),
             ])
             ->defaultSort('date', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('mapping_type')
+                    ->options(MappingType::class),
+
+                Tables\Filters\SelectFilter::make('account_head_id')
+                    ->label('Account Head')
+                    ->relationship('accountHead', 'name')
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\Filter::make('date_range')
+                    ->form([
+                        Forms\Components\DatePicker::make('from'),
+                        Forms\Components\DatePicker::make('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $q, string $date) => $q->whereDate('date', '>=', $date))
+                            ->when($data['until'], fn (Builder $q, string $date) => $q->whereDate('date', '<=', $date));
+                    }),
+
+                Tables\Filters\TernaryFilter::make('unmapped_only')
+                    ->label('Unmapped Only')
+                    ->queries(
+                        true: fn (Builder $query) => $query->where('mapping_type', MappingType::Unmapped),
+                        false: fn (Builder $query) => $query->where('mapping_type', '!=', MappingType::Unmapped),
+                    ),
+            ])
             ->recordActions([
-                ViewAction::make(),
+                Action::make('assign_head')
+                    ->label('Assign Head')
+                    ->icon('heroicon-o-tag')
+                    ->form([
+                        Forms\Components\Select::make('account_head_id')
+                            ->label('Account Head')
+                            ->options(fn () => AccountHead::where('is_active', true)->pluck('name', 'id'))
+                            ->searchable()
+                            ->required(),
+                    ])
+                    ->action(function (Transaction $record, array $data) {
+                        DB::transaction(function () use ($record, $data) {
+                            $record->update([
+                                'account_head_id' => $data['account_head_id'],
+                                'mapping_type' => MappingType::Manual,
+                                'ai_confidence' => null,
+                            ]);
+
+                            $file = $record->importedFile;
+                            $file->update([
+                                'mapped_rows' => $file->transactions()
+                                    ->where('mapping_type', '!=', MappingType::Unmapped)
+                                    ->count(),
+                            ]);
+                        });
+
+                        $record->refresh();
+                        $this->sendRuleSuggestionNotification($record);
+                    }),
+
+                Actions\ActionGroup::make([
+                    Action::make('create_rule')
+                        ->label('Create Rule')
+                        ->icon('heroicon-o-plus-circle')
+                        ->color('info')
+                        ->form([
+                            Forms\Components\TextInput::make('pattern')
+                                ->label('Pattern')
+                                ->required()
+                                ->default(fn (Transaction $record) => $record->description),
+
+                            Forms\Components\Select::make('match_type')
+                                ->options(MatchType::class)
+                                ->default(MatchType::Contains)
+                                ->required(),
+
+                            Forms\Components\Select::make('account_head_id')
+                                ->label('Account Head')
+                                ->options(fn () => AccountHead::where('is_active', true)->pluck('name', 'id'))
+                                ->searchable()
+                                ->required()
+                                ->default(fn (Transaction $record) => $record->account_head_id),
+
+                            Forms\Components\TextInput::make('bank_name')
+                                ->label('Bank Name (optional)')
+                                ->default(fn (Transaction $record) => $record->importedFile?->bank_name),
+                        ])
+                        ->action(function (Transaction $record, array $data) {
+                            HeadMapping::create([
+                                'pattern' => $data['pattern'],
+                                'match_type' => $data['match_type'],
+                                'account_head_id' => $data['account_head_id'],
+                                'bank_name' => $data['bank_name'] ?: null,
+                                'created_by' => Auth::id(),
+                            ]);
+
+                            Notification::make()
+                                ->title('Mapping rule created')
+                                ->success()
+                                ->send();
+                        })
+                        ->visible(fn (Transaction $record) => $record->account_head_id !== null),
+
+                    Action::make('match_invoice')
+                        ->label('Match Invoice')
+                        ->icon('heroicon-o-link')
+                        ->color('warning')
+                        ->form([
+                            Forms\Components\CheckboxList::make('invoice_transaction_ids')
+                                ->label('Select Invoice(s)')
+                                ->options(function (Transaction $record) {
+                                    return Transaction::whereHas(
+                                        'importedFile',
+                                        fn (Builder $q) => $q->where('statement_type', StatementType::Invoice)
+                                            ->where('company_id', $record->importedFile?->company_id)
+                                    )
+                                        ->where('reconciliation_status', ReconciliationStatus::Unreconciled)
+                                        ->select(['id', 'description', 'debit'])
+                                        ->orderByDesc('date')
+                                        ->limit(500)
+                                        ->get()
+                                        ->mapWithKeys(fn (Transaction $t) => [
+                                            $t->id => $t->description.' ('.number_format((float) $t->debit, 2).')',
+                                        ]);
+                                })
+                                ->required(),
+                        ])
+                        ->action(function (Transaction $record, array $data) {
+                            $service = app(ReconciliationService::class);
+                            $invoiceTransactions = Transaction::whereIn('id', $data['invoice_transaction_ids'])->get()->keyBy('id');
+
+                            DB::transaction(function () use ($record, $data, $service, $invoiceTransactions) {
+                                foreach ($data['invoice_transaction_ids'] as $invoiceId) {
+                                    /** @var Transaction $invoiceTxn */
+                                    $invoiceTxn = $invoiceTransactions->get($invoiceId);
+                                    $service->createMatch($record, $invoiceTxn, 1.0, MatchMethod::Manual);
+                                }
+                            });
+
+                            $record->loadMissing('importedFile');
+                            $service->enrichMatchedTransactions($record->importedFile);
+
+                            Notification::make()
+                                ->title('Invoice matched successfully')
+                                ->success()
+                                ->send();
+                        })
+                        ->visible(fn (Transaction $record) => $record->reconciliation_status === ReconciliationStatus::Unreconciled
+                            && $record->importedFile?->statement_type !== StatementType::Invoice),
+                ]),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\BulkAction::make('bulk_assign_head')
+                        ->label('Assign Account Head')
+                        ->icon('heroicon-o-tag')
+                        ->form([
+                            Forms\Components\Select::make('account_head_id')
+                                ->label('Account Head')
+                                ->options(fn () => AccountHead::where('is_active', true)->pluck('name', 'id'))
+                                ->searchable()
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data) {
+                            DB::transaction(function () use ($records, $data) {
+                                $records->each(function (Model $record) use ($data) {
+                                    $record->update([
+                                        'account_head_id' => $data['account_head_id'],
+                                        'mapping_type' => MappingType::Manual,
+                                        'ai_confidence' => null,
+                                    ]);
+                                });
+
+                                /** @var ImportedFile $file */
+                                $file = $this->getOwnerRecord();
+                                $file->update([
+                                    'mapped_rows' => $file->transactions()
+                                        ->where('mapping_type', '!=', MappingType::Unmapped)
+                                        ->count(),
+                                ]);
+                            });
+
+                            /** @var Transaction|null $first */
+                            $first = $records->first();
+                            if ($first) {
+                                $first->refresh();
+                                $this->sendRuleSuggestionNotification($first);
+                            }
+                        })
+                        ->deselectRecordsAfterCompletion(),
+                ]),
+            ])
+            ->headerActions([
+                Action::make('run_ai_matching')
+                    ->label('Run AI Matching')
+                    ->icon('heroicon-o-cpu-chip')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('This will run rule-based and AI matching on all unmapped transactions in this file.')
+                    ->action(function () {
+                        /** @var ImportedFile $file */
+                        $file = $this->getOwnerRecord();
+
+                        if ($file->is_matching) {
+                            return;
+                        }
+
+                        $file->update(['is_matching' => true]);
+                        MatchTransactionHeads::dispatch($file);
+
+                        Notification::make()
+                            ->title('AI matching job dispatched')
+                            ->success()
+                            ->send();
+                    }),
+
+                Actions\ActionGroup::make([
+                    Action::make('export_tally')
+                        ->label('Tally XML')
+                        ->icon('heroicon-o-document-text')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')->label('From Date'),
+                            Forms\Components\DatePicker::make('until')->label('Until Date'),
+                        ])
+                        ->action(function (array $data): StreamedResponse {
+                            /** @var ImportedFile $file */
+                            $file = $this->getOwnerRecord();
+
+                            $query = Transaction::where('imported_file_id', $file->id)
+                                ->whereNotNull('account_head_id')
+                                ->with(['accountHead', 'importedFile.company', 'importedFile.bankAccount'])
+                                ->orderBy('date');
+
+                            if (! empty($data['from'])) {
+                                $query->whereDate('date', '>=', $data['from']);
+                            }
+
+                            if (! empty($data['until'])) {
+                                $query->whereDate('date', '<=', $data['until']);
+                            }
+
+                            $xml = app(TallyExportService::class)->exportTransactions($query->get());
+
+                            return response()->streamDownload(
+                                fn () => print ($xml),
+                                'tally-export-'.now()->format('Y-m-d-His').'.xml',
+                                ['Content-Type' => 'application/xml']
+                            );
+                        }),
+
+                    Action::make('export_csv')
+                        ->label('CSV')
+                        ->icon('heroicon-o-table-cells')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')->label('From Date'),
+                            Forms\Components\DatePicker::make('until')->label('Until Date'),
+                        ])
+                        ->action(function (array $data): BinaryFileResponse {
+                            /** @var ImportedFile $file */
+                            $file = $this->getOwnerRecord();
+
+                            return Excel::download(
+                                new TransactionCsvExport(
+                                    from: $data['from'] ?? null,
+                                    until: $data['until'] ?? null,
+                                    baseQuery: Transaction::where('imported_file_id', $file->id),
+                                ),
+                                'transactions-'.now()->format('Y-m-d-His').'.csv',
+                            );
+                        }),
+
+                    Action::make('export_excel')
+                        ->label('Excel')
+                        ->icon('heroicon-o-document-arrow-down')
+                        ->form([
+                            Forms\Components\DatePicker::make('from')->label('From Date'),
+                            Forms\Components\DatePicker::make('until')->label('Until Date'),
+                        ])
+                        ->action(function (array $data): BinaryFileResponse {
+                            /** @var ImportedFile $file */
+                            $file = $this->getOwnerRecord();
+
+                            return Excel::download(
+                                new TransactionExcelExport(
+                                    from: $data['from'] ?? null,
+                                    until: $data['until'] ?? null,
+                                    baseQuery: Transaction::where('imported_file_id', $file->id),
+                                    importedFile: $file->load('creditCard'),
+                                ),
+                                'transactions-'.now()->format('Y-m-d-His').'.xlsx',
+                            );
+                        }),
+                ])
+                    ->label('Export')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('success')
+                    ->button(),
             ])
             ->emptyStateHeading('No transactions yet')
             ->emptyStateDescription('Transactions appear here once this file has been processed.')
             ->emptyStateIcon('heroicon-o-banknotes');
+    }
+
+    private function sendRuleSuggestionNotification(Transaction $record): void
+    {
+        $user = Auth::user();
+        /** @var \App\Models\Company|null $tenant */
+        $tenant = Filament::getTenant();
+
+        if (! $user || ! $tenant) {
+            return;
+        }
+
+        $suggestion = app(RuleSuggestionService::class)->suggest($record, $user, $tenant->id);
+
+        if (! $suggestion) {
+            return;
+        }
+
+        Notification::make()
+            ->title('Create a mapping rule?')
+            ->body("{$suggestion->matchCount} similar unmapped transaction(s) found for '{$suggestion->pattern}' → '{$suggestion->accountHeadName}'.")
+            ->info()
+            ->persistent()
+            ->actions([
+                Action::make('create_rule')
+                    ->label('Create Rule')
+                    ->button()
+                    ->dispatch('openRuleSuggestion', [[
+                        'pattern' => $suggestion->pattern,
+                        'accountHeadId' => $suggestion->accountHeadId,
+                        'importedFileId' => $suggestion->importedFileId,
+                        'matchCount' => $suggestion->matchCount,
+                    ]])
+                    ->close(),
+                Action::make('dismiss')
+                    ->label('Dismiss')
+                    ->color('gray')
+                    ->dispatch('dismissRuleSuggestion', [$suggestion->pattern, $tenant->id])
+                    ->close(),
+            ])
+            ->send();
     }
 }

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -51,7 +51,7 @@ class TransactionsRelationManager extends RelationManager
                 /** @var ImportedFile $file */
                 $file = $this->getOwnerRecord();
 
-                return $file->isProcessing() ? '10s' : null;
+                return $file->isProcessing() ? '10s' : '30s';
             })
             ->columns([
                 Tables\Columns\TextColumn::make('date')
@@ -175,7 +175,7 @@ class TransactionsRelationManager extends RelationManager
                                 ->default(fn (Transaction $record) => $record->importedFile?->bank_name),
                         ])
                         ->action(function (Transaction $record, array $data) {
-                            /** @var \App\Models\Company|null $tenant */
+                            /** @var Company|null $tenant */
                             $tenant = Filament::getTenant();
 
                             HeadMapping::create([
@@ -460,7 +460,7 @@ class TransactionsRelationManager extends RelationManager
     private function sendRuleSuggestionNotification(Transaction $record): void
     {
         $user = Auth::user();
-        /** @var \App\Models\Company|null $tenant */
+        /** @var Company|null $tenant */
         $tenant = Filament::getTenant();
 
         if (! $user || ! $tenant) {

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -175,11 +175,15 @@ class TransactionsRelationManager extends RelationManager
                                 ->default(fn (Transaction $record) => $record->importedFile?->bank_name),
                         ])
                         ->action(function (Transaction $record, array $data) {
+                            /** @var \App\Models\Company|null $tenant */
+                            $tenant = Filament::getTenant();
+
                             HeadMapping::create([
                                 'pattern' => $data['pattern'],
                                 'match_type' => $data['match_type'],
                                 'account_head_id' => $data['account_head_id'],
                                 'bank_name' => $data['bank_name'] ?: null,
+                                'company_id' => $tenant?->id,
                                 'created_by' => Auth::id(),
                             ]);
 

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources\ImportedFileResource\RelationManagers;
+
+use App\Filament\Resources\Concerns\HasTransactionColumns;
+use App\Models\Transaction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class TransactionsRelationManager extends RelationManager
+{
+    use HasTransactionColumns;
+
+    protected static string $relationship = 'transactions';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('date')
+                    ->date('d M Y')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('description')
+                    ->limit(50)
+                    ->tooltip(fn (Transaction $record) => $record->description),
+
+                static::amountColumn(),
+
+                static::currencyColumn(),
+
+                Tables\Columns\TextColumn::make('balance')
+                    ->label('Balance')
+                    ->numeric(decimalPlaces: 2)
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                Tables\Columns\TextColumn::make('accountHead.name')
+                    ->label('Account Head')
+                    ->placeholder('Unmapped')
+                    ->searchable()
+                    ->description(static::mappingTypeDescription()),
+            ])
+            ->defaultSort('date', 'desc')
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->emptyStateHeading('No transactions yet')
+            ->emptyStateDescription('Transactions appear here once this file has been processed.')
+            ->emptyStateIcon('heroicon-o-banknotes');
+    }
+}

--- a/app/Filament/Resources/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource.php
@@ -41,7 +41,7 @@ class ReconciliationResource extends Resource
     /** @return Builder<Transaction> */
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
+        return Transaction::query()
             ->with([
                 'importedFile',
                 'accountHead',

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -201,11 +201,15 @@ class TransactionResource extends Resource
                                 ->default(fn (Transaction $record) => $record->importedFile?->bank_name),
                         ])
                         ->action(function (Transaction $record, array $data) {
+                            /** @var \App\Models\Company|null $tenant */
+                            $tenant = Filament::getTenant();
+
                             HeadMapping::create([
                                 'pattern' => $data['pattern'],
                                 'match_type' => $data['match_type'],
                                 'account_head_id' => $data['account_head_id'],
                                 'bank_name' => $data['bank_name'] ?: null,
+                                'company_id' => $tenant?->id,
                                 'created_by' => Auth::id(),
                             ]);
 

--- a/app/Services/HeadMatcher/HeadMatcherService.php
+++ b/app/Services/HeadMatcher/HeadMatcherService.php
@@ -18,7 +18,7 @@ class HeadMatcherService
 
     protected int $ruleChunkSize = 500;
 
-    protected int $aiChunkSize = 50;
+    protected int $aiChunkSize = 20;
 
     public function __construct(
         protected RuleBasedMatcher $ruleBasedMatcher,

--- a/tests/Architecture/ArchTest.php
+++ b/tests/Architecture/ArchTest.php
@@ -53,7 +53,8 @@ describe('Filament Resources', function () {
             ->ignoring('App\Filament\Resources\TeamMemberResource\Pages')
             ->ignoring('App\Filament\Resources\TransactionResource\Pages')
             ->ignoring('App\Filament\Resources\DuplicateFlags\Pages')
-            ->ignoring('App\Filament\Resources\BudgetResource\Pages');
+            ->ignoring('App\Filament\Resources\BudgetResource\Pages')
+            ->ignoring('App\Filament\Resources\ImportedFileResource\RelationManagers');
     });
 })->group('architecture');
 

--- a/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
+++ b/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
@@ -57,7 +57,7 @@ describe('ImportedFile Transactions RelationManager', function () {
             ->assertCanSeeTableRecords([]);
     });
 
-    it('has a view action for each transaction row', function () {
+    it('has an assign_head action for each transaction row', function () {
         $file = ImportedFile::factory()->create();
         $transaction = Transaction::factory()->for($file, 'importedFile')->create();
 
@@ -65,7 +65,27 @@ describe('ImportedFile Transactions RelationManager', function () {
             'ownerRecord' => $file,
             'pageClass' => ViewImportedFile::class,
         ])
-            ->assertTableActionExists('view', record: $transaction);
+            ->assertTableActionExists('assign_head', record: $transaction);
+    });
+
+    it('has a bulk assign_head action', function () {
+        $file = ImportedFile::factory()->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertTableBulkActionExists('bulk_assign_head');
+    });
+
+    it('has an export header action group', function () {
+        $file = ImportedFile::factory()->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertTableActionExists('run_ai_matching');
     });
 
     it('has no create action', function () {

--- a/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
+++ b/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Filament\Resources\ImportedFileResource\Pages\ViewImportedFile;
+use App\Filament\Resources\ImportedFileResource\RelationManagers\TransactionsRelationManager;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+
+use function Pest\Livewire\livewire;
+
+describe('ImportedFile Transactions RelationManager', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('renders successfully on the view page', function () {
+        $file = ImportedFile::factory()->create();
+
+        livewire(ViewImportedFile::class, ['record' => $file->getRouteKey()])
+            ->assertSeeLivewire(TransactionsRelationManager::class);
+    });
+
+    it('shows transactions belonging to the file', function () {
+        $file = ImportedFile::factory()->create();
+        $transactions = Transaction::factory()->count(3)->for($file, 'importedFile')->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords($transactions);
+    });
+
+    it('does not show transactions from other files', function () {
+        $file = ImportedFile::factory()->create();
+        $otherFile = ImportedFile::factory()->create();
+
+        $ours = Transaction::factory()->for($file, 'importedFile')->create();
+        $theirs = Transaction::factory()->for($otherFile, 'importedFile')->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertCanSeeTableRecords([$ours])
+            ->assertCanNotSeeTableRecords([$theirs]);
+    });
+
+    it('shows an empty state when the file has no transactions', function () {
+        $file = ImportedFile::factory()->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([]);
+    });
+
+    it('has a view action for each transaction row', function () {
+        $file = ImportedFile::factory()->create();
+        $transaction = Transaction::factory()->for($file, 'importedFile')->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertTableActionExists('view', record: $transaction);
+    });
+
+    it('has no create action', function () {
+        $file = ImportedFile::factory()->create();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->assertTableActionDoesNotExist('create');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a **Transactions** relation manager to the `ImportedFile` view page
- Shows only transactions extracted from that specific file (scoped by `imported_file_id`)
- Columns match the global Transactions table: date, description, amount, currency, balance, account head + mapping type — reusing the existing `HasTransactionColumns` trait
- Read-only: view action per row opens a modal; no create/edit/delete

## Test plan

- [x] `ImportedFileTransactionsRelationManagerTest` — 6 tests: renders on view page, scoped records, tenant isolation, empty state, view action exists, no create action
- [x] Architecture test updated to ignore `RelationManagers` namespace
- [x] Pint, PHPStan, all tests pass

Closes #208