### PR TITLE
fix(tenancy): guard backfill migration to prevent phantom company on fresh install

### DIFF
--- a/database/migrations/2026_02_26_103900_backfill_company_id.php
+++ b/database/migrations/2026_02_26_103900_backfill_company_id.php
@@ -7,36 +7,39 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // Create the initial company from config defaults
-        $companyId = DB::table('companies')->insertGetId([
-            'name' => config('company.name', 'Zysk Technologies Private Limited - 2025 - 2026'),
-            'gstin' => config('company.gstin', '29AABCZ5012F1ZG'),
-            'state' => config('company.state', 'Karnataka'),
-            'gst_registration_type' => config('company.gst_registration_type', 'Regular'),
-            'financial_year' => config('company.financial_year', '2025-2026'),
-            'currency' => config('company.currency', 'INR'),
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
-
-        // Attach all existing users to this company
+        // This is a one-time backfill for databases that pre-date multi-tenancy.
+        // On a fresh install every table is empty — there is nothing to backfill
+        // and creating a default company here would pollute test databases.
         $userIds = DB::table('users')->pluck('id');
-        foreach ($userIds as $userId) {
-            DB::table('company_user')->insert([
-                'company_id' => $companyId,
-                'user_id' => $userId,
+
+        if ($userIds->isNotEmpty()) {
+            $companyId = DB::table('companies')->insertGetId([
+                'name' => config('company.name', 'Zysk Technologies Private Limited - 2025 - 2026'),
+                'gstin' => config('company.gstin', '29AABCZ5012F1ZG'),
+                'state' => config('company.state', 'Karnataka'),
+                'gst_registration_type' => config('company.gst_registration_type', 'Regular'),
+                'financial_year' => config('company.financial_year', '2025-2026'),
+                'currency' => config('company.currency', 'INR'),
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);
+
+            foreach ($userIds as $userId) {
+                DB::table('company_user')->insert([
+                    'company_id' => $companyId,
+                    'user_id' => $userId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            DB::table('imported_files')->whereNull('company_id')->update(['company_id' => $companyId]);
+            DB::table('account_heads')->whereNull('company_id')->update(['company_id' => $companyId]);
+            DB::table('head_mappings')->whereNull('company_id')->update(['company_id' => $companyId]);
+            DB::table('transactions')->whereNull('company_id')->update(['company_id' => $companyId]);
         }
 
-        // Backfill company_id on all existing rows
-        DB::table('imported_files')->whereNull('company_id')->update(['company_id' => $companyId]);
-        DB::table('account_heads')->whereNull('company_id')->update(['company_id' => $companyId]);
-        DB::table('head_mappings')->whereNull('company_id')->update(['company_id' => $companyId]);
-        DB::table('transactions')->whereNull('company_id')->update(['company_id' => $companyId]);
-
-        // Make company_id NOT NULL after backfill
+        // Applied outside the guard — safe on empty tables, required after backfill
         DB::statement('ALTER TABLE imported_files ALTER COLUMN company_id SET NOT NULL');
         DB::statement('ALTER TABLE account_heads ALTER COLUMN company_id SET NOT NULL');
         DB::statement('ALTER TABLE head_mappings ALTER COLUMN company_id SET NOT NULL');

--- a/tests/Feature/Filament/CompanyTenancyTest.php
+++ b/tests/Feature/Filament/CompanyTenancyTest.php
@@ -187,6 +187,20 @@ describe('Register Company page', function () {
             ->callAction('cancel')
             ->assertRedirect(route('filament.admin.auth.login'));
     });
+
+    it('creates exactly one company when registering', function () {
+        livewire(RegisterCompany::class)
+            ->fillForm([
+                'name' => 'My New Company',
+                'gst_registration_type' => 'Regular',
+                'currency' => 'INR',
+            ])
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        expect(Company::count())->toBe(1)
+            ->and(Company::first()->name)->toBe('My New Company');
+    });
 });
 
 describe('Edit Company Settings page', function () {


### PR DESCRIPTION
## Summary

- The backfill migration was unconditionally creating a \"Zysk Technologies\" company on every `migrate:fresh`, making `LazilyRefreshDatabase` inject a phantom company before each test suite run
- Migration-committed rows survive the per-test transaction rollback, so `Company::count()` saw 2 records during registration tests
- Fix: guard the backfill behind `$userIds->isNotEmpty()` — only runs when legacy pre-tenancy data exists; NOT NULL constraints remain unconditional

## Test plan

- [ ] `php artisan test --filter=CompanyTenancyTest --compact` — all 25 tests pass, including new regression test `creates exactly one company when registering`
- [ ] Full suite: 1212 passed (1 pre-existing unrelated failure in `CreditCardSharingTest`, tracked as #225)
- [ ] Pint: Pass | PHPStan: Pass

Closes #222