### PR TITLE
fix(reports): rebuild aggregates after head matching (#214)

### DIFF
--- a/app/Jobs/MatchTransactionHeads.php
+++ b/app/Jobs/MatchTransactionHeads.php
@@ -6,6 +6,7 @@ use App\Enums\MappingType;
 use App\Models\ImportedFile;
 use App\Notifications\HeadMatchingCompletedNotification;
 use App\Notifications\LowConfidenceMatchesNotification;
+use App\Services\AggregateService;
 use App\Services\HeadMatcher\HeadMatcherService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -46,7 +47,7 @@ class MatchTransactionHeads implements ShouldQueue
         return [30, 120, 300];
     }
 
-    public function handle(HeadMatcherService $headMatcherService): void
+    public function handle(HeadMatcherService $headMatcherService, AggregateService $aggregateService): void
     {
         try {
             $results = $headMatcherService->matchForFile($this->importedFile);
@@ -57,6 +58,8 @@ class MatchTransactionHeads implements ShouldQueue
                 'ai_matched' => $results['ai_matched'],
                 'unmatched' => $results['unmatched'],
             ]);
+
+            $aggregateService->rebuildForFile($this->importedFile);
 
             $this->importedFile->update(['is_matching' => false]);
             $this->notifyCompletion($results);

--- a/app/Services/AggregateService.php
+++ b/app/Services/AggregateService.php
@@ -5,8 +5,10 @@ namespace App\Services;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Models\TransactionAggregate;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class AggregateService
 {
@@ -45,7 +47,7 @@ class AggregateService
         $aggregates = [];
 
         $query->chunk(500, function ($transactions) use (&$aggregates) {
-            /** @var \Illuminate\Database\Eloquent\Collection<int, Transaction> $transactions */
+            /** @var Collection<int, Transaction> $transactions */
             foreach ($transactions as $transaction) {
                 $key = $this->buildAggregateKey($transaction);
 
@@ -85,6 +87,31 @@ class AggregateService
                 ]), $chunk)
             );
         }
+    }
+
+    /**
+     * Rebuild aggregates for all transactions belonging to a specific imported file.
+     * Replaces stale null-head aggregates written when transactions were first created.
+     */
+    public function rebuildForFile(ImportedFile $file): void
+    {
+        $yearMonths = Transaction::query()
+            ->where('imported_file_id', $file->id)
+            ->distinct()
+            ->pluck(DB::raw("TO_CHAR(date, 'YYYY-MM') AS year_month"));
+
+        if ($yearMonths->isEmpty()) {
+            return;
+        }
+
+        foreach ($yearMonths as $yearMonth) {
+            $this->rebuild($file->company_id, $yearMonth);
+        }
+
+        Log::info('Aggregates rebuilt for file', [
+            'file_id' => $file->id,
+            'year_months' => $yearMonths->all(),
+        ]);
     }
 
     /**

--- a/tests/Feature/Jobs/MatchTransactionHeadsTest.php
+++ b/tests/Feature/Jobs/MatchTransactionHeadsTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use App\Jobs\MatchTransactionHeads;
+use App\Models\AccountHead;
 use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Models\TransactionAggregate;
+use App\Services\AggregateService;
 use App\Services\HeadMatcher\HeadMatcherService;
 use Illuminate\Support\Facades\Log;
 
@@ -16,24 +20,25 @@ describe('MatchTransactionHeads job', function () {
             ->andReturn(['rule_matched' => 2, 'ai_matched' => 1, 'unmatched' => 0]);
 
         $job = new MatchTransactionHeads($file);
-        $job->handle($service);
+        $job->handle($service, app(AggregateService::class));
     });
 
     it('logs results after matching', function () {
         $file = ImportedFile::factory()->create();
 
         Log::shouldReceive('info')
-            ->once()
             ->withArgs(fn ($msg, $context) => $msg === 'Head matching completed'
                 && $context['file_id'] === $file->id
-                && $context['rule_matched'] === 5);
+                && $context['rule_matched'] === 5)
+            ->once();
+        Log::shouldReceive('info')->withAnyArgs();
 
         $service = Mockery::mock(HeadMatcherService::class);
         $service->shouldReceive('matchForFile')
             ->andReturn(['rule_matched' => 5, 'ai_matched' => 0, 'unmatched' => 3]);
 
         $job = new MatchTransactionHeads($file);
-        $job->handle($service);
+        $job->handle($service, app(AggregateService::class));
     });
 
     it('logs and rethrows errors', function () {
@@ -49,7 +54,7 @@ describe('MatchTransactionHeads job', function () {
 
         $job = new MatchTransactionHeads($file);
 
-        expect(fn () => $job->handle($service))->toThrow(RuntimeException::class, 'AI service unavailable');
+        expect(fn () => $job->handle($service, app(AggregateService::class)))->toThrow(RuntimeException::class, 'AI service unavailable');
     });
 
     it('implements ShouldQueue', function () {
@@ -70,5 +75,93 @@ describe('MatchTransactionHeads job', function () {
 
     it('has 3 tries configured', function () {
         expect((new MatchTransactionHeads(ImportedFile::factory()->create()))->tries)->toBe(3);
+    });
+});
+
+describe('MatchTransactionHeads aggregate rebuild', function () {
+    it('rebuilds TransactionAggregate after matching so reports reflect real account heads', function () {
+        asUser();
+        $company = tenant();
+        $head = AccountHead::factory()->create(['company_id' => $company->id]);
+        $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+
+        // Step 1: Create transactions (observer fires → aggregates written with null account_head_id)
+        $transactions = Transaction::factory()->count(2)->debit(3000)->create([
+            'company_id' => $company->id,
+            'imported_file_id' => $file->id,
+            'account_head_id' => null,
+            'date' => '2025-04-10',
+        ]);
+
+        // Confirm stale aggregate state: null head
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->whereNull('account_head_id')
+            ->where('year_month', '2025-04')
+            ->exists()
+        )->toBeTrue();
+
+        // Step 2: Simulate bulk head matching — bypasses observer, aggregates stay stale
+        Transaction::where('imported_file_id', $file->id)
+            ->update(['account_head_id' => $head->id]);
+
+        // Aggregates still show null head (the bug)
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->where('account_head_id', $head->id)
+            ->exists()
+        )->toBeFalse();
+
+        // Step 3: Run the job (mock service so AI doesn't actually run)
+        $service = Mockery::mock(HeadMatcherService::class);
+        $service->shouldReceive('matchForFile')
+            ->once()
+            ->andReturn(['rule_matched' => 2, 'ai_matched' => 0, 'unmatched' => 0]);
+
+        $job = new MatchTransactionHeads($file);
+        $job->handle($service, app(AggregateService::class));
+
+        // Step 4: Aggregates should now reflect the real account head
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->where('account_head_id', $head->id)
+            ->where('year_month', '2025-04')
+            ->exists()
+        )->toBeTrue();
+    });
+
+    it('does not rebuild aggregates when matching throws an exception', function () {
+        asUser();
+        $company = tenant();
+        $head = AccountHead::factory()->create(['company_id' => $company->id]);
+        $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+
+        Transaction::factory()->debit(1000)->create([
+            'company_id' => $company->id,
+            'imported_file_id' => $file->id,
+            'account_head_id' => null,
+            'date' => '2025-04-10',
+        ]);
+
+        // Pre-assign head via bulk update (stale state)
+        Transaction::where('imported_file_id', $file->id)
+            ->update(['account_head_id' => $head->id]);
+
+        $service = Mockery::mock(HeadMatcherService::class);
+        $service->shouldReceive('matchForFile')
+            ->andThrow(new RuntimeException('AI service unavailable'));
+
+        $aggregateService = Mockery::mock(AggregateService::class);
+        $aggregateService->shouldNotReceive('rebuildForFile');
+
+        Log::shouldReceive('error')->once();
+
+        $job = new MatchTransactionHeads($file);
+
+        expect(fn () => $job->handle($service, $aggregateService))->toThrow(RuntimeException::class);
+
+        // Aggregate rebuild should NOT have run — null-head aggregate still present
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->whereNull('account_head_id')
+            ->where('year_month', '2025-04')
+            ->exists()
+        )->toBeTrue();
     });
 });

--- a/tests/Feature/Services/AggregateServiceTest.php
+++ b/tests/Feature/Services/AggregateServiceTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\AccountHead;
 use App\Models\Company;
+use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Models\TransactionAggregate;
 use App\Services\AggregateService;
@@ -150,6 +151,107 @@ describe('AggregateService', function () {
                 ->where('year_month', '2025-03')
                 ->first();
             expect($marchAgg)->not->toBeNull();
+        });
+    });
+
+    describe('rebuildForFile', function () {
+        it('rebuilds aggregates for a file so stale null-head rows are replaced with real account heads', function () {
+            $company = tenant();
+            $head = AccountHead::factory()->create(['company_id' => $company->id]);
+
+            $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+
+            // Create transaction with the real account_head_id but WITHOUT firing the observer
+            // so we can manually insert a stale aggregate (simulating the bug: aggregate was
+            // written at transaction creation time when account_head_id was null).
+            Transaction::withoutEvents(function () use ($company, $file, $head) {
+                Transaction::factory()->debit(5000)->create([
+                    'company_id' => $company->id,
+                    'imported_file_id' => $file->id,
+                    'account_head_id' => $head->id,
+                    'date' => '2025-04-15',
+                ]);
+            });
+
+            // Insert a stale aggregate with null account_head_id — this mirrors what the
+            // observer writes at transaction creation time (before head matching runs).
+            TransactionAggregate::insert([
+                'company_id' => $company->id,
+                'account_head_id' => null,
+                'bank_account_id' => null,
+                'credit_card_id' => null,
+                'year_month' => '2025-04',
+                'total_debit' => 5000,
+                'total_credit' => 0,
+                'transaction_count' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Confirm stale state: aggregate has null account_head_id
+            expect(TransactionAggregate::where('company_id', $company->id)
+                ->where('year_month', '2025-04')
+                ->whereNull('account_head_id')
+                ->exists()
+            )->toBeTrue();
+
+            $this->service->rebuildForFile($file);
+
+            // After rebuild: null-head aggregate is gone, real head aggregate exists
+            expect(TransactionAggregate::where('company_id', $company->id)
+                ->where('year_month', '2025-04')
+                ->whereNull('account_head_id')
+                ->exists()
+            )->toBeFalse()
+                ->and(TransactionAggregate::where('company_id', $company->id)
+                    ->where('year_month', '2025-04')
+                    ->where('account_head_id', $head->id)
+                    ->value('total_debit')
+                )->toBe('5000.00');
+        });
+
+        it('handles a file whose transactions span multiple months', function () {
+            $company = tenant();
+            $head = AccountHead::factory()->create(['company_id' => $company->id]);
+            $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+
+            Transaction::withoutEvents(function () use ($company, $file, $head) {
+                Transaction::factory()->debit(1000)->create([
+                    'company_id' => $company->id,
+                    'imported_file_id' => $file->id,
+                    'account_head_id' => $head->id,
+                    'date' => '2025-03-20',
+                ]);
+                Transaction::factory()->debit(2000)->create([
+                    'company_id' => $company->id,
+                    'imported_file_id' => $file->id,
+                    'account_head_id' => $head->id,
+                    'date' => '2025-04-05',
+                ]);
+            });
+
+            $this->service->rebuildForFile($file);
+
+            expect(TransactionAggregate::where('company_id', $company->id)
+                ->where('account_head_id', $head->id)
+                ->where('year_month', '2025-03')
+                ->value('total_debit')
+            )->toBe('1000.00')
+                ->and(TransactionAggregate::where('company_id', $company->id)
+                    ->where('account_head_id', $head->id)
+                    ->where('year_month', '2025-04')
+                    ->value('total_debit')
+                )->toBe('2000.00');
+        });
+
+        it('does nothing when the file has no transactions', function () {
+            $company = tenant();
+            $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+
+            // Should not throw
+            $this->service->rebuildForFile($file);
+
+            expect(TransactionAggregate::where('company_id', $company->id)->count())->toBe(0);
         });
     });
 


### PR DESCRIPTION
## Summary

- `MatchTransactionHeads` uses `Transaction::where()->update()` (bulk update) which bypasses Eloquent observers — leaving `TransactionAggregate` rows with `null` account_head_id even after all transactions are mapped
- Added `AggregateService::rebuildForFile(ImportedFile $file)` that queries distinct year-months for the file's transactions and calls the existing `rebuild(company_id, yearMonth)` for each
- Called at the end of `MatchTransactionHeads::handle()` after matching completes — reports now show real account head names instead of "Unknown"

## Test plan

- [ ] Run `php artisan test --filter="MatchTransactionHeads|AggregateService"` — all 27 tests pass
- [ ] Upload a bank/CC statement, trigger head matching, verify Reports page shows mapped account heads
- [ ] Re-run head matching on a file, confirm aggregates are refreshed correctly
- [ ] Verify unmapped transactions still aggregate under `null` account_head_id

Closes #214