### PR TITLE
fix(export): invoice Journal voucher with GST breakdown and display name

### DIFF
--- a/app/Services/DisplayNameGenerator.php
+++ b/app/Services/DisplayNameGenerator.php
@@ -2,13 +2,19 @@
 
 namespace App\Services;
 
+use App\Enums\StatementType;
 use App\Models\ImportedFile;
+use App\Models\Transaction;
 use Carbon\Carbon;
 
 class DisplayNameGenerator
 {
     public function generate(ImportedFile $file): string
     {
+        if ($file->statement_type === StatementType::Invoice) {
+            return $this->generateInvoiceName($file);
+        }
+
         $period = $this->resolvePeriod($file);
         $variant = $file->card_variant ?? $file->creditCard?->name;
 
@@ -17,6 +23,29 @@ class DisplayNameGenerator
         }
 
         return "{$file->bank_name}_{$period}";
+    }
+
+    private function generateInvoiceName(ImportedFile $file): string
+    {
+        $file->loadMissing('transactions');
+
+        /** @var Transaction|null $firstTransaction */
+        $firstTransaction = $file->transactions->first();
+
+        /** @var array<string, mixed>|null $raw */
+        $raw = $firstTransaction?->raw_data;
+
+        $invoiceNumber = $raw['invoice_number'] ?? null;
+        $vendorName = $raw['vendor_name'] ?? null;
+        $description = $raw['line_items'][0]['description'] ?? null;
+
+        $parts = array_filter([$invoiceNumber, $vendorName, $description]);
+
+        if (empty($parts)) {
+            return $file->bank_name ?? 'Invoice';
+        }
+
+        return implode(' - ', $parts);
     }
 
     private function resolvePeriod(ImportedFile $file): string

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -671,12 +671,15 @@ class DocumentProcessor
                 'bank_format' => $vendorName,
             ]);
 
+            $serviceDescription = ($rawData['line_items'][0]['description'] ?? null);
+            $displayName = implode(' - ', array_filter([$invoiceNumber, $vendorName, $serviceDescription]));
+
             $file->update([
                 'status' => ImportStatus::Completed,
                 'total_rows' => 1,
                 'mapped_rows' => 0,
                 'processed_at' => now(),
-                'display_name' => "{$vendorName}_{$file->statement_type->getLabel()}",
+                'display_name' => $displayName,
             ]);
         });
     }

--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -2,9 +2,12 @@
 
 namespace App\Services\TallyExport;
 
+use App\Enums\StatementType;
+use App\Models\AccountHead;
 use App\Models\Company;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class TallyExportService
@@ -19,14 +22,14 @@ class TallyExportService
     {
         $importedFile->loadMissing(['company', 'bankAccount']);
 
-        /** @var \Illuminate\Support\Collection<int, Transaction> $transactions */
+        /** @var Collection<int, Transaction> $transactions */
         $transactions = $importedFile->transactions()
             ->whereNotNull('account_head_id')
             ->with('accountHead')
             ->orderBy('date')
             ->get();
 
-        return $this->generateXml($transactions, $importedFile->company, $importedFile->bankAccount?->name);
+        return $this->generateXml($transactions, $importedFile->company, $importedFile->bankAccount?->name, $importedFile);
     }
 
     /**
@@ -46,6 +49,7 @@ class TallyExportService
             $transactions,
             $importedFile?->company,
             $importedFile?->bankAccount?->name,
+            $importedFile,
         );
     }
 
@@ -54,11 +58,10 @@ class TallyExportService
      *
      * @param  Collection<int, Transaction>  $transactions
      */
-    private function generateXml(Collection $transactions, ?Company $company, ?string $bankLedgerName): string
+    private function generateXml(Collection $transactions, ?Company $company, ?string $bankLedgerName, ?ImportedFile $importedFile = null): string
     {
         $this->voucherCounters = [];
         $companyName = $company?->name ?? '';
-        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?>'."\n";
         $xml .= '<ENVELOPE>'."\n";
@@ -70,13 +73,13 @@ class TallyExportService
         $xml .= '      <REQUESTDESC>'."\n";
         $xml .= '        <REPORTNAME>All Masters</REPORTNAME>'."\n";
         $xml .= '        <STATICVARIABLES>'."\n";
-        $xml .= '          <SVCURRENTCOMPANY>'.$e($companyName).'</SVCURRENTCOMPANY>'."\n";
+        $xml .= '          <SVCURRENTCOMPANY>'.$this->escapeXml($companyName).'</SVCURRENTCOMPANY>'."\n";
         $xml .= '        </STATICVARIABLES>'."\n";
         $xml .= '      </REQUESTDESC>'."\n";
         $xml .= '      <REQUESTDATA>'."\n";
 
         foreach ($transactions as $transaction) {
-            $xml .= $this->generateVoucher($transaction, $company, $bankLedgerName);
+            $xml .= $this->generateVoucher($transaction, $company, $bankLedgerName, $importedFile);
         }
 
         if ($company && $transactions->isNotEmpty()) {
@@ -92,42 +95,42 @@ class TallyExportService
     }
 
     /**
-     * Generate a single Tally voucher XML element (Payment or Receipt).
+     * Generate a single Tally voucher XML element (Payment, Receipt, or Journal).
      */
-    private function generateVoucher(Transaction $transaction, ?Company $company, ?string $bankLedgerName): string
+    private function generateVoucher(Transaction $transaction, ?Company $company, ?string $bankLedgerName, ?ImportedFile $importedFile = null): string
     {
+        if ($importedFile?->statement_type === StatementType::Invoice) {
+            return $this->generateInvoiceJournalVoucher($transaction, $company);
+        }
+
         $isPayment = $transaction->debit !== null;
         $voucherType = $isPayment ? 'Payment' : 'Receipt';
         $amount = (float) ($isPayment ? $transaction->debit : $transaction->credit);
-        /** @var \Illuminate\Support\Carbon $transactionDate */
+        /** @var Carbon $transactionDate */
         $transactionDate = $transaction->date;
         $date = $transactionDate->format('Ymd');
-        /** @var \App\Models\AccountHead|null $accountHead */
+        /** @var AccountHead|null $accountHead */
         $accountHead = $transaction->accountHead;
         $headName = $accountHead?->name ?? 'Unknown';
         $bankName = $bankLedgerName ?? 'Bank Account';
         $voucherNumber = $this->nextVoucherNumber($voucherType);
 
-        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
-
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
-        $xml .= '          <VOUCHER VCHTYPE="'.$e($voucherType).'" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
+        $xml .= '          <VOUCHER VCHTYPE="'.$this->escapeXml($voucherType).'" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
         $xml .= '            <DATE>'.$date.'</DATE>'."\n";
         $xml .= '            <VCHSTATUSDATE>'.$date.'</VCHSTATUSDATE>'."\n";
-        $xml .= '            <NARRATION>'.$e($transaction->description ?? '').'</NARRATION>'."\n";
-        $xml .= '            <VOUCHERTYPENAME>'.$e($voucherType).'</VOUCHERTYPENAME>'."\n";
+        $xml .= '            <NARRATION>'.$this->escapeXml($transaction->description ?? '').'</NARRATION>'."\n";
+        $xml .= '            <VOUCHERTYPENAME>'.$this->escapeXml($voucherType).'</VOUCHERTYPENAME>'."\n";
         $xml .= '            <VOUCHERNUMBER>'.$voucherNumber.'</VOUCHERNUMBER>'."\n";
-        $xml .= '            <PARTYLEDGERNAME>'.$e($headName).'</PARTYLEDGERNAME>'."\n";
+        $xml .= '            <PARTYLEDGERNAME>'.$this->escapeXml($headName).'</PARTYLEDGERNAME>'."\n";
 
         if ($company) {
-            $xml .= '            <CMPGSTIN>'.$e($company->gstin ?? '').'</CMPGSTIN>'."\n";
-            $xml .= '            <CMPGSTREGISTRATIONTYPE>'.$e($company->gst_registration_type ?? 'Regular').'</CMPGSTREGISTRATIONTYPE>'."\n";
-            $xml .= '            <CMPGSTSTATE>'.$e($company->state ?? '').'</CMPGSTSTATE>'."\n";
+            $xml .= '            <CMPGSTIN>'.$this->escapeXml($company->gstin ?? '').'</CMPGSTIN>'."\n";
+            $xml .= '            <CMPGSTREGISTRATIONTYPE>'.$this->escapeXml($company->gst_registration_type ?? 'Regular').'</CMPGSTREGISTRATIONTYPE>'."\n";
+            $xml .= '            <CMPGSTSTATE>'.$this->escapeXml($company->state ?? '').'</CMPGSTSTATE>'."\n";
         }
 
         $xml .= '            <EFFECTIVEDATE>'.$date.'</EFFECTIVEDATE>'."\n";
-
-        // Boilerplate boolean flags
         $xml .= '            <ISDELETED>No</ISDELETED>'."\n";
         $xml .= '            <ISCANCELLED>No</ISCANCELLED>'."\n";
         $xml .= '            <ISONHOLD>No</ISONHOLD>'."\n";
@@ -135,11 +138,10 @@ class TallyExportService
         $xml .= '            <AUDITED>No</AUDITED>'."\n";
         $xml .= '            <HASCASHFLOW>Yes</HASCASHFLOW>'."\n";
 
-        // Ledger entries
         if ($isPayment) {
-            $xml .= $this->generatePaymentLedgerEntries($headName, $bankName, $amount, $date, $e);
+            $xml .= $this->generatePaymentLedgerEntries($headName, $bankName, $amount, $date);
         } else {
-            $xml .= $this->generateReceiptLedgerEntries($headName, $bankName, $amount, $date, $e);
+            $xml .= $this->generateReceiptLedgerEntries($headName, $bankName, $amount, $date);
         }
 
         $xml .= '          </VOUCHER>'."\n";
@@ -149,28 +151,162 @@ class TallyExportService
     }
 
     /**
+     * Generate a Journal voucher for an invoice transaction with GST breakup.
+     * Multi-leg: expense debit, CGST/SGST (or IGST) debits, TDS credit (optional), vendor party credit.
+     */
+    private function generateInvoiceJournalVoucher(Transaction $transaction, ?Company $company): string
+    {
+        /** @var Carbon $transactionDate */
+        $transactionDate = $transaction->date;
+        $date = $transactionDate->format('Ymd');
+        /** @var AccountHead|null $accountHead */
+        $accountHead = $transaction->accountHead;
+        $headName = $accountHead?->name ?? 'Unknown';
+        $voucherNumber = $this->nextVoucherNumber('Journal');
+
+        /** @var array<string, mixed> $raw */
+        $raw = $transaction->raw_data ?? [];
+        $vendorName = (string) ($raw['vendor_name'] ?? 'Unknown Vendor');
+        $vendorGstin = (string) ($raw['vendor_gstin'] ?? '');
+        $invoiceNumber = (string) ($raw['invoice_number'] ?? '');
+        $baseAmount = (float) ($raw['base_amount'] ?? 0);
+        $cgstRate = $raw['cgst_rate'] ?? null;
+        $cgstAmount = (float) ($raw['cgst_amount'] ?? 0);
+        $sgstRate = $raw['sgst_rate'] ?? null;
+        $sgstAmount = (float) ($raw['sgst_amount'] ?? 0);
+        $igstRate = $raw['igst_rate'] ?? null;
+        $igstAmount = (float) ($raw['igst_amount'] ?? 0);
+        $tdsAmount = (float) ($raw['tds_amount'] ?? 0);
+        $totalAmount = (float) ($raw['total_amount'] ?? (float) ($transaction->debit ?? 0));
+
+        $narration = $invoiceNumber
+            ? "Invoice No: {$invoiceNumber} payment towards {$vendorName}"
+            : "Invoice payment towards {$vendorName}";
+
+        $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
+        $xml .= '          <VOUCHER VCHTYPE="Journal" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
+        $xml .= '            <DATE>'.$date.'</DATE>'."\n";
+        $xml .= '            <VCHSTATUSDATE>'.$date.'</VCHSTATUSDATE>'."\n";
+        $xml .= '            <NARRATION>'.$this->escapeXml($narration).'</NARRATION>'."\n";
+        $xml .= '            <VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>'."\n";
+        $xml .= '            <VOUCHERNUMBER>'.$voucherNumber.'</VOUCHERNUMBER>'."\n";
+        $xml .= '            <PARTYLEDGERNAME>'.$this->escapeXml($vendorName).'</PARTYLEDGERNAME>'."\n";
+        $xml .= '            <GSTREGISTRATIONTYPE>Regular</GSTREGISTRATIONTYPE>'."\n";
+
+        if ($vendorGstin !== '') {
+            $xml .= '            <PARTYGSTIN>'.$this->escapeXml($vendorGstin).'</PARTYGSTIN>'."\n";
+        }
+
+        if ($company) {
+            $xml .= '            <CMPGSTIN>'.$this->escapeXml($company->gstin ?? '').'</CMPGSTIN>'."\n";
+            $xml .= '            <CMPGSTREGISTRATIONTYPE>'.$this->escapeXml($company->gst_registration_type ?? 'Regular').'</CMPGSTREGISTRATIONTYPE>'."\n";
+            $xml .= '            <CMPGSTSTATE>'.$this->escapeXml($company->state ?? '').'</CMPGSTSTATE>'."\n";
+        }
+
+        $xml .= '            <EFFECTIVEDATE>'.$date.'</EFFECTIVEDATE>'."\n";
+        $xml .= '            <ISDELETED>No</ISDELETED>'."\n";
+        $xml .= '            <ISCANCELLED>No</ISCANCELLED>'."\n";
+        $xml .= '            <ISONHOLD>No</ISONHOLD>'."\n";
+        $xml .= '            <ISOPTIONAL>No</ISOPTIONAL>'."\n";
+        $xml .= '            <AUDITED>No</AUDITED>'."\n";
+
+        $xml .= $this->generateExpenseLedgerEntry($headName, $baseAmount, $cgstRate, $sgstRate);
+        $xml .= $this->generateGstLedgerEntries($igstRate, $igstAmount, $cgstRate, $cgstAmount, $sgstRate, $sgstAmount);
+
+        if ($tdsAmount > 0) {
+            $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+            $xml .= '              <LEDGERNAME>TDS Payable</LEDGERNAME>'."\n";
+            $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+            $xml .= '              <AMOUNT>'.number_format($tdsAmount, 2, '.', '').'</AMOUNT>'."\n";
+            $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+        }
+
+        $partyAmount = $tdsAmount > 0 ? $totalAmount - $tdsAmount : $totalAmount;
+        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($vendorName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISPARTYLEDGER>Yes</ISPARTYLEDGER>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>'.number_format($partyAmount, 2, '.', '').'</AMOUNT>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        $xml .= '          </VOUCHER>'."\n";
+        $xml .= '        </TALLYMESSAGE>'."\n";
+
+        return $xml;
+    }
+
+    private function generateExpenseLedgerEntry(string $headName, float $baseAmount, mixed $cgstRate, mixed $sgstRate): string
+    {
+        $xml = '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>-'.number_format($baseAmount, 2, '.', '').'</AMOUNT>'."\n";
+
+        if ($cgstRate !== null && $sgstRate !== null) {
+            $xml .= '              <RATEDETAILS.LIST>'."\n";
+            $xml .= '                <GSTRATEDUTYHEAD>CGST</GSTRATEDUTYHEAD>'."\n";
+            $xml .= '                <GSTRATEVALUATIONTYPE>Based on Value</GSTRATEVALUATIONTYPE>'."\n";
+            $xml .= '              </RATEDETAILS.LIST>'."\n";
+            $xml .= '              <RATEDETAILS.LIST>'."\n";
+            $xml .= '                <GSTRATEDUTYHEAD>SGST/UTGST</GSTRATEDUTYHEAD>'."\n";
+            $xml .= '                <GSTRATEVALUATIONTYPE>Based on Value</GSTRATEVALUATIONTYPE>'."\n";
+            $xml .= '              </RATEDETAILS.LIST>'."\n";
+        }
+
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        return $xml;
+    }
+
+    private function generateGstLedgerEntries(mixed $igstRate, float $igstAmount, mixed $cgstRate, float $cgstAmount, mixed $sgstRate, float $sgstAmount): string
+    {
+        if ($igstRate !== null && $igstAmount > 0) {
+            return $this->generateTaxLedgerEntry("Input Igst @ {$igstRate}%", $igstAmount);
+        }
+
+        $xml = '';
+
+        if ($cgstRate !== null && $cgstAmount > 0) {
+            $xml .= $this->generateTaxLedgerEntry("Input Cgst @ {$cgstRate}%", $cgstAmount);
+        }
+
+        if ($sgstRate !== null && $sgstAmount > 0) {
+            $xml .= $this->generateTaxLedgerEntry("Input Sgst @ {$sgstRate}%", $sgstAmount);
+        }
+
+        return $xml;
+    }
+
+    private function generateTaxLedgerEntry(string $ledgerName, float $amount): string
+    {
+        $xml = '            <ALLLEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($ledgerName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <AMOUNT>-'.number_format($amount, 2, '.', '').'</AMOUNT>'."\n";
+        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
+
+        return $xml;
+    }
+
+    /**
      * Generate ledger entries for a Payment voucher.
      * Debit: expense/party (negative amount, ISDEEMEDPOSITIVE=Yes)
      * Credit: bank (positive amount, ISDEEMEDPOSITIVE=No)
-     *
-     * @param  \Closure(string): string  $e
      */
-    private function generatePaymentLedgerEntries(string $headName, string $bankName, float $amount, string $date, \Closure $e): string
+    private function generatePaymentLedgerEntries(string $headName, string $bankName, float $amount, string $date): string
     {
         $formattedAmount = number_format($amount, 2, '.', '');
 
         $xml = '';
 
-        // Debit leg: Expense/Party
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$e($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($headName).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
         $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
 
-        // Credit leg: Bank
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$e($bankName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($bankName).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
         $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
@@ -189,18 +325,15 @@ class TallyExportService
      * Generate ledger entries for a Receipt voucher.
      * Debit: bank (negative amount, ISDEEMEDPOSITIVE=Yes)
      * Credit: party/income (positive amount, ISDEEMEDPOSITIVE=No)
-     *
-     * @param  \Closure(string): string  $e
      */
-    private function generateReceiptLedgerEntries(string $headName, string $bankName, float $amount, string $date, \Closure $e): string
+    private function generateReceiptLedgerEntries(string $headName, string $bankName, float $amount, string $date): string
     {
         $formattedAmount = number_format($amount, 2, '.', '');
 
         $xml = '';
 
-        // Debit leg: Bank
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$e($bankName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($bankName).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
         $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
@@ -212,9 +345,8 @@ class TallyExportService
         $xml .= '              </BANKALLOCATIONS.LIST>'."\n";
         $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
 
-        // Credit leg: Party/Income
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$e($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($headName).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
         $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
@@ -227,14 +359,12 @@ class TallyExportService
      */
     private function generateCompanyFooter(Company $company): string
     {
-        $e = fn (string $value): string => htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
-
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
         $xml .= '          <COMPANY>'."\n";
         $xml .= '            <REMOTECMPINFO.LIST MERGE="Yes">'."\n";
-        $xml .= '              <NAME>'.$e($company->gstin ?? '').'</NAME>'."\n";
-        $xml .= '              <REMOTECMPNAME>'.$e($company->name ?? '').'</REMOTECMPNAME>'."\n";
-        $xml .= '              <REMOTECMPSTATE>'.$e($company->state ?? '').'</REMOTECMPSTATE>'."\n";
+        $xml .= '              <NAME>'.$this->escapeXml($company->gstin ?? '').'</NAME>'."\n";
+        $xml .= '              <REMOTECMPNAME>'.$this->escapeXml($company->name ?? '').'</REMOTECMPNAME>'."\n";
+        $xml .= '              <REMOTECMPSTATE>'.$this->escapeXml($company->state ?? '').'</REMOTECMPSTATE>'."\n";
         $xml .= '            </REMOTECMPINFO.LIST>'."\n";
         $xml .= '          </COMPANY>'."\n";
         $xml .= '        </TALLYMESSAGE>'."\n";
@@ -252,5 +382,10 @@ class TallyExportService
         }
 
         return ++$this->voucherCounters[$voucherType];
+    }
+
+    private function escapeXml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
     }
 }

--- a/tests/Feature/Jobs/ProcessImportedFileTest.php
+++ b/tests/Feature/Jobs/ProcessImportedFileTest.php
@@ -456,7 +456,7 @@ describe('ProcessImportedFile with Agent::fake()', function () {
 });
 
 describe('ProcessImportedFile invoice display_name', function () {
-    it('sets display_name to vendor_name_Invoice for a manually uploaded invoice', function () {
+    it('sets display_name to invoice number, vendor, and description for a manually uploaded invoice', function () {
         Storage::fake('local');
         Storage::put('statements/invoice.pdf', 'fake-pdf-content');
 
@@ -485,10 +485,10 @@ describe('ProcessImportedFile invoice display_name', function () {
         $job->handle(app(DocumentProcessor::class));
 
         $file->refresh();
-        expect($file->display_name)->toBe('Swiggy_Invoice');
+        expect($file->display_name)->toBe('SWG/2025/001 - Swiggy - Food delivery');
     });
 
-    it('sets display_name to vendor_name_Invoice for an invoice imported via email', function () {
+    it('sets display_name to invoice number, vendor, and description for an invoice imported via email', function () {
         Storage::fake('local');
         Storage::put('statements/invoice.pdf', 'fake-pdf-content');
 
@@ -517,7 +517,7 @@ describe('ProcessImportedFile invoice display_name', function () {
         $job->handle(app(DocumentProcessor::class));
 
         $file->refresh();
-        expect($file->display_name)->toBe('AWS_Invoice');
+        expect($file->display_name)->toBe('AWS/2025/042 - AWS - Cloud services');
     });
 });
 

--- a/tests/Feature/Services/DisplayNameGeneratorTest.php
+++ b/tests/Feature/Services/DisplayNameGeneratorTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Enums\StatementType;
 use App\Models\Company;
 use App\Models\CreditCard;
 use App\Models\ImportedFile;
+use App\Models\Transaction;
 use App\Services\DisplayNameGenerator;
 use Carbon\Carbon;
 
@@ -149,5 +151,46 @@ describe('DisplayNameGenerator', function () {
         $name = (new DisplayNameGenerator)->generate($file);
 
         expect($name)->toBe('HDFC_Millennia_Feb_2025');
+    });
+
+    it('generates invoice display name from invoice number, vendor name, and service description', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+        ]);
+        Transaction::factory()->create([
+            'imported_file_id' => $file->id,
+            'raw_data' => [
+                'invoice_number' => 'INV/2439',
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'line_items' => [
+                    ['description' => 'Office Assistant and Housekeeping charges', 'amount' => 27500.00],
+                ],
+            ],
+        ]);
+
+        $file->load('transactions');
+        $name = (new DisplayNameGenerator)->generate($file);
+
+        expect($name)
+            ->toStartWith('INV')
+            ->toContain('Test Vendor')
+            ->toContain('Office Assistant');
+    });
+
+    it('generates invoice display name with only vendor name when invoice number and line items are missing', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+        ]);
+        Transaction::factory()->create([
+            'imported_file_id' => $file->id,
+            'raw_data' => [
+                'vendor_name' => 'Simple Vendor Ltd',
+            ],
+        ]);
+
+        $file->load('transactions');
+        $name = (new DisplayNameGenerator)->generate($file);
+
+        expect($name)->toContain('Simple Vendor');
     });
 });

--- a/tests/Feature/Services/TallyExportInvoiceTest.php
+++ b/tests/Feature/Services/TallyExportInvoiceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+use App\Enums\StatementType;
+use App\Models\AccountHead;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\TallyExport\TallyExportService;
+
+describe('TallyExportService invoice Journal voucher', function () {
+    beforeEach(fn () => asUser());
+
+    it('exports invoice transaction as Journal voucher not Payment', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'vendor_gstin' => '29AAQCA1895C1ZD',
+                'invoice_number' => 'INV/001',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('Journal')->not->toContain('Payment');
+    });
+
+    it('includes separate CGST and SGST legs in the journal voucher', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'Manpower Supply Charges',
+        ]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('Input Cgst @ 9%')
+            ->toContain('Input Sgst @ 9%')
+            ->toContain('-2475.00')
+            ->toContain('-27500.00');
+    });
+
+    it('includes TDS credit leg when tds_amount is non-zero', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31350',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Assetpro Solution Pvt Ltd',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 550.00,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('TDS Payable')
+            ->toContain('550.00');
+    });
+
+    it('uses IGST leg instead of CGST/SGST for inter-state invoices', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Inter State Vendor Ltd',
+                'base_amount' => 27500.00,
+                'cgst_rate' => null,
+                'cgst_amount' => null,
+                'sgst_rate' => null,
+                'sgst_amount' => null,
+                'igst_rate' => 18,
+                'igst_amount' => 4950.00,
+                'tds_amount' => 0,
+                'total_amount' => 32450.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('Input Igst @ 18%')
+            ->toContain('-4950.00')
+            ->not->toContain('Input Cgst')
+            ->not->toContain('Input Sgst');
+    });
+
+    it('includes vendor party ledger as credit leg', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'vendor_gstin' => '29AAQCA1895C1ZD',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<ISPARTYLEDGER>Yes</ISPARTYLEDGER>')
+            ->toContain('31900.00')
+            ->toContain('29AAQCA1895C1ZD');
+    });
+});


### PR DESCRIPTION
## Summary
- `TallyExportService` now emits `VCHTYPE="Journal"` for invoice transactions with multi-leg GST entries (expense debit, CGST/SGST or IGST, optional TDS credit, vendor party credit) per `tally-xml-format.md`
- `DisplayNameGenerator` extended to handle invoice type: `{invoice_number} - {vendor_name} - {line_items[0].description}`
- `DocumentProcessor` fixed to write the same display name pattern when processing invoices
- Refactored `TallyExportService`: extracted `escapeXml()`, `generateExpenseLedgerEntry()`, `generateGstLedgerEntries()`, `generateTaxLedgerEntry()` — removed duplicated closure and copy-paste GST blocks

## Test plan
- [x] New `TallyExportInvoiceTest`: Journal voucher type, CGST/SGST legs, IGST inter-state, TDS credit leg, vendor party ledger
- [x] Extended `DisplayNameGeneratorTest`: invoice display name, fallback when fields missing
- [x] All 34 existing TallyExportService tests still pass (no regression)
- [x] Pint: Pass | PHPStan: Pass | Tests: 34/34

Closes #223