### PR TITLE
chore(factory): remove Zysk hardcoding — generalise to knownDefaults()

### DIFF
--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -37,14 +37,12 @@ class CompanyFactory extends Factory
         ]);
     }
 
-    public function zysk(): static
+    public function knownDefaults(): static
     {
         return $this->state(fn (array $attributes) => [
-            'name' => 'Zysk Technologies Private Limited - 2025 - 2026',
-            'gstin' => '29AABCZ5012F1ZG',
-            'state' => 'Karnataka',
-            'gst_registration_type' => 'Regular',
-            'currency' => 'INR',
+            'name' => 'Acme Corp Private Limited - 2025 - 2026',
+            'gstin' => '27AABCA5012F1ZA',
+            'state' => 'Maharashtra',
         ]);
     }
 }

--- a/database/migrations/2026_02_26_103900_backfill_company_id.php
+++ b/database/migrations/2026_02_26_103900_backfill_company_id.php
@@ -7,13 +7,15 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // Create the initial company from config defaults
+        // Create the initial company from config defaults.
+        // NOTE: This migration ran once in production. The config/company.php file does not
+        // exist; config() calls resolve to null and the DB defaults ('Regular', 'INR') apply.
+        // On fresh installs the company created here will be replaced via RegisterCompany.
         $companyId = DB::table('companies')->insertGetId([
-            'name' => config('company.name', 'Zysk Technologies Private Limited - 2025 - 2026'),
-            'gstin' => config('company.gstin', '29AABCZ5012F1ZG'),
-            'state' => config('company.state', 'Karnataka'),
+            'name' => config('company.name', ''),
+            'gstin' => config('company.gstin'),
+            'state' => config('company.state'),
             'gst_registration_type' => config('company.gst_registration_type', 'Regular'),
-            'financial_year' => config('company.financial_year', '2025-2026'),
             'currency' => config('company.currency', 'INR'),
             'created_at' => now(),
             'updated_at' => now(),

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Enums\UserRole;
-use App\Models\Company;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 
@@ -11,24 +9,10 @@ class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        $company = Company::firstOrCreate(
-            ['gstin' => '29AABCZ5012F1ZG'],
-            [
-                'name' => 'Zysk Technologies Private Limited - 2025 - 2026',
-                'state' => 'Karnataka',
-                'gst_registration_type' => 'Regular',
-                'currency' => 'INR',
-            ],
-        );
-
         if (app()->environment('local', 'testing')) {
-            $user = User::factory()->create([
+            User::factory()->create([
                 'name' => 'Admin',
-                'email' => 'admin@zysk.in',
-            ]);
-
-            $company->users()->syncWithoutDetaching([
-                $user->id => ['role' => UserRole::Admin->value],
+                'email' => 'admin@example.com',
             ]);
         }
     }

--- a/tests/Feature/Models/CompanyTest.php
+++ b/tests/Feature/Models/CompanyTest.php
@@ -3,10 +3,12 @@
 use App\Models\AccountHead;
 use App\Models\BankAccount;
 use App\Models\Company;
+use App\Models\Connector;
 use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 use App\Models\User;
+use Illuminate\Support\Facades\Schema;
 
 describe('Company factory', function () {
     it('creates a company with valid defaults', function () {
@@ -21,16 +23,18 @@ describe('Company factory', function () {
     });
 
     it('does not have financial_year column in database', function () {
-        expect(Illuminate\Support\Facades\Schema::hasColumn('companies', 'financial_year'))->toBeFalse();
+        expect(Schema::hasColumn('companies', 'financial_year'))->toBeFalse();
     });
 
-    it('creates a zysk company with known defaults', function () {
-        $company = Company::factory()->zysk()->create();
+    it('creates a company with known defaults via knownDefaults state', function () {
+        $company = Company::factory()->knownDefaults()->create();
 
-        expect($company->name)->toBe('Zysk Technologies Private Limited - 2025 - 2026')
-            ->and($company->gstin)->toBe('29AABCZ5012F1ZG')
-            ->and($company->state)->toBe('Karnataka');
+        expect($company->name)->toBe('Acme Corp Private Limited - 2025 - 2026')
+            ->and($company->gstin)->toBe('27AABCA5012F1ZA')
+            ->and($company->state)->toBe('Maharashtra')
+            ->and($company->name)->not->toContain('Zysk');
     });
+
 });
 
 describe('Company relationships', function () {
@@ -81,7 +85,7 @@ describe('Company relationships', function () {
 describe('Company connectors relationship', function () {
     it('has many connectors', function () {
         $company = Company::factory()->create();
-        \App\Models\Connector::factory()->create(['company_id' => $company->id]);
+        Connector::factory()->create(['company_id' => $company->id]);
 
         expect($company->connectors)->toHaveCount(1);
     });

--- a/tests/Feature/Services/TallyExportServiceTest.php
+++ b/tests/Feature/Services/TallyExportServiceTest.php
@@ -9,7 +9,7 @@ use App\Services\TallyExport\TallyExportService;
 
 describe('TallyExportService', function () {
     beforeEach(function () {
-        $this->company = Company::factory()->zysk()->create();
+        $this->company = Company::factory()->knownDefaults()->create();
         $this->bankAccount = BankAccount::factory()->create([
             'company_id' => $this->company->id,
             'name' => 'Icici Bank',
@@ -42,7 +42,7 @@ describe('TallyExportService', function () {
                 ->and($xml)->toContain('<IMPORTDATA>')
                 ->and($xml)->toContain('<REQUESTDESC>')
                 ->and($xml)->toContain('<REPORTNAME>All Masters</REPORTNAME>')
-                ->and($xml)->toContain('<SVCURRENTCOMPANY>Zysk Technologies Private Limited - 2025 - 2026</SVCURRENTCOMPANY>')
+                ->and($xml)->toContain('<SVCURRENTCOMPANY>Acme Corp Private Limited - 2025 - 2026</SVCURRENTCOMPANY>')
                 ->and($xml)->toContain('<REQUESTDATA>')
                 ->and($xml)->toContain('</ENVELOPE>');
         });
@@ -80,9 +80,9 @@ describe('TallyExportService', function () {
                 ->and($xml)->toContain('<VOUCHERTYPENAME>Payment</VOUCHERTYPENAME>')
                 ->and($xml)->toContain('<NARRATION>ACH/TATACAPFINSERLTD</NARRATION>')
                 ->and($xml)->toContain('<PARTYLEDGERNAME>TATA CAPITAL LIMITED</PARTYLEDGERNAME>')
-                ->and($xml)->toContain('<CMPGSTIN>29AABCZ5012F1ZG</CMPGSTIN>')
+                ->and($xml)->toContain('<CMPGSTIN>27AABCA5012F1ZA</CMPGSTIN>')
                 ->and($xml)->toContain('<CMPGSTREGISTRATIONTYPE>Regular</CMPGSTREGISTRATIONTYPE>')
-                ->and($xml)->toContain('<CMPGSTSTATE>Karnataka</CMPGSTSTATE>');
+                ->and($xml)->toContain('<CMPGSTSTATE>Maharashtra</CMPGSTSTATE>');
         });
 
         it('generates correct ledger entries for payment voucher', function () {
@@ -232,8 +232,8 @@ describe('TallyExportService', function () {
             $xml = $this->service->exportForFile($this->file);
 
             expect($xml)->toContain('<COMPANY>')
-                ->and($xml)->toContain('<REMOTECMPNAME>Zysk Technologies Private Limited - 2025 - 2026</REMOTECMPNAME>')
-                ->and($xml)->toContain('<REMOTECMPSTATE>Karnataka</REMOTECMPSTATE>');
+                ->and($xml)->toContain('<REMOTECMPNAME>Acme Corp Private Limited - 2025 - 2026</REMOTECMPNAME>')
+                ->and($xml)->toContain('<REMOTECMPSTATE>Maharashtra</REMOTECMPSTATE>');
         });
     });
 


### PR DESCRIPTION
## Summary

- Renames `CompanyFactory::zysk()` to `knownDefaults()` with generic Acme Corp data, so fresh installs see no Zysk-specific company data
- Strips hardcoded Zysk GSTIN/name/state fallbacks from the backfill migration (dead code — already ran in production)
- Removes company creation from `DatabaseSeeder`; `admin@example.com` user is created, no company — forcing new deployments through the `RegisterCompany` onboarding flow
- Updates `CompanyTest` and `TallyExportServiceTest` to use the new `knownDefaults()` state

## Test plan

- [x] `CompanyTest` — 14 tests pass, including new `creates a company with known defaults via knownDefaults state`
- [x] `TallyExportServiceTest` — 17 tests pass with updated Acme Corp assertions
- [x] Pint: Pass | PHPStan: Pass

Closes #230