### PR TITLE
fix(review-queue): explicit company_id filter for defence-in-depth tenant scoping (#216)

### DIFF
--- a/app/Filament/Pages/ReviewQueue.php
+++ b/app/Filament/Pages/ReviewQueue.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Enums\MappingType;
 use App\Models\AccountHead;
+use App\Models\Company;
 use App\Models\Transaction;
 use BackedEnum;
 use Filament\Actions;
@@ -39,13 +40,14 @@ class ReviewQueue extends Page implements HasActions, HasSchemas, HasTable
 
     public function table(Table $table): Table
     {
-        /** @var \App\Models\Company $company */
+        /** @var Company $company */
         $company = Filament::getTenant();
         $threshold = (float) $company->review_confidence_threshold;
 
         return $table
             ->query(
                 Transaction::query()
+                    ->where('company_id', $company->getKey())
                     ->where('mapping_type', MappingType::Ai)
                     ->where('ai_confidence', '<', $threshold)
                     ->with(['accountHead', 'importedFile'])
@@ -154,7 +156,7 @@ class ReviewQueue extends Page implements HasActions, HasSchemas, HasTable
 
     public static function getNavigationBadge(): ?string
     {
-        /** @var \App\Models\Company|null $company */
+        /** @var Company|null $company */
         $company = Filament::getTenant();
 
         if (! $company) {

--- a/tests/Feature/Filament/ReviewQueueTest.php
+++ b/tests/Feature/Filament/ReviewQueueTest.php
@@ -3,6 +3,7 @@
 use App\Enums\MappingType;
 use App\Filament\Pages\ReviewQueue;
 use App\Models\AccountHead;
+use App\Models\Company;
 use App\Models\Transaction;
 use Filament\Actions\Testing\TestAction;
 
@@ -147,5 +148,68 @@ describe('ReviewQueue page', function () {
         ]);
 
         expect(ReviewQueue::getNavigationBadge())->toBe('5');
+    });
+});
+
+describe('ReviewQueue tenant isolation', function () {
+    beforeEach(function () {
+        asUser();
+        $this->company = tenant();
+        $this->company->update(['review_confidence_threshold' => 0.80]);
+    });
+
+    it('does not show transactions from another company', function () {
+        $otherCompany = Company::factory()->create(['review_confidence_threshold' => 0.80]);
+
+        $ownTxn = Transaction::factory()->for($this->company)->create([
+            'mapping_type' => MappingType::Ai,
+            'ai_confidence' => 0.65,
+            'account_head_id' => AccountHead::factory()->for($this->company)->create()->id,
+        ]);
+
+        Transaction::withoutEvents(function () use ($otherCompany) {
+            Transaction::factory()->for($otherCompany)->create([
+                'mapping_type' => MappingType::Ai,
+                'ai_confidence' => 0.65,
+                'account_head_id' => AccountHead::factory()->for($otherCompany)->create()->id,
+            ]);
+        });
+
+        livewire(ReviewQueue::class)
+            ->assertCanSeeTableRecords([$ownTxn])
+            ->assertCountTableRecords(1);
+    });
+
+    it('shows the correct AI suggested head name', function () {
+        $head = AccountHead::factory()->for($this->company)->create(['name' => 'Office Supplies']);
+
+        Transaction::factory()->for($this->company)->create([
+            'mapping_type' => MappingType::Ai,
+            'ai_confidence' => 0.65,
+            'account_head_id' => $head->id,
+        ]);
+
+        livewire(ReviewQueue::class)
+            ->assertSeeText('Office Supplies');
+    });
+
+    it('navigation badge only counts current company transactions', function () {
+        $otherCompany = Company::factory()->create(['review_confidence_threshold' => 0.80]);
+
+        Transaction::factory()->count(3)->for($this->company)->create([
+            'mapping_type' => MappingType::Ai,
+            'ai_confidence' => 0.65,
+            'account_head_id' => AccountHead::factory()->for($this->company)->create()->id,
+        ]);
+
+        Transaction::withoutEvents(function () use ($otherCompany) {
+            Transaction::factory()->count(10)->for($otherCompany)->create([
+                'mapping_type' => MappingType::Ai,
+                'ai_confidence' => 0.65,
+                'account_head_id' => AccountHead::factory()->for($otherCompany)->create()->id,
+            ]);
+        });
+
+        expect(ReviewQueue::getNavigationBadge())->toBe('3');
     });
 });


### PR DESCRIPTION
## Summary

- `ReviewQueue` table query was missing an explicit `company_id` filter, inconsistent with `getNavigationBadge()` which already had it
- Filament v5 automatically scopes table queries via panel tenancy — so this is defence-in-depth rather than a functional bug fix
- Adds 3 tenant isolation tests to document and protect the expected behaviour

## Test plan

- [ ] Run `php artisan test --filter=ReviewQueue` — all 12 tests pass
- [ ] Verify Review Queue shows only current tenant's transactions in the UI

## Notes

The blank "AI Suggested Head" column reported in the issue is caused by a separate issue: soft-deleted account heads whose `nullOnDelete` FK does not fire on soft deletes — tracked in #217.

Closes #216