### PR TITLE
chore(infra): remove ini_set memory_limit from application code

### DIFF
--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -14,6 +14,7 @@ use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -182,7 +183,7 @@ class AccountHeadResource extends Resource
     }
 
     /**
-     * @return array<Actions\Action|\Filament\Schemas\Components\Component>
+     * @return array<Actions\Action|Component>
      */
     private static function tallyImportForm(): array
     {
@@ -202,8 +203,6 @@ class AccountHeadResource extends Resource
     private static function tallyImportAction(): Closure
     {
         return function (array $data): void {
-            ini_set('memory_limit', '512M');
-
             $filePath = $data['xml_file'];
             $xmlContent = Storage::disk('local')->get($filePath);
             /** @var Company $company */

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -71,6 +71,23 @@ Release notes are grouped by PR labels:
 
 The `.github/workflows/deploy.yml` workflow triggers automatically when a tag matching `v*` is pushed. Currently a placeholder — configure the deployment target when the hosting platform is decided.
 
+### Server PHP Configuration (Required Before First Deploy)
+
+The application relies on server-level PHP configuration rather than runtime `ini_set()` calls. These settings must be applied once to the production PHP-FPM pool config (e.g., `/etc/php/8.4/fpm/pool.d/www.conf`) or a `php.ini` override:
+
+```ini
+; Tally XML exports can exceed 10 MB — must match the 50 MB cap enforced by
+; Livewire and FileUpload. Mirrors .user.ini at the project root (used by Herd
+; for local development).
+upload_max_filesize = 50M
+post_max_size = 50M
+memory_limit = 512M
+```
+
+After editing, reload PHP-FPM: `sudo systemctl reload php8.4-fpm`
+
+> **Why no `ini_set()` in code?** Runtime overrides scatter infrastructure config across the codebase, apply only to specific code paths, and mask whether server configuration is correct. The `.user.ini` at the project root handles local development (Herd picks it up automatically); production must mirror it here.
+
 ### Post-deployment Steps
 
 After deployment completes, run these commands on the production server:


### PR DESCRIPTION
## Summary

- Removes `ini_set('memory_limit', '512M')` from `AccountHeadResource::tallyImportAction()` — memory limit is now configured exclusively at the server level
- Documents the required server-side PHP-FPM configuration in `docs/guides/release-process.md` so production can be set up correctly without application-level overrides
- Minor docblock cleanup: FQN `\Filament\Schemas\Components\Component` → imported short name `Component`

## Why

Hardcoding `ini_set()` inside application logic conflates infrastructure config with business logic. It only applies to this one code path, masks whether the server configuration is actually working, and requires a deployment to change a limit value. The `.user.ini` at the project root already handles local Herd development; production must mirror it in the PHP-FPM pool config.

## Test plan

- [x] `ini_set` absent from all of `app/` — verified with grep
- [x] `.user.ini` at project root already has `memory_limit = 512M` — unchanged, still correct
- [x] Deployment runbook documents required server settings with rationale
- [x] Pint: Pass
- [x] PHPStan: Pass (with `--memory-limit=512M` CLI flag — PostgreSQL not running in shell context)

Closes #224