### PR TITLE
fix(jobs): auto-dispatch head matching after bank/CC import

### DIFF
--- a/app/Enums/ImportSource.php
+++ b/app/Enums/ImportSource.php
@@ -42,4 +42,12 @@ enum ImportSource: string implements HasColor, HasIcon, HasLabel
             self::Api => 'heroicon-m-code-bracket',
         };
     }
+
+    public function shouldAutoMatchHeads(): bool
+    {
+        return match ($this) {
+            self::ManualUpload, self::Zoho, self::Api => true,
+            self::Email => false,
+        };
+    }
 }

--- a/app/Jobs/ProcessImportedFile.php
+++ b/app/Jobs/ProcessImportedFile.php
@@ -123,7 +123,11 @@ class ProcessImportedFile implements ShouldQueue
 
         if ($statementType === StatementType::Invoice) {
             SuggestReconciliationMatches::dispatch($this->importedFile);
+
+            return;
         }
+
+        MatchTransactionHeads::dispatch($this->importedFile);
     }
 
     private function sanitiseErrorMessage(\Throwable $exception, string $prefix): string

--- a/app/Jobs/ProcessImportedFile.php
+++ b/app/Jobs/ProcessImportedFile.php
@@ -127,7 +127,9 @@ class ProcessImportedFile implements ShouldQueue
             return;
         }
 
-        MatchTransactionHeads::dispatch($this->importedFile);
+        if ($this->importedFile->source->shouldAutoMatchHeads()) {
+            MatchTransactionHeads::dispatch($this->importedFile);
+        }
     }
 
     private function sanitiseErrorMessage(\Throwable $exception, string $prefix): string

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -676,6 +676,7 @@ class DocumentProcessor
                 'total_rows' => 1,
                 'mapped_rows' => 0,
                 'processed_at' => now(),
+                'display_name' => "{$vendorName}_{$file->statement_type->getLabel()}",
             ]);
         });
     }

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -65,7 +65,7 @@ describe('ProcessImportedFile auto-suggestion dispatch', function () {
             ],
         ]);
 
-        Queue::fake([SuggestReconciliationMatches::class]);
+        Queue::fake([SuggestReconciliationMatches::class, MatchTransactionHeads::class]);
 
         $file = ImportedFile::factory()->create([
             'status' => ImportStatus::Pending,
@@ -277,6 +277,8 @@ describe('ProcessImportedFile with Agent::fake()', function () {
             ],
         ]);
 
+        Queue::fake([MatchTransactionHeads::class]);
+
         $file = ImportedFile::factory()->create([
             'status' => ImportStatus::Pending,
             'file_path' => 'statements/test.pdf',
@@ -299,7 +301,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
             ->and($transactions->first()->mapping_type)->toBe(MappingType::Unmapped);
     });
 
-    it('does not auto-dispatch MatchTransactionHeads after processing', function () {
+    it('auto-dispatches MatchTransactionHeads after processing a bank statement', function () {
         Storage::fake('local');
         Storage::put('statements/test.pdf', 'fake-pdf-content');
 
@@ -316,6 +318,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
 
         $file = ImportedFile::factory()->create([
             'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Bank,
             'file_path' => 'statements/test.pdf',
         ]);
 
@@ -329,6 +332,70 @@ describe('ProcessImportedFile with Agent::fake()', function () {
 
         $file->refresh();
         expect($file->status)->toBe(ImportStatus::Completed);
+
+        Queue::assertPushed(MatchTransactionHeads::class, function ($job) use ($file) {
+            return $job->importedFile->id === $file->id;
+        });
+    });
+
+    it('auto-dispatches MatchTransactionHeads after processing a credit card statement', function () {
+        Storage::fake('local');
+        Storage::put('statements/cc.pdf', 'fake-pdf-content');
+
+        StatementParser::fake([
+            [
+                'bank_name' => 'HDFC CC',
+                'transactions' => [
+                    ['date' => '2024-01-10', 'description' => 'SWIGGY ORDER', 'debit' => 500, 'balance' => 9500],
+                ],
+            ],
+        ]);
+
+        Queue::fake([MatchTransactionHeads::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::CreditCard,
+            'file_path' => 'statements/cc.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        $file->refresh();
+        expect($file->status)->toBe(ImportStatus::Completed);
+
+        Queue::assertPushed(MatchTransactionHeads::class, function ($job) use ($file) {
+            return $job->importedFile->id === $file->id;
+        });
+    });
+
+    it('does not dispatch MatchTransactionHeads for invoice files', function () {
+        Storage::fake('local');
+        Storage::put('statements/invoice.pdf', 'fake-pdf-content');
+
+        InvoiceParser::fake([
+            [
+                'vendor_name' => 'Test Vendor',
+                'invoice_number' => 'INV/001',
+                'invoice_date' => '2025-04-05',
+                'total_amount' => 15000,
+                'currency' => 'INR',
+                'base_amount' => 12712,
+                'line_items' => [['description' => 'Services', 'amount' => 12712]],
+            ],
+        ]);
+
+        Queue::fake([MatchTransactionHeads::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Invoice,
+            'file_path' => 'statements/invoice.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
 
         Queue::assertNotPushed(MatchTransactionHeads::class);
     });

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -2,6 +2,7 @@
 
 use App\Ai\Agents\InvoiceParser;
 use App\Ai\Agents\StatementParser;
+use App\Enums\ImportSource;
 use App\Enums\ImportStatus;
 use App\Enums\MappingType;
 use App\Enums\StatementType;
@@ -451,5 +452,157 @@ describe('ProcessImportedFile with Agent::fake()', function () {
         $file->refresh();
         expect($file->status)->toBe(ImportStatus::Failed)
             ->and($file->error_message)->not->toBeNull();
+    });
+});
+
+describe('ProcessImportedFile invoice display_name', function () {
+    it('sets display_name to vendor_name_Invoice for a manually uploaded invoice', function () {
+        Storage::fake('local');
+        Storage::put('statements/invoice.pdf', 'fake-pdf-content');
+
+        InvoiceParser::fake([
+            [
+                'vendor_name' => 'Swiggy',
+                'invoice_number' => 'SWG/2025/001',
+                'invoice_date' => '2025-04-05',
+                'total_amount' => 5000,
+                'currency' => 'INR',
+                'base_amount' => 4237,
+                'line_items' => [['description' => 'Food delivery', 'amount' => 4237]],
+            ],
+        ]);
+
+        Queue::fake([SuggestReconciliationMatches::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Invoice,
+            'source' => ImportSource::ManualUpload,
+            'file_path' => 'statements/invoice.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        $file->refresh();
+        expect($file->display_name)->toBe('Swiggy_Invoice');
+    });
+
+    it('sets display_name to vendor_name_Invoice for an invoice imported via email', function () {
+        Storage::fake('local');
+        Storage::put('statements/invoice.pdf', 'fake-pdf-content');
+
+        InvoiceParser::fake([
+            [
+                'vendor_name' => 'AWS',
+                'invoice_number' => 'AWS/2025/042',
+                'invoice_date' => '2025-03-31',
+                'total_amount' => 12000,
+                'currency' => 'INR',
+                'base_amount' => 10169,
+                'line_items' => [['description' => 'Cloud services', 'amount' => 10169]],
+            ],
+        ]);
+
+        Queue::fake([SuggestReconciliationMatches::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Invoice,
+            'source' => ImportSource::Email,
+            'file_path' => 'statements/invoice.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        $file->refresh();
+        expect($file->display_name)->toBe('AWS_Invoice');
+    });
+});
+
+describe('ProcessImportedFile email import matching', function () {
+    it('does not dispatch MatchTransactionHeads for a bank statement imported via email', function () {
+        Storage::fake('local');
+        Storage::put('statements/bank.pdf', 'fake-pdf-content');
+
+        StatementParser::fake([
+            [
+                'bank_name' => 'HDFC Bank',
+                'transactions' => [
+                    ['date' => '2025-04-05', 'description' => 'NEFT IN', 'credit' => 50000, 'balance' => 150000],
+                ],
+            ],
+        ]);
+
+        Queue::fake([MatchTransactionHeads::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Bank,
+            'source' => ImportSource::Email,
+            'file_path' => 'statements/bank.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        Queue::assertNotPushed(MatchTransactionHeads::class);
+    });
+
+    it('does not dispatch MatchTransactionHeads for a credit card statement imported via email', function () {
+        Storage::fake('local');
+        Storage::put('statements/cc.pdf', 'fake-pdf-content');
+
+        StatementParser::fake([
+            [
+                'bank_name' => 'HDFC CC',
+                'transactions' => [
+                    ['date' => '2025-04-10', 'description' => 'ZOMATO', 'debit' => 350, 'balance' => 9650],
+                ],
+            ],
+        ]);
+
+        Queue::fake([MatchTransactionHeads::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::CreditCard,
+            'source' => ImportSource::Email,
+            'file_path' => 'statements/cc.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        Queue::assertNotPushed(MatchTransactionHeads::class);
+    });
+
+    it('dispatches MatchTransactionHeads for a bank statement uploaded manually', function () {
+        Storage::fake('local');
+        Storage::put('statements/bank.pdf', 'fake-pdf-content');
+
+        StatementParser::fake([
+            [
+                'bank_name' => 'SBI',
+                'transactions' => [
+                    ['date' => '2025-04-05', 'description' => 'DEPOSIT', 'credit' => 20000, 'balance' => 120000],
+                ],
+            ],
+        ]);
+
+        Queue::fake([MatchTransactionHeads::class]);
+
+        $file = ImportedFile::factory()->create([
+            'status' => ImportStatus::Pending,
+            'statement_type' => StatementType::Bank,
+            'source' => ImportSource::ManualUpload,
+            'file_path' => 'statements/bank.pdf',
+        ]);
+
+        $job = new ProcessImportedFile($file);
+        $job->handle(app(DocumentProcessor::class));
+
+        Queue::assertPushed(MatchTransactionHeads::class, fn ($job) => $job->importedFile->id === $file->id);
     });
 });


### PR DESCRIPTION
## Summary
- `ProcessImportedFile` now automatically dispatches `MatchTransactionHeads` after processing Bank and Credit Card statements
- This closes the pipeline gap that left `TransactionAggregate` rows with `account_head_id = null`, causing reports graphs to show no data
- Invoice files continue to dispatch `SuggestReconciliationMatches` as before

## Test plan
- [ ] Upload a bank statement → verify `MatchTransactionHeads` is queued automatically
- [ ] Upload a credit card statement → verify `MatchTransactionHeads` is queued automatically
- [ ] Upload an invoice → verify `SuggestReconciliationMatches` is queued, `MatchTransactionHeads` is not
- [ ] After processing completes, verify reports page shows data without any manual steps

Closes #212