### PR TITLE
fix(credit-card): send notification when share target is not admin company

### DIFF
--- a/app/Filament/Resources/CreditCardResource.php
+++ b/app/Filament/Resources/CreditCardResource.php
@@ -120,7 +120,7 @@ class CreditCardResource extends Resource
                             ->multiple()
                             ->options(function () {
                                 $user = Auth::user();
-                                /** @var \App\Models\Company|null $currentTenant */
+                                /** @var Company|null $currentTenant */
                                 $currentTenant = Filament::getTenant();
 
                                 return Company::query()
@@ -131,6 +131,14 @@ class CreditCardResource extends Resource
                                     ->when($currentTenant, fn (Builder $q) => $q->where('companies.id', '!=', $currentTenant->id))
                                     ->pluck('name', 'id');
                             })
+                            // Filament v5 applies an `in()` validation by default, checking that submitted
+                            // values have a matching option label. Without this, submitting a company where
+                            // the user is not an admin fails silently before the action closure runs.
+                            // The closure handles the actual authorization check and sends a notification.
+                            ->getOptionLabelsUsing(fn (array $values): array => Company::query()
+                                ->whereIn('id', $values)
+                                ->pluck('name', 'id')
+                                ->all())
                             ->required(),
                     ])
                     ->action(function (CreditCard $record, array $data) {
@@ -182,7 +190,7 @@ class CreditCardResource extends Resource
                 SoftDeletingScope::class,
             ]);
 
-        /** @var \App\Models\Company|null $tenant */
+        /** @var Company|null $tenant */
         $tenant = Filament::getTenant();
 
         if ($tenant) {


### PR DESCRIPTION
## Summary

- Filament v5 silently rejects form values not found in a Select's `->options()` list via an automatic `in()` validation rule — the action closure never ran, so no notification was dispatched when a non-admin company was submitted
- Added `->getOptionLabelsUsing()` to resolve labels for any existing company ID, decoupling what shows in the dropdown from what passes form validation
- Authorization remains entirely in the action closure, which sends a danger notification when the user isn't an admin on all target companies

## Test plan

- [ ] `php artisan test --filter="cannot share if not admin on target company" --compact` — was failing, now passes
- [ ] `php artisan test --filter=CreditCardSharingTest --compact` — 19/19 pass
- [ ] Pint: Pass | PHPStan: Pass

Closes #225