### PR TITLE
feat(export): Sales voucher Tally XML export for outward invoices

### DIFF
--- a/app/Ai/Agents/InvoiceParser.php
+++ b/app/Ai/Agents/InvoiceParser.php
@@ -2,6 +2,7 @@
 
 namespace App\Ai\Agents;
 
+use App\Ai\Middleware\AuditLlmCalls;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Attributes\MaxTokens;
 use Laravel\Ai\Attributes\Provider;
@@ -22,12 +23,12 @@ class InvoiceParser implements Agent, HasMiddleware, HasStructuredOutput
     use Promptable;
 
     /**
-     * @return array<int, \App\Ai\Middleware\AuditLlmCalls>
+     * @return array<int, AuditLlmCalls>
      */
     public function middleware(): array
     {
         return [
-            new \App\Ai\Middleware\AuditLlmCalls,
+            new AuditLlmCalls,
         ];
     }
 
@@ -68,10 +69,15 @@ class InvoiceParser implements Agent, HasMiddleware, HasStructuredOutput
         return [
             'vendor_name' => $schema->string()->required(),
             'vendor_gstin' => $schema->string(),
+            'buyer_name' => $schema->string(),
+            'buyer_gstin' => $schema->string(),
+            'buyer_address' => $schema->array()->items($schema->string()),
             'invoice_number' => $schema->string()->required(),
             'invoice_date' => $schema->string()->required(),
             'due_date' => $schema->string(),
             'place_of_supply' => $schema->string(),
+            'service_name' => $schema->string(),
+            'hsn_sac' => $schema->string(),
             'line_items' => $schema->array()->items($schema->object([
                 'description' => $schema->string()->required(),
                 'hsn_sac' => $schema->string(),

--- a/app/Enums/StatementType.php
+++ b/app/Enums/StatementType.php
@@ -9,6 +9,7 @@ enum StatementType: string implements HasLabel
     case Bank = 'bank';
     case CreditCard = 'credit_card';
     case Invoice = 'invoice';
+    case SalesInvoice = 'sales_invoice';
 
     public function getLabel(): string
     {
@@ -16,6 +17,7 @@ enum StatementType: string implements HasLabel
             self::Bank => 'Bank Statement',
             self::CreditCard => 'Credit Card Statement',
             self::Invoice => 'Invoice',
+            self::SalesInvoice => 'Sales Invoice',
         };
     }
 }

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -257,6 +257,7 @@ class DocumentProcessor
             match ($statementType) {
                 StatementType::Bank, StatementType::CreditCard => $this->parsePdfStatement($file, $filePath),
                 StatementType::Invoice => $this->parsePdfInvoice($file, $filePath),
+                StatementType::SalesInvoice => throw new \LogicException('SalesInvoice files are not parsed via PDF processing.'),
             };
         } finally {
             if ($decryptedPath !== null) {

--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -71,7 +71,8 @@ class TallyExportService
         $xml .= '  <BODY>'."\n";
         $xml .= '    <IMPORTDATA>'."\n";
         $xml .= '      <REQUESTDESC>'."\n";
-        $xml .= '        <REPORTNAME>All Masters</REPORTNAME>'."\n";
+        $reportName = $importedFile?->statement_type === StatementType::SalesInvoice ? 'Vouchers' : 'All Masters';
+        $xml .= '        <REPORTNAME>'.$reportName.'</REPORTNAME>'."\n";
         $xml .= '        <STATICVARIABLES>'."\n";
         $xml .= '          <SVCURRENTCOMPANY>'.$this->escapeXml($companyName).'</SVCURRENTCOMPANY>'."\n";
         $xml .= '        </STATICVARIABLES>'."\n";
@@ -99,6 +100,10 @@ class TallyExportService
      */
     private function generateVoucher(Transaction $transaction, ?Company $company, ?string $bankLedgerName, ?ImportedFile $importedFile = null): string
     {
+        if ($importedFile?->statement_type === StatementType::SalesInvoice) {
+            return $this->generateSalesVoucher($transaction, $company);
+        }
+
         if ($importedFile?->statement_type === StatementType::Invoice) {
             return $this->generateInvoiceJournalVoucher($transaction, $company);
         }
@@ -231,6 +236,163 @@ class TallyExportService
 
         $xml .= '          </VOUCHER>'."\n";
         $xml .= '        </TALLYMESSAGE>'."\n";
+
+        return $xml;
+    }
+
+    /**
+     * Generate a Sales voucher for an outward (sales) invoice.
+     * Multi-leg: customer party debit, sales revenue credit, Output GST credits.
+     */
+    private function generateSalesVoucher(Transaction $transaction, ?Company $company): string
+    {
+        /** @var Carbon $transactionDate */
+        $transactionDate = $transaction->date;
+
+        /** @var array<string, mixed> $raw */
+        $raw = $transaction->raw_data ?? [];
+        $invoiceDateRaw = (string) ($raw['invoice_date'] ?? '');
+        $date = $invoiceDateRaw !== ''
+            ? Carbon::parse($invoiceDateRaw)->format('Ymd')
+            : $transactionDate->format('Ymd');
+
+        /** @var AccountHead|null $accountHead */
+        $accountHead = $transaction->accountHead;
+        $voucherNumber = (string) ($raw['invoice_number'] ?? $this->nextVoucherNumber('Sales'));
+
+        $buyerName = (string) ($raw['buyer_name'] ?? 'Unknown Buyer');
+        $buyerGstin = (string) ($raw['buyer_gstin'] ?? '');
+        $placeOfSupply = (string) ($raw['place_of_supply'] ?? '');
+        $serviceName = (string) ($raw['service_name'] ?? ($accountHead?->name ?? 'Unknown'));
+        $hsnSac = (string) ($raw['hsn_sac'] ?? '');
+        $narration = (string) ($raw['description'] ?? $transaction->description ?? '');
+        $baseAmount = (float) ($raw['base_amount'] ?? 0);
+        $cgstRate = $raw['cgst_rate'] ?? null;
+        $cgstAmount = (float) ($raw['cgst_amount'] ?? 0);
+        $sgstRate = $raw['sgst_rate'] ?? null;
+        $sgstAmount = (float) ($raw['sgst_amount'] ?? 0);
+        $igstRate = $raw['igst_rate'] ?? null;
+        $igstAmount = (float) ($raw['igst_amount'] ?? 0);
+
+        /** @var array<int, string> $buyerAddress */
+        $buyerAddress = is_array($raw['buyer_address'] ?? null) ? $raw['buyer_address'] : [];
+
+        $hasIgst = $igstRate !== null && $igstAmount > 0;
+        $partyAmount = $hasIgst
+            ? $baseAmount + $igstAmount
+            : $baseAmount + $cgstAmount + $sgstAmount;
+
+        $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
+        $xml .= '          <VOUCHER VCHTYPE="Sales" ACTION="Create" OBJVIEW="Invoice Voucher View">'."\n";
+        $xml .= '            <DATE>'.$date.'</DATE>'."\n";
+        $xml .= '            <NARRATION>'.$this->escapeXml($narration).'</NARRATION>'."\n";
+        $xml .= '            <VOUCHERTYPENAME>Sales</VOUCHERTYPENAME>'."\n";
+        $xml .= '            <VOUCHERNUMBER>'.$this->escapeXml($voucherNumber).'</VOUCHERNUMBER>'."\n";
+        $xml .= '            <PARTYLEDGERNAME>'.$this->escapeXml($buyerName).'</PARTYLEDGERNAME>'."\n";
+        $xml .= '            <PARTYMAILINGNAME>'.$this->escapeXml($buyerName).'</PARTYMAILINGNAME>'."\n";
+
+        if ($buyerGstin !== '') {
+            $xml .= '            <PARTYGSTIN>'.$this->escapeXml($buyerGstin).'</PARTYGSTIN>'."\n";
+        }
+
+        if ($company) {
+            $xml .= '            <CMPGSTIN>'.$this->escapeXml($company->gstin ?? '').'</CMPGSTIN>'."\n";
+            $xml .= '            <CMPGSTREGISTRATIONTYPE>'.$this->escapeXml($company->gst_registration_type ?? 'Regular').'</CMPGSTREGISTRATIONTYPE>'."\n";
+            $xml .= '            <CMPGSTSTATE>'.$this->escapeXml($company->state ?? '').'</CMPGSTSTATE>'."\n";
+        }
+
+        $xml .= '            <GSTREGISTRATIONTYPE>Regular</GSTREGISTRATIONTYPE>'."\n";
+
+        if ($placeOfSupply !== '') {
+            $xml .= '            <STATENAME>'.$this->escapeXml($placeOfSupply).'</STATENAME>'."\n";
+            $xml .= '            <PLACEOFSUPPLY>'.$this->escapeXml($placeOfSupply).'</PLACEOFSUPPLY>'."\n";
+        }
+
+        $xml .= '            <ISINVOICE>Yes</ISINVOICE>'."\n";
+        $xml .= '            <VCHENTRYMORE>Accounting Invoice</VCHENTRYMORE>'."\n";
+        $xml .= '            <NUMBERINGSTYLE>Manual</NUMBERINGSTYLE>'."\n";
+        $xml .= '            <EFFECTIVEDATE>'.$date.'</EFFECTIVEDATE>'."\n";
+        $xml .= '            <ISREVERSCHARGEAPPLICABLE>No</ISREVERSCHARGEAPPLICABLE>'."\n";
+        $xml .= '            <ISELIGIBLEFORLITC>Yes</ISELIGIBLEFORLITC>'."\n";
+
+        if ($buyerAddress !== []) {
+            $xml .= '            <ADDRESS.LIST TYPE="String">'."\n";
+            foreach ($buyerAddress as $line) {
+                $xml .= '              <ADDRESS>'.$this->escapeXml($line).'</ADDRESS>'."\n";
+            }
+            $xml .= '            </ADDRESS.LIST>'."\n";
+        }
+
+        $xml .= '            <LEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($buyerName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <ISPARTYLEDGER>Yes</ISPARTYLEDGER>'."\n";
+        $xml .= '              <AMOUNT>-'.number_format($partyAmount, 2, '.', '').'</AMOUNT>'."\n";
+        $xml .= '            </LEDGERENTRIES.LIST>'."\n";
+
+        $xml .= '            <LEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($serviceName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <ISPARTYLEDGER>No</ISPARTYLEDGER>'."\n";
+        $xml .= '              <AMOUNT>'.number_format($baseAmount, 2, '.', '').'</AMOUNT>'."\n";
+
+        if ($hsnSac !== '') {
+            $xml .= '              <GSTHSNNAME>'.$this->escapeXml($hsnSac).'</GSTHSNNAME>'."\n";
+        }
+
+        $xml .= '              <GSTOVRDNTAXABILITY>Taxable</GSTOVRDNTAXABILITY>'."\n";
+        $xml .= '              <GSTOVRDNTYPEOFSUPPLY>Services</GSTOVRDNTYPEOFSUPPLY>'."\n";
+
+        if ($hasIgst) {
+            $xml .= '              <RATEDETAILS.LIST>'."\n";
+            $xml .= '                <GSTRATEDUTYHEAD>IGST</GSTRATEDUTYHEAD>'."\n";
+            $xml .= '                <GSTRATEVALUATIONTYPE>Based on Value</GSTRATEVALUATIONTYPE>'."\n";
+            $xml .= '                <GSTRATE>'.$igstRate.'</GSTRATE>'."\n";
+            $xml .= '              </RATEDETAILS.LIST>'."\n";
+        } elseif ($cgstRate !== null && $sgstRate !== null) {
+            $xml .= '              <RATEDETAILS.LIST>'."\n";
+            $xml .= '                <GSTRATEDUTYHEAD>CGST</GSTRATEDUTYHEAD>'."\n";
+            $xml .= '                <GSTRATEVALUATIONTYPE>Based on Value</GSTRATEVALUATIONTYPE>'."\n";
+            $xml .= '                <GSTRATE>'.$cgstRate.'</GSTRATE>'."\n";
+            $xml .= '              </RATEDETAILS.LIST>'."\n";
+            $xml .= '              <RATEDETAILS.LIST>'."\n";
+            $xml .= '                <GSTRATEDUTYHEAD>SGST/UTGST</GSTRATEDUTYHEAD>'."\n";
+            $xml .= '                <GSTRATEVALUATIONTYPE>Based on Value</GSTRATEVALUATIONTYPE>'."\n";
+            $xml .= '                <GSTRATE>'.$sgstRate.'</GSTRATE>'."\n";
+            $xml .= '              </RATEDETAILS.LIST>'."\n";
+        }
+
+        $xml .= '            </LEDGERENTRIES.LIST>'."\n";
+
+        if ($hasIgst) {
+            $xml .= $this->generateOutputTaxLedgerEntry("Output Igst @ {$igstRate}%", $igstRate, $igstAmount);
+        } else {
+            if ($cgstRate !== null && $cgstAmount > 0) {
+                $xml .= $this->generateOutputTaxLedgerEntry("Output Cgst @ {$cgstRate}%", $cgstRate, $cgstAmount);
+            }
+
+            if ($sgstRate !== null && $sgstAmount > 0) {
+                $xml .= $this->generateOutputTaxLedgerEntry("Output Sgst @ {$sgstRate}%", $sgstRate, $sgstAmount);
+            }
+        }
+
+        $xml .= '          </VOUCHER>'."\n";
+        $xml .= '        </TALLYMESSAGE>'."\n";
+
+        return $xml;
+    }
+
+    private function generateOutputTaxLedgerEntry(string $ledgerName, float|int $rate, float $amount): string
+    {
+        $xml = '            <LEDGERENTRIES.LIST>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($ledgerName).'</LEDGERNAME>'."\n";
+        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <ISPARTYLEDGER>No</ISPARTYLEDGER>'."\n";
+        $xml .= '              <RATEOFINVOICETAX.LIST TYPE="Number">'."\n";
+        $xml .= '                <RATEOFINVOICETAX>'.$rate.'</RATEOFINVOICETAX>'."\n";
+        $xml .= '              </RATEOFINVOICETAX.LIST>'."\n";
+        $xml .= '              <AMOUNT>'.number_format($amount, 2, '.', '').'</AMOUNT>'."\n";
+        $xml .= '            </LEDGERENTRIES.LIST>'."\n";
 
         return $xml;
     }

--- a/database/factories/ImportedFileFactory.php
+++ b/database/factories/ImportedFileFactory.php
@@ -11,7 +11,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ImportedFile>
+ * @extends Factory<ImportedFile>
  */
 class ImportedFileFactory extends Factory
 {
@@ -80,6 +80,15 @@ class ImportedFileFactory extends Factory
             'statement_type' => StatementType::Invoice,
             'file_path' => 'statements/'.fake()->uuid().'.pdf',
             'original_filename' => 'invoice_'.fake()->date('Y_m').'.pdf',
+        ]);
+    }
+
+    public function salesInvoice(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'statement_type' => StatementType::SalesInvoice,
+            'file_path' => 'statements/'.fake()->uuid().'.pdf',
+            'original_filename' => 'sales_invoice_'.fake()->date('Y_m').'.pdf',
         ]);
     }
 

--- a/tests/Feature/Services/TallyExportSalesVoucherTest.php
+++ b/tests/Feature/Services/TallyExportSalesVoucherTest.php
@@ -1,0 +1,490 @@
+<?php
+
+use App\Ai\Agents\InvoiceParser;
+use App\Enums\StatementType;
+use App\Models\AccountHead;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\TallyExport\TallyExportService;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+
+describe('TallyExportService sales voucher', function () {
+    beforeEach(fn () => asUser());
+
+    it('exports sales invoice as Sales voucher not Journal', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'buyer_gstin' => '29AAGCV9545C1ZZ',
+                'buyer_address' => ['NO 10 & 11 NAT STREET BASAVANAGUDI'],
+                'place_of_supply' => 'Karnataka',
+                'service_name' => 'Website Maintenance',
+                'hsn_sac' => '998313',
+                'invoice_number' => 'ZY26-0002',
+                'invoice_date' => '2026-04-01',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'igst_rate' => null,
+                'igst_amount' => null,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('VCHTYPE="Sales"')
+            ->toContain('OBJVIEW="Invoice Voucher View"')
+            ->not->toContain('VCHTYPE="Journal"');
+    });
+
+    it('uses REPORTNAME Vouchers for sales invoice export', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client Pvt Ltd',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<REPORTNAME>Vouchers</REPORTNAME>')
+            ->not->toContain('<REPORTNAME>All Masters</REPORTNAME>');
+    });
+
+    it('generates intrastate 4-leg voucher: party debit, sales credit, CGST credit, SGST credit', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'Website Maintenance',
+        ]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'service_name' => 'Website Maintenance',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'igst_rate' => null,
+                'igst_amount' => null,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        // Party debit leg
+        expect($xml)
+            ->toContain('<ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>')
+            ->toContain('<ISPARTYLEDGER>Yes</ISPARTYLEDGER>')
+            ->toContain('-3844.44')
+            // Sales credit leg
+            ->toContain('Website Maintenance')
+            ->toContain('3258.00')
+            // Tax credit legs
+            ->toContain('Output Cgst @ 9%')
+            ->toContain('Output Sgst @ 9%')
+            ->toContain('293.22')
+            // No IGST
+            ->not->toContain('Output Igst');
+    });
+
+    it('generates interstate 3-leg voucher: party debit, sales credit, IGST credit', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'IT Consulting',
+        ]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '11800.00',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Mumbai Client Pvt Ltd',
+                'place_of_supply' => 'Maharashtra',
+                'service_name' => 'IT Consulting',
+                'base_amount' => 10000.00,
+                'cgst_rate' => null,
+                'cgst_amount' => null,
+                'sgst_rate' => null,
+                'sgst_amount' => null,
+                'igst_rate' => 18,
+                'igst_amount' => 1800.00,
+                'total_amount' => 11800.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('Output Igst @ 18%')
+            ->toContain('-11800.00')
+            ->toContain('10000.00')
+            ->toContain('1800.00')
+            ->not->toContain('Output Cgst')
+            ->not->toContain('Output Sgst');
+    });
+
+    it('sets party ledger amount to exact mathematical sum with no rounding entry', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'service_name' => 'Website Maintenance',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        // Party amount = -(base + cgst + sgst) = -(3258 + 293.22 + 293.22) = -3844.44
+        expect($xml)
+            ->toContain('-3844.44')
+            ->not->toContain('Rounding');
+    });
+
+    it('includes GSTHSNNAME, GSTOVRDNTAXABILITY and GSTOVRDNTYPEOFSUPPLY in sales ledger entry', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create([
+            'company_id' => tenant()->id,
+            'name' => 'Website Maintenance',
+        ]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'Website Maintenance',
+                'hsn_sac' => '998313',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<GSTHSNNAME>998313</GSTHSNNAME>')
+            ->toContain('<GSTOVRDNTAXABILITY>Taxable</GSTOVRDNTAXABILITY>')
+            ->toContain('<GSTOVRDNTYPEOFSUPPLY>Services</GSTOVRDNTYPEOFSUPPLY>');
+    });
+
+    it('includes RATEOFINVOICETAX in each tax ledger entry', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<RATEOFINVOICETAX.LIST TYPE="Number">')
+            ->toContain('<RATEOFINVOICETAX>9</RATEOFINVOICETAX>');
+    });
+
+    it('populates ADDRESS.LIST from buyer_address', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'buyer_address' => ['NO 10 & 11 NAT STREET BASAVANAGUDI', 'BANGALORE 560004'],
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<ADDRESS.LIST TYPE="String">')
+            ->toContain('NO 10 &amp; 11 NAT STREET BASAVANAGUDI')
+            ->toContain('BANGALORE 560004');
+    });
+
+    it('includes buyer GSTIN as PARTYGSTIN', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'buyer_gstin' => '29AAGCV9545C1ZZ',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<PARTYGSTIN>29AAGCV9545C1ZZ</PARTYGSTIN>');
+    });
+
+    it('uses invoice_date from raw_data not the transaction date', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-15',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'invoice_date' => '2026-04-01',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        // Uses invoice_date (20260401) not transaction date (20260415)
+        expect($xml)->toContain('<DATE>20260401</DATE>');
+    });
+
+    it('falls back to transaction date when invoice_date is absent', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-15',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<DATE>20260415</DATE>');
+    });
+
+    it('includes ISINVOICE Yes in sales voucher', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<ISINVOICE>Yes</ISINVOICE>');
+    });
+
+    it('does not affect existing journal voucher export for purchase invoices', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('VCHTYPE="Journal"')
+            ->toContain('<REPORTNAME>All Masters</REPORTNAME>')
+            ->not->toContain('VCHTYPE="Sales"');
+    });
+
+    it('includes PLACEOFSUPPLY and STATENAME from raw_data', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::SalesInvoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'place_of_supply' => 'Karnataka',
+                'service_name' => 'IT Services',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<PLACEOFSUPPLY>Karnataka</PLACEOFSUPPLY>')
+            ->toContain('<STATENAME>Karnataka</STATENAME>');
+    });
+});
+
+describe('InvoiceParser schema for sales invoices', function () {
+    it('schema includes buyer_name, buyer_address, buyer_gstin, service_name, hsn_sac fields', function () {
+        $parser = app(InvoiceParser::class);
+        $schemaBuilder = new JsonSchemaTypeFactory;
+
+        $schema = $parser->schema($schemaBuilder);
+
+        expect($schema)
+            ->toHaveKey('buyer_name')
+            ->toHaveKey('buyer_address')
+            ->toHaveKey('buyer_gstin')
+            ->toHaveKey('service_name')
+            ->toHaveKey('hsn_sac');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `StatementType::SalesInvoice` enum value for outward (sales) invoice files
- Adds `generateSalesVoucher()` to `TallyExportService` — `VCHTYPE="Sales"` / `OBJVIEW="Invoice Voucher View"` with `REPORTNAME=Vouchers` envelope
- Intrastate: 4-leg voucher (party debit, sales credit, CGST credit, SGST credit); Interstate: 3-leg (party debit, sales credit, IGST credit)
- Extends `InvoiceParser` schema with `buyer_name`, `buyer_address`, `buyer_gstin`, `service_name`, `hsn_sac` fields for sales invoice parsing

## Test plan

- [x] `VCHTYPE="Sales"` and `OBJVIEW="Invoice Voucher View"` in generated XML
- [x] `REPORTNAME=Vouchers` for Sales exports (not `All Masters`)
- [x] Intrastate: 4 ledger legs, CGST + SGST credits
- [x] Interstate: 3 ledger legs, IGST credit only
- [x] Party amount = exact sum of base + GST (no rounding entry)
- [x] `GSTHSNNAME`, `GSTOVRDNTAXABILITY`, `GSTOVRDNTYPEOFSUPPLY` in sales ledger entry
- [x] `RATEOFINVOICETAX.LIST` in each output tax ledger entry
- [x] `ADDRESS.LIST` populated from `buyer_address` array
- [x] `invoice_date` from `raw_data` with fallback to transaction date
- [x] `PARTYGSTIN` from buyer GSTIN
- [x] Existing Journal voucher tests unaffected (0 regressions, 37 total passing)

Closes #238