### PR TITLE
fix(reports): null account_head_id on soft-delete and rebuild aggregates

### DIFF
--- a/app/Models/AccountHead.php
+++ b/app/Models/AccountHead.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\AggregateService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,6 +16,31 @@ class AccountHead extends Model
     use HasFactory;
     use LogsActivity;
     use SoftDeletes;
+
+    protected static function booted(): void
+    {
+        static::deleting(function (AccountHead $head) {
+            if (! $head->isForceDeleting()) {
+                $yearMonths = Transaction::where('account_head_id', $head->id)
+                    ->distinct()
+                    ->selectRaw("TO_CHAR(date, 'YYYY-MM') AS year_month")
+                    ->pluck('year_month');
+
+                if ($yearMonths->isEmpty()) {
+                    return;
+                }
+
+                Transaction::withoutEvents(function () use ($head) {
+                    $head->transactions()->update(['account_head_id' => null]);
+                });
+
+                $service = app(AggregateService::class);
+                foreach ($yearMonths as $yearMonth) {
+                    $service->rebuild($head->company_id, $yearMonth);
+                }
+            }
+        });
+    }
 
     protected $fillable = [
         'company_id',

--- a/tests/Feature/Models/AccountHeadTest.php
+++ b/tests/Feature/Models/AccountHeadTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\AccountHead;
+use App\Models\Transaction;
+use App\Models\TransactionAggregate;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 describe('AccountHead soft deletes', function () {
@@ -77,6 +79,74 @@ describe('AccountHead::fullPath', function () {
         $child = AccountHead::factory()->withParent($parent)->create(['name' => 'Bank Accounts']);
 
         expect($child->full_path)->toBe('Assets > Current Assets > Bank Accounts');
+    });
+});
+
+describe('AccountHead soft-delete cascade', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('nulls account_head_id on mapped transactions when soft-deleted', function () {
+        $head = AccountHead::factory()->create();
+        $txn = Transaction::factory()->mapped($head)->create();
+
+        $head->delete();
+
+        expect($txn->fresh()->account_head_id)->toBeNull();
+    });
+
+    it('updates TransactionAggregate when soft-deleting an account head', function () {
+        $company = tenant();
+        $head = AccountHead::factory()->create(['company_id' => $company->id]);
+
+        Transaction::factory()->mapped($head)->debit(5000)->create([
+            'company_id' => $company->id,
+            'date' => '2025-04-15',
+        ]);
+
+        // Aggregate should have the head assigned
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->where('account_head_id', $head->id)
+            ->exists()
+        )->toBeTrue();
+
+        $head->delete();
+
+        // Aggregate should now be under null head
+        expect(TransactionAggregate::where('company_id', $company->id)
+            ->where('account_head_id', $head->id)
+            ->exists()
+        )->toBeFalse()
+            ->and(TransactionAggregate::where('company_id', $company->id)
+                ->whereNull('account_head_id')
+                ->exists()
+            )->toBeTrue();
+    });
+
+    it('does not re-map transactions when an account head is restored', function () {
+        $head = AccountHead::factory()->create();
+        $txn = Transaction::factory()->mapped($head)->create();
+
+        $head->delete();
+
+        // After soft-delete: transaction is unmapped
+        expect($txn->fresh()->account_head_id)->toBeNull();
+
+        $head->restore();
+
+        // After restore: transaction remains unmapped
+        expect($txn->fresh()->account_head_id)->toBeNull();
+    });
+
+    it('does not null transactions when force-deleted (DB cascade handles it)', function () {
+        $head = AccountHead::factory()->create();
+        $txn = Transaction::factory()->mapped($head)->create();
+
+        $head->forceDelete();
+
+        // DB nullOnDelete fires — transaction's account_head_id is nulled by PostgreSQL
+        expect($txn->fresh()->account_head_id)->toBeNull();
     });
 });
 


### PR DESCRIPTION
## Summary

- Soft-deleting an `AccountHead` now nulls `account_head_id` on all its mapped transactions and rebuilds `TransactionAggregate` for affected months
- Force deletes are left to PostgreSQL's `nullOnDelete` FK constraint (no change)
- Reports page will no longer show "Unknown" for soft-deleted account heads

## Root Cause

`nullOnDelete()` FK constraints only fire on hard (force) deletes at the DB level. Eloquent soft-deletes just set `deleted_at`, so relationship loads exclude the row via the global scope — `$row->accountHead` returns `null` → "Unknown" in reports.

## Approach

In `AccountHead::booted()`, on soft-delete:
1. Collect distinct year-months from mapped transactions (before nulling)
2. Null `account_head_id` on all transactions via `withoutEvents()` (skip per-row observer to avoid N redundant aggregate updates)
3. Call `AggregateService::rebuild()` for each affected month to recompute aggregates from scratch

## Test plan

- [x] Soft-deleting an account head nulls `account_head_id` on mapped transactions
- [x] `TransactionAggregate` rows move from the deleted head to the null-head bucket
- [x] Restoring an account head does NOT re-map previously unmapped transactions
- [x] Force-deleting still works (DB cascade handles it, no PHP intervention)
- [x] All 16 `AccountHeadTest` tests pass
- [x] Pint, PHPStan, and full test suite pass with no new failures

Closes #217