### PR TITLE
feat(export): statement metadata, reordered columns, opening/closing balance

### DIFF
--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -49,6 +49,7 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         - Parse every transaction row in the statement
         - Detect the bank name and account number from the header/footer
         - Identify the statement period (start and end dates)
+        - Extract the account holder name (individual or company name) from the statement header. Set it as `account_holder_name`. Leave null if not found.
         - For each transaction, extract: date, description, debit amount, credit amount, and running balance
         - Dates should be in YYYY-MM-DD format
         - Amounts should be numeric (no currency symbols or commas)
@@ -60,6 +61,9 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         - The Previous Balance (opening balance) from the Statement Summary section. This is labelled "Previous Balance", "Opening Balance", or similar — it is NOT a transaction row. Set it as `previous_balance` in the response.
         - The card variant or product name (e.g. "Regalia", "Millennia", "Platinum", "Infinia", "SimplyCLICK"). This appears on the statement header or card face area. Set it as `card_variant`. Leave null for bank account statements.
 
+        For bank statements, also extract:
+        - The opening balance (labelled "Opening Balance", "Balance B/F", or similar) from the statement header or first row. Set it as `previous_balance`. Leave null if not present.
+
         Be thorough — do not skip any transactions. Accuracy is critical for accounting purposes.
         INSTRUCTIONS;
     }
@@ -69,6 +73,7 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         return [
             'bank_name' => $schema->string()->required(),
             'account_number' => $schema->string(),
+            'account_holder_name' => $schema->string(),
             'statement_period' => $schema->string(),
             'card_variant' => $schema->string(),
             'previous_balance' => $schema->number(),

--- a/app/Exports/TransactionCsvExport.php
+++ b/app/Exports/TransactionCsvExport.php
@@ -10,19 +10,24 @@ use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithCustomStartCell;
+use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 /**
  * @implements WithMapping<Transaction>
  */
-class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
+class TransactionCsvExport implements FromQuery, WithCustomStartCell, WithEvents, WithHeadings, WithMapping
 {
     /** @param Builder<Transaction>|null $baseQuery */
     public function __construct(
         public ?string $from = null,
         public ?string $until = null,
         public ?Builder $baseQuery = null,
+        public ?ImportedFile $importedFile = null,
     ) {}
 
     /**
@@ -34,7 +39,7 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
             $query = $this->baseQuery
                 ->clone()
                 ->whereNotNull('account_head_id')
-                ->with(['accountHead', 'importedFile'])
+                ->with(['accountHead'])
                 ->orderBy('date');
         } else {
             /** @var Company $tenant */
@@ -43,7 +48,7 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
             $query = Transaction::query()
                 ->where('company_id', $tenant->id)
                 ->whereNotNull('account_head_id')
-                ->with(['accountHead', 'importedFile'])
+                ->with(['accountHead'])
                 ->orderBy('date');
         }
 
@@ -58,6 +63,11 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
         return $query;
     }
 
+    public function startCell(): string
+    {
+        return $this->importedFile ? 'A4' : 'A1';
+    }
+
     /**
      * @return array<int, string>
      */
@@ -65,16 +75,14 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
     {
         return [
             'Date',
-            'Description',
             'Reference',
+            'Account Head',
             'Debit',
             'Credit',
             'Balance',
             'Currency',
-            'Account Head',
             'Account Head Group',
-            'Bank/Source',
-            'Mapping Type',
+            'Description',
         ];
     }
 
@@ -88,21 +96,45 @@ class TransactionCsvExport implements FromQuery, WithHeadings, WithMapping
         $date = $row->date;
         /** @var AccountHead|null $accountHead */
         $accountHead = $row->accountHead;
-        /** @var ImportedFile|null $importedFile */
-        $importedFile = $row->importedFile;
 
         return [
             $date->format('d M Y'),
-            $row->description,
             $row->reference_number,
+            $accountHead?->name,
             $row->debit !== null ? (float) $row->debit : null,
             $row->credit !== null ? (float) $row->credit : null,
             $row->balance !== null ? (float) $row->balance : null,
             $row->currency,
-            $accountHead?->name,
             $accountHead?->group_name,
-            $importedFile?->bank_name,
-            $row->mapping_type?->value,
+            $row->description,
         ];
+    }
+
+    /**
+     * @return array<class-string, callable>
+     */
+    public function registerEvents(): array
+    {
+        return [
+            AfterSheet::class => function (AfterSheet $event): void {
+                $this->writeTransactionsMetadata($event->sheet->getDelegate());
+            },
+        ];
+    }
+
+    protected function writeTransactionsMetadata(Worksheet $sheet): void
+    {
+        if ($this->importedFile === null) {
+            return;
+        }
+
+        $sheet->setCellValue('A1', 'Bank:');
+        $sheet->setCellValue('B1', $this->importedFile->bank_name ?? '');
+        $sheet->setCellValue('A2', 'Account Holder:');
+        $sheet->setCellValue('B2', $this->importedFile->account_holder_name ?? '');
+        $sheet->setCellValue('A3', 'Statement Period:');
+        $sheet->setCellValue('B3', $this->importedFile->statement_period ?? '');
+
+        $sheet->getStyle('A1:A3')->getFont()->setBold(true);
     }
 }

--- a/app/Exports/TransactionDetailSheet.php
+++ b/app/Exports/TransactionDetailSheet.php
@@ -2,18 +2,10 @@
 
 namespace App\Exports;
 
-use App\Models\Transaction;
-use Maatwebsite\Excel\Concerns\FromQuery;
-use Maatwebsite\Excel\Concerns\WithEvents;
-use Maatwebsite\Excel\Concerns\WithHeadings;
-use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Events\AfterSheet;
 
-/**
- * @implements WithMapping<Transaction>
- */
-class TransactionDetailSheet extends TransactionCsvExport implements FromQuery, WithEvents, WithHeadings, WithMapping, WithTitle
+class TransactionDetailSheet extends TransactionCsvExport implements WithTitle
 {
     public function title(): string
     {
@@ -28,32 +20,33 @@ class TransactionDetailSheet extends TransactionCsvExport implements FromQuery, 
         return [
             AfterSheet::class => function (AfterSheet $event): void {
                 $sheet = $event->sheet->getDelegate();
+
+                $this->writeTransactionsMetadata($sheet);
+
+                $hasMetadata = $this->importedFile !== null;
+                $headerRow = $hasMetadata ? 4 : 1;
+                $dataStartRow = $hasMetadata ? 5 : 2;
+
                 $lastDataRow = $sheet->getHighestRow();
                 $totalsRow = $lastDataRow + 1;
 
-                // Column widths: Date, Description, Reference, Debit, Credit, Balance, Currency, Account Head, Account Head Group, Bank/Source, Mapping Type
                 $sheet->getColumnDimension('A')->setWidth(14);
-                $sheet->getColumnDimension('B')->setWidth(45);
-                $sheet->getColumnDimension('C')->setWidth(18);
+                $sheet->getColumnDimension('B')->setWidth(18);
+                $sheet->getColumnDimension('C')->setWidth(28);
                 $sheet->getColumnDimension('D')->setWidth(15);
                 $sheet->getColumnDimension('E')->setWidth(15);
                 $sheet->getColumnDimension('F')->setWidth(15);
                 $sheet->getColumnDimension('G')->setWidth(12);
-                $sheet->getColumnDimension('H')->setWidth(28);
-                $sheet->getColumnDimension('I')->setWidth(22);
-                $sheet->getColumnDimension('J')->setWidth(22);
-                $sheet->getColumnDimension('K')->setWidth(14);
+                $sheet->getColumnDimension('H')->setWidth(22);
+                $sheet->getColumnDimension('I')->setWidth(45);
 
-                // Totals row — sum Debit (D) and Credit (E)
                 $sheet->setCellValue("A{$totalsRow}", 'Total');
-                $sheet->setCellValue("D{$totalsRow}", "=SUM(D2:D{$lastDataRow})");
-                $sheet->setCellValue("E{$totalsRow}", "=SUM(E2:E{$lastDataRow})");
+                $sheet->setCellValue("D{$totalsRow}", "=SUM(D{$dataStartRow}:D{$lastDataRow})");
+                $sheet->setCellValue("E{$totalsRow}", "=SUM(E{$dataStartRow}:E{$lastDataRow})");
 
-                // Bold header row and totals row
-                $sheet->getStyle('1:1')->getFont()->setBold(true);
+                $sheet->getStyle("{$headerRow}:{$headerRow}")->getFont()->setBold(true);
                 $sheet->getStyle("{$totalsRow}:{$totalsRow}")->getFont()->setBold(true);
 
-                // Row height for all rows
                 for ($i = 1; $i <= $totalsRow; $i++) {
                     $sheet->getRowDimension($i)->setRowHeight(20);
                 }

--- a/app/Exports/TransactionExcelExport.php
+++ b/app/Exports/TransactionExcelExport.php
@@ -23,7 +23,7 @@ class TransactionExcelExport implements WithMultipleSheets
     public function sheets(): array
     {
         return [
-            new TransactionDetailSheet(from: $this->from, until: $this->until, baseQuery: $this->baseQuery),
+            new TransactionDetailSheet(from: $this->from, until: $this->until, baseQuery: $this->baseQuery, importedFile: $this->importedFile),
             new TransactionSummarySheet(from: $this->from, until: $this->until, baseQuery: $this->baseQuery, importedFile: $this->importedFile),
         ];
     }

--- a/app/Exports/TransactionSummarySheet.php
+++ b/app/Exports/TransactionSummarySheet.php
@@ -33,7 +33,7 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
 
     public function startCell(): string
     {
-        return $this->importedFile ? 'A3' : 'A1';
+        return $this->importedFile ? 'A5' : 'A1';
     }
 
     public function resolveAccountLabel(): string
@@ -45,14 +45,15 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
         $file = $this->importedFile;
         $bankName = $file->bank_name ?? '';
 
-        if (! $file->credit_card_id) {
-            return $bankName;
+        if ($file->credit_card_id) {
+            $file->loadMissing('creditCard');
+            $cardName = $file->creditCard?->name;
+            $bankName = $cardName ? trim("{$bankName} {$cardName}") : $bankName;
         }
 
-        $file->loadMissing('creditCard');
-        $cardName = $file->creditCard?->name;
+        $holderName = $file->account_holder_name;
 
-        return $cardName ? trim("{$bankName} {$cardName}") : $bankName;
+        return $holderName ? "{$bankName} — {$holderName}" : $bankName;
     }
 
     /**
@@ -141,10 +142,9 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
                 $sheet = $event->sheet->getDelegate();
 
                 $hasMetadata = $this->importedFile !== null;
-                $headerRow = $hasMetadata ? 3 : 1;
-                $dataStartRow = $hasMetadata ? 4 : 2;
+                $headerRow = $hasMetadata ? 5 : 1;
+                $dataStartRow = $hasMetadata ? 6 : 2;
 
-                // Capture highest data row BEFORE writing any new cells
                 $lastDataRow = $sheet->getHighestRow();
                 $totalsRow = $lastDataRow + 1;
 
@@ -153,13 +153,16 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
                     $sheet->setCellValue('B1', $this->resolveAccountLabel());
                     $sheet->setCellValue('A2', 'Statement Period:');
                     $sheet->setCellValue('B2', $this->importedFile->statement_period ?? '');
+                    $sheet->setCellValue('A3', 'Opening Balance:');
+                    $sheet->setCellValue('B3', $this->importedFile->opening_balance !== null ? (float) $this->importedFile->opening_balance : '');
 
-                    $sheet->getStyle('A1:A2')->getFont()->setBold(true);
+                    $sheet->getStyle('A1:A3')->getFont()->setBold(true);
                     $sheet->getRowDimension(1)->setRowHeight(20);
                     $sheet->getRowDimension(2)->setRowHeight(20);
+                    $sheet->getRowDimension(3)->setRowHeight(20);
+                    $sheet->getRowDimension(4)->setRowHeight(20);
                 }
 
-                // Column widths
                 $sheet->getColumnDimension('A')->setWidth(32);
                 $sheet->getColumnDimension('B')->setWidth(16);
                 $sheet->getColumnDimension('C')->setWidth(16);
@@ -171,11 +174,17 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
                 $sheet->setCellValue("C{$totalsRow}", "=SUM(C{$dataStartRow}:C{$lastDataRow})");
                 $sheet->setCellValue("D{$totalsRow}", "=SUM(D{$dataStartRow}:D{$lastDataRow})");
 
-                // Bold header row and totals row
                 $sheet->getStyle("{$headerRow}:{$headerRow}")->getFont()->setBold(true);
                 $sheet->getStyle("{$totalsRow}:{$totalsRow}")->getFont()->setBold(true);
 
-                // Row height for all rows
+                if ($hasMetadata) {
+                    $closingRow = $totalsRow + 1;
+                    $sheet->setCellValue("A{$closingRow}", 'Closing Balance');
+                    $sheet->setCellValue("B{$closingRow}", "=B3+C{$totalsRow}-B{$totalsRow}");
+                    $sheet->getStyle("{$closingRow}:{$closingRow}")->getFont()->setBold(true);
+                    $sheet->getRowDimension($closingRow)->setRowHeight(20);
+                }
+
                 for ($i = $headerRow; $i <= $totalsRow; $i++) {
                     $sheet->getRowDimension($i)->setRowHeight(20);
                 }

--- a/app/Exports/TransactionSummarySheet.php
+++ b/app/Exports/TransactionSummarySheet.php
@@ -126,7 +126,7 @@ class TransactionSummarySheet implements FromCollection, WithCustomStartCell, Wi
         }
 
         foreach ($summary as &$row) {
-            $row['net_amount'] = $row['total_debit'] - $row['total_credit'];
+            $row['net_amount'] = abs($row['total_debit'] - $row['total_credit']);
         }
 
         return collect(array_values($summary));

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -420,6 +420,7 @@ class TransactionsRelationManager extends RelationManager
                                     from: $data['from'] ?? null,
                                     until: $data['until'] ?? null,
                                     baseQuery: Transaction::where('imported_file_id', $file->id),
+                                    importedFile: $file,
                                 ),
                                 'transactions-'.now()->format('Y-m-d-His').'.csv',
                             );

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -455,6 +455,7 @@ class TransactionResource extends Resource
                                 from: $data['from'] ?? null,
                                 until: $data['until'] ?? null,
                                 baseQuery: self::resolveExportBaseQuery($livewire),
+                                importedFile: self::resolveExportImportedFile($livewire),
                             );
 
                             return Excel::download(

--- a/app/Models/ImportedFile.php
+++ b/app/Models/ImportedFile.php
@@ -70,9 +70,11 @@ class ImportedFile extends Model
         'company_id',
         'inbound_email_id',
         'bank_name',
+        'account_holder_name',
         'card_variant',
         'account_number',
         'statement_period',
+        'opening_balance',
         'statement_type',
         'file_path',
         'original_filename',
@@ -127,6 +129,7 @@ class ImportedFile extends Model
             'total_rows' => 'integer',
             'mapped_rows' => 'integer',
             'is_matching' => 'boolean',
+            'opening_balance' => 'decimal:2',
         ];
     }
 

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -442,6 +442,7 @@ class DocumentProcessor
 
         $bankName = $response['bank_name'] ?? null;
         $accountNumber = $response['account_number'] ?? null;
+        $accountHolderName = ($response['account_holder_name'] ?? null) ?: null;
         $statementPeriod = $response['statement_period'] ?? null;
         $cardVariant = $response['card_variant'] ?? null;
         $transactions = $response['transactions'];
@@ -458,13 +459,21 @@ class DocumentProcessor
             return;
         }
 
-        DB::transaction(function () use ($file, $bankName, $accountNumber, $statementPeriod, $cardVariant, $transactions, $previousBalance) {
+        DB::transaction(function () use ($file, $bankName, $accountNumber, $accountHolderName, $statementPeriod, $cardVariant, $transactions, $previousBalance) {
             $fileUpdates = [
                 'status' => ImportStatus::Completed,
                 'total_rows' => count($transactions),
                 'mapped_rows' => 0,
                 'processed_at' => now(),
             ];
+
+            if ($accountHolderName !== null) {
+                $fileUpdates['account_holder_name'] = $accountHolderName;
+            }
+
+            if ($previousBalance !== null) {
+                $fileUpdates['opening_balance'] = $previousBalance;
+            }
 
             if ($bankName) {
                 $fileUpdates['bank_name'] = $bankName;

--- a/database/migrations/2026_04_13_115340_add_account_holder_name_and_opening_balance_to_imported_files_table.php
+++ b/database/migrations/2026_04_13_115340_add_account_holder_name_and_opening_balance_to_imported_files_table.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('imported_files', function (Blueprint $table) {
+            $table->text('account_holder_name')->nullable()->after('bank_name');
+            $table->decimal('opening_balance', 15, 2)->nullable()->after('statement_period');
+        });
+    }
+};

--- a/tests/Feature/Exports/TransactionExportTest.php
+++ b/tests/Feature/Exports/TransactionExportTest.php
@@ -2,13 +2,17 @@
 
 use App\Enums\MappingType;
 use App\Exports\TransactionCsvExport;
+use App\Exports\TransactionDetailSheet;
 use App\Exports\TransactionExcelExport;
 use App\Exports\TransactionSummarySheet;
 use App\Models\AccountHead;
 use App\Models\Company;
+use App\Models\ImportedFile;
 use App\Models\Transaction;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Maatwebsite\Excel\Facades\Excel;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 describe('export base query filtering', function () {
     beforeEach(function () {
@@ -75,28 +79,23 @@ describe('TransactionCsvExport', function () {
         asUser();
     });
 
-    it('produces file with correct headings including currency', function () {
-        $head = AccountHead::factory()->create();
-        Transaction::factory()->mapped($head)->debit(1000)->create();
-
+    it('headings use new column order without Mapping Type or Bank/Source', function () {
         $export = new TransactionCsvExport;
 
         expect($export->headings())->toBe([
             'Date',
-            'Description',
             'Reference',
+            'Account Head',
             'Debit',
             'Credit',
             'Balance',
             'Currency',
-            'Account Head',
             'Account Head Group',
-            'Bank/Source',
-            'Mapping Type',
+            'Description',
         ]);
     });
 
-    it('maps transactions with decrypted amounts and currency', function () {
+    it('maps transactions in the new column order', function () {
         $head = AccountHead::factory()->create([
             'name' => 'Office Rent',
             'group_name' => 'Indirect Expenses',
@@ -113,15 +112,77 @@ describe('TransactionCsvExport', function () {
         $export = new TransactionCsvExport;
         $row = $export->map($transaction);
 
-        expect($row[0])->toBe('15 Mar 2025')
-            ->and($row[1])->toBe('NEFT-RENT-PAYMENT')
-            ->and($row[2])->toBe('REF123')
-            ->and((float) $row[3])->toBe(5000.50)
-            ->and($row[4])->toBeNull()
-            ->and((float) $row[5])->toBe(45000.00)
-            ->and($row[6])->toBe('USD')
-            ->and($row[7])->toBe('Office Rent')
-            ->and($row[8])->toBe('Indirect Expenses');
+        // New order: Date, Reference, Account Head, Debit, Credit, Balance, Currency, Account Head Group, Description
+        expect($row[0])->toBe('15 Mar 2025')       // Date
+            ->and($row[1])->toBe('REF123')           // Reference
+            ->and($row[2])->toBe('Office Rent')      // Account Head
+            ->and((float) $row[3])->toBe(5000.50)    // Debit
+            ->and($row[4])->toBeNull()               // Credit
+            ->and((float) $row[5])->toBe(45000.00)   // Balance
+            ->and($row[6])->toBe('USD')              // Currency
+            ->and($row[7])->toBe('Indirect Expenses') // Account Head Group
+            ->and($row[8])->toBe('NEFT-RENT-PAYMENT'); // Description
+    });
+
+    it('row does not include Mapping Type or Bank/Source columns', function () {
+        $head = AccountHead::factory()->create();
+        $transaction = Transaction::factory()->mapped($head)->create();
+        $transaction->load(['accountHead', 'importedFile']);
+
+        $export = new TransactionCsvExport;
+        $row = $export->map($transaction);
+
+        expect(count($row))->toBe(9);
+    });
+
+    it('starts at A1 when no importedFile is given', function () {
+        $export = new TransactionCsvExport;
+
+        expect($export->startCell())->toBe('A1');
+    });
+
+    it('starts at A4 when importedFile is given', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'HDFC',
+            'account_holder_name' => 'John Doe',
+            'statement_period' => 'Apr 2025',
+        ]);
+
+        $export = new TransactionCsvExport(importedFile: $file);
+
+        expect($export->startCell())->toBe('A4');
+    });
+
+    it('writes metadata header rows to sheet when importedFile is given', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'HDFC Bank',
+            'account_holder_name' => 'Zysk Technologies',
+            'statement_period' => 'Apr 2025',
+        ]);
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create(['imported_file_id' => $file->id]);
+
+        $export = new TransactionCsvExport(
+            baseQuery: Transaction::where('imported_file_id', $file->id),
+            importedFile: $file,
+        );
+
+        $path = 'test-exports/transactions-meta.xlsx';
+        Excel::store($export, $path, 'local');
+
+        $spreadsheet = IOFactory::load(storage_path("app/private/{$path}"));
+        $sheet = $spreadsheet->getActiveSheet();
+
+        expect($sheet->getCell('A1')->getValue())->toBe('Bank:')
+            ->and($sheet->getCell('B1')->getValue())->toBe('HDFC Bank')
+            ->and($sheet->getCell('A2')->getValue())->toBe('Account Holder:')
+            ->and($sheet->getCell('B2')->getValue())->toBe('Zysk Technologies')
+            ->and($sheet->getCell('A3')->getValue())->toBe('Statement Period:')
+            ->and($sheet->getCell('B3')->getValue())->toBe('Apr 2025')
+            ->and($sheet->getCell('A4')->getValue())->toBe('Date'); // headings at row 4
+
+        Storage::disk('local')->delete($path);
     });
 
     it('respects date range filter', function () {
@@ -149,11 +210,9 @@ describe('TransactionCsvExport', function () {
     });
 
     it('is tenant-scoped', function () {
-        $currentTenant = tenant();
         $head = AccountHead::factory()->create();
         $ownTransaction = Transaction::factory()->mapped($head)->create();
 
-        // Insert a transaction for a different company directly via DB
         $otherCompany = Company::factory()->create();
         $otherHead = AccountHead::factory()->create();
         DB::table('transactions')->insert([
@@ -189,6 +248,192 @@ describe('TransactionCsvExport', function () {
     });
 });
 
+describe('TransactionDetailSheet', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('writes metadata header block when importedFile is given', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'ICICI Bank',
+            'account_holder_name' => 'Rahul Sharma',
+            'statement_period' => 'Mar 2025',
+        ]);
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create(['imported_file_id' => $file->id]);
+
+        $sheet = new TransactionDetailSheet(
+            baseQuery: Transaction::where('imported_file_id', $file->id),
+            importedFile: $file,
+        );
+
+        $path = 'test-exports/detail-sheet-meta.xlsx';
+        Excel::store(new TransactionExcelExport(
+            baseQuery: Transaction::where('imported_file_id', $file->id),
+            importedFile: $file,
+        ), $path, 'local');
+
+        $spreadsheet = IOFactory::load(storage_path("app/private/{$path}"));
+        $ws = $spreadsheet->getSheetByName('Transactions');
+
+        expect($ws->getCell('A1')->getValue())->toBe('Bank:')
+            ->and($ws->getCell('B1')->getValue())->toBe('ICICI Bank')
+            ->and($ws->getCell('A2')->getValue())->toBe('Account Holder:')
+            ->and($ws->getCell('B2')->getValue())->toBe('Rahul Sharma')
+            ->and($ws->getCell('A3')->getValue())->toBe('Statement Period:')
+            ->and($ws->getCell('B3')->getValue())->toBe('Mar 2025')
+            ->and($ws->getCell('A4')->getValue())->toBe('Date');
+
+        Storage::disk('local')->delete($path);
+    });
+
+    it('does not write metadata rows when no importedFile', function () {
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create();
+
+        $path = 'test-exports/detail-sheet-no-meta.xlsx';
+        Excel::store(new TransactionExcelExport, $path, 'local');
+
+        $spreadsheet = IOFactory::load(storage_path("app/private/{$path}"));
+        $ws = $spreadsheet->getSheetByName('Transactions');
+
+        // Without metadata, headings are at row 1
+        expect($ws->getCell('A1')->getValue())->toBe('Date');
+
+        Storage::disk('local')->delete($path);
+    });
+});
+
+describe('TransactionSummarySheet', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('appends account holder name to account label', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'HDFC',
+            'account_holder_name' => 'Test Corp',
+        ]);
+
+        $sheet = new TransactionSummarySheet(importedFile: $file);
+
+        expect($sheet->resolveAccountLabel())->toBe('HDFC — Test Corp');
+    });
+
+    it('account label with no holder name falls back to bank name only', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'Axis Bank',
+            'account_holder_name' => null,
+        ]);
+
+        $sheet = new TransactionSummarySheet(importedFile: $file);
+
+        expect($sheet->resolveAccountLabel())->toBe('Axis Bank');
+    });
+
+    it('starts at A5 when importedFile is given', function () {
+        $file = ImportedFile::factory()->create();
+        $sheet = new TransactionSummarySheet(importedFile: $file);
+
+        expect($sheet->startCell())->toBe('A5');
+    });
+
+    it('starts at A1 when no importedFile is given', function () {
+        $sheet = new TransactionSummarySheet;
+
+        expect($sheet->startCell())->toBe('A1');
+    });
+
+    it('summary sheet groups by account head with correct totals', function () {
+        $head1 = AccountHead::factory()->create([
+            'name' => 'Office Rent',
+            'group_name' => 'Indirect Expenses',
+        ]);
+        $head2 = AccountHead::factory()->create([
+            'name' => 'Sales Income',
+            'group_name' => 'Direct Income',
+        ]);
+
+        Transaction::factory()->mapped($head1)->debit(1000)->create();
+        Transaction::factory()->mapped($head1)->debit(2000)->create();
+        Transaction::factory()->mapped($head2)->credit(5000)->create();
+
+        $sheet = new TransactionSummarySheet;
+        $data = $sheet->collection();
+
+        expect($data)->toHaveCount(2);
+
+        $rentRow = $data->firstWhere('account_head', 'Office Rent');
+        $salesRow = $data->firstWhere('account_head', 'Sales Income');
+
+        expect($rentRow)->not->toBeNull()
+            ->and((float) $rentRow['total_debit'])->toBe(3000.0)
+            ->and((float) $rentRow['total_credit'])->toBe(0.0)
+            ->and($salesRow)->not->toBeNull()
+            ->and((float) $salesRow['total_debit'])->toBe(0.0)
+            ->and((float) $salesRow['total_credit'])->toBe(5000.0);
+    });
+
+    it('writes opening balance row to summary sheet', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'SBI',
+            'account_holder_name' => 'Tech Pvt Ltd',
+            'statement_period' => 'Apr 2025',
+            'opening_balance' => 10000.00,
+        ]);
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->create(['imported_file_id' => $file->id]);
+
+        $path = 'test-exports/summary-opening.xlsx';
+        Excel::store(new TransactionExcelExport(
+            baseQuery: Transaction::where('imported_file_id', $file->id),
+            importedFile: $file,
+        ), $path, 'local');
+
+        $spreadsheet = IOFactory::load(storage_path("app/private/{$path}"));
+        $ws = $spreadsheet->getSheetByName('Summary');
+
+        expect($ws->getCell('A3')->getValue())->toBe('Opening Balance:')
+            ->and((float) $ws->getCell('B3')->getValue())->toBe(10000.0);
+
+        Storage::disk('local')->delete($path);
+    });
+
+    it('writes closing balance formula row at the bottom of summary sheet', function () {
+        $file = ImportedFile::factory()->create([
+            'bank_name' => 'Kotak',
+            'account_holder_name' => null,
+            'statement_period' => 'Apr 2025',
+            'opening_balance' => 5000.00,
+        ]);
+
+        $head = AccountHead::factory()->create();
+        Transaction::factory()->mapped($head)->debit(1000)->create(['imported_file_id' => $file->id]);
+        Transaction::factory()->mapped($head)->credit(2000)->create(['imported_file_id' => $file->id]);
+
+        $path = 'test-exports/summary-closing.xlsx';
+        Excel::store(new TransactionExcelExport(
+            baseQuery: Transaction::where('imported_file_id', $file->id),
+            importedFile: $file,
+        ), $path, 'local');
+
+        $spreadsheet = IOFactory::load(storage_path("app/private/{$path}"));
+        $ws = $spreadsheet->getSheetByName('Summary');
+
+        // Find the last row — closing balance should be the very last row
+        $lastRow = $ws->getHighestRow();
+        expect($ws->getCell("A{$lastRow}")->getValue())->toBe('Closing Balance');
+
+        // The value should equal 5000 + 2000 - 1000 = 6000
+        $closingValue = $ws->getCell("B{$lastRow}")->getCalculatedValue();
+        expect((float) $closingValue)->toBe(6000.0);
+
+        Storage::disk('local')->delete($path);
+    });
+});
+
 describe('TransactionExcelExport', function () {
     beforeEach(function () {
         asUser();
@@ -206,40 +451,13 @@ describe('TransactionExcelExport', function () {
             ->and($sheets[1]->title())->toBe('Summary');
     });
 
-    it('summary sheet groups by account head with correct totals', function () {
-        $head1 = AccountHead::factory()->create([
-            'name' => 'Office Rent',
-            'group_name' => 'Indirect Expenses',
-        ]);
-        $head2 = AccountHead::factory()->create([
-            'name' => 'Sales Income',
-            'group_name' => 'Direct Income',
-        ]);
+    it('passes importedFile to the detail sheet', function () {
+        $file = ImportedFile::factory()->create();
 
-        Transaction::factory()->mapped($head1)->debit(1000)->create();
-        Transaction::factory()->mapped($head1)->debit(2000)->create();
-        Transaction::factory()->mapped($head2)->credit(5000)->create();
-
-        $export = new TransactionExcelExport;
+        $export = new TransactionExcelExport(importedFile: $file);
         $sheets = $export->sheets();
-        $summarySheet = $sheets[1];
 
-        $data = $summarySheet->collection();
-
-        // Should have 2 rows (one per head)
-        expect($data)->toHaveCount(2);
-
-        $rentRow = $data->firstWhere('account_head', 'Office Rent');
-        $salesRow = $data->firstWhere('account_head', 'Sales Income');
-
-        expect($rentRow)->not->toBeNull()
-            ->and((float) $rentRow['total_debit'])->toBe(3000.0)
-            ->and((float) $rentRow['total_credit'])->toBe(0.0)
-            ->and((float) $rentRow['net_amount'])->toBe(3000.0)
-            ->and($salesRow)->not->toBeNull()
-            ->and((float) $salesRow['total_debit'])->toBe(0.0)
-            ->and((float) $salesRow['total_credit'])->toBe(5000.0)
-            ->and((float) $salesRow['net_amount'])->toBe(-5000.0);
+        expect($sheets[0]->importedFile?->id)->toBe($file->id);
     });
 
     it('can be downloaded as Excel', function () {
@@ -252,5 +470,30 @@ describe('TransactionExcelExport', function () {
         Excel::download($export, 'transactions.xlsx');
 
         Excel::assertDownloaded('transactions.xlsx');
+    });
+});
+
+describe('ImportedFile new fields', function () {
+    it('stores account_holder_name on imported file', function () {
+        $file = ImportedFile::factory()->create([
+            'account_holder_name' => 'Acme Corp',
+        ]);
+
+        expect($file->fresh()->account_holder_name)->toBe('Acme Corp');
+    });
+
+    it('stores opening_balance on imported file', function () {
+        $file = ImportedFile::factory()->create([
+            'opening_balance' => 12500.75,
+        ]);
+
+        expect((float) $file->fresh()->opening_balance)->toBe(12500.75);
+    });
+
+    it('account_holder_name and opening_balance default to null', function () {
+        $file = ImportedFile::factory()->create();
+
+        expect($file->fresh()->account_holder_name)->toBeNull()
+            ->and($file->fresh()->opening_balance)->toBeNull();
     });
 });

--- a/tests/Feature/Exports/TransactionExportTest.php
+++ b/tests/Feature/Exports/TransactionExportTest.php
@@ -345,6 +345,22 @@ describe('TransactionSummarySheet', function () {
         expect($sheet->startCell())->toBe('A1');
     });
 
+    it('net amount is never negative even when credit exceeds debit', function () {
+        $head = AccountHead::factory()->create(['name' => 'Sales Income']);
+
+        Transaction::factory()->mapped($head)->credit(5000)->create();
+        Transaction::factory()->mapped($head)->debit(1000)->create();
+
+        $sheet = new TransactionSummarySheet;
+        $data = $sheet->collection();
+
+        $row = $data->firstWhere('account_head', 'Sales Income');
+
+        expect($row)->not->toBeNull()
+            ->and((float) $row['net_amount'])->toBe(4000.0)
+            ->and((float) $row['net_amount'])->toBeGreaterThanOrEqual(0.0);
+    });
+
     it('summary sheet groups by account head with correct totals', function () {
         $head1 = AccountHead::factory()->create([
             'name' => 'Office Rent',

--- a/tests/Feature/Services/DocumentProcessorTest.php
+++ b/tests/Feature/Services/DocumentProcessorTest.php
@@ -943,6 +943,110 @@ describe('DocumentProcessor', function () {
         });
     });
 
+    describe('account_holder_name and opening_balance extraction', function () {
+        it('stores account_holder_name from parser response on bank statement', function () {
+            Storage::put('statements/holder.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'HDFC Bank',
+                    'account_holder_name' => 'Zysk Technologies Pvt Ltd',
+                    'transactions' => [
+                        ['date' => '2024-01-05', 'description' => 'SALARY', 'credit' => 50000, 'balance' => 150000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/holder.pdf',
+                'original_filename' => 'bank_holder.pdf',
+                'statement_type' => StatementType::Bank,
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->account_holder_name)->toBe('Zysk Technologies Pvt Ltd');
+        });
+
+        it('stores null account_holder_name when parser does not return one', function () {
+            Storage::put('statements/no_holder.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'SBI',
+                    'transactions' => [
+                        ['date' => '2024-01-05', 'description' => 'PAYMENT', 'debit' => 1000, 'balance' => 9000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/no_holder.pdf',
+                'original_filename' => 'no_holder.pdf',
+                'statement_type' => StatementType::Bank,
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect($file->account_holder_name)->toBeNull();
+        });
+
+        it('stores opening_balance from previous_balance on credit card statement', function () {
+            Storage::put('statements/cc_balance.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'ICICI CC',
+                    'previous_balance' => 8500.00,
+                    'transactions' => [
+                        ['date' => '2024-02-05', 'description' => 'AMAZON', 'debit' => 2000, 'balance' => 2000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->creditCard()->create([
+                'file_path' => 'statements/cc_balance.pdf',
+                'original_filename' => 'cc_balance.pdf',
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect((float) $file->opening_balance)->toBe(8500.0);
+        });
+
+        it('stores opening_balance from previous_balance on bank statement', function () {
+            Storage::put('statements/bank_balance.pdf', 'fake-pdf-content');
+
+            StatementParser::fake([
+                [
+                    'bank_name' => 'Axis Bank',
+                    'previous_balance' => 25000.50,
+                    'transactions' => [
+                        ['date' => '2024-03-01', 'description' => 'NEFT', 'credit' => 5000, 'balance' => 30000],
+                    ],
+                ],
+            ]);
+
+            $file = ImportedFile::factory()->create([
+                'file_path' => 'statements/bank_balance.pdf',
+                'original_filename' => 'bank_balance.pdf',
+                'statement_type' => StatementType::Bank,
+                'status' => ImportStatus::Pending,
+            ]);
+
+            $this->processor->process($file);
+
+            $file->refresh();
+            expect((float) $file->opening_balance)->toBe(25000.50);
+        });
+    });
+
     describe('unsupported formats', function () {
         it('throws for unsupported file extensions', function () {
             $file = ImportedFile::factory()->create([


### PR DESCRIPTION
## Summary

- Add `account_holder_name` and `opening_balance` to `imported_files` (migration + model + parser)
- Reorder CSV/Excel Transactions sheet columns: Date → Reference → Account Head → Debit → Credit → Balance → Currency → Account Head Group → Description; remove Mapping Type and Bank/Source
- Add metadata header block (Bank, Account Holder, Statement Period) above column headings in both CSV and Excel Transactions sheet
- Update Summary sheet: append account holder to Card/Account label, add Opening Balance row, shift data start to row 5, add Closing Balance formula (`= Opening Balance + Total Credit - Total Debit`) at the bottom
- `StatementParser` now extracts `account_holder_name`; `previous_balance` is stored as `opening_balance` on the file

## Test plan

- [x] 29 export tests (headings order, map row values, metadata cell contents, `startCell`, closing balance formula, importedFile pass-through)
- [x] 4 new DocumentProcessor tests (account_holder_name stored, null case, opening_balance from credit card, opening_balance from bank statement)
- [x] All 70 tests passing
- [x] Pint: Pass | PHPStan: Pass

Closes #233