### PR TITLE
refactor(tests): fix top-level beforeEach scope in 4 Feature test files

### DIFF
--- a/tests/Feature/Services/PdfDecryptionServiceTest.php
+++ b/tests/Feature/Services/PdfDecryptionServiceTest.php
@@ -4,103 +4,105 @@ use App\Services\DocumentProcessor\PdfDecryptionService;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
 
-beforeEach(function () {
-    Storage::fake('local');
+describe('PdfDecryptionService', function () {
+    beforeEach(function () {
+        Storage::fake('local');
 
-    $this->service = new PdfDecryptionService;
-});
-
-describe('PdfDecryptionService isQpdfAvailable', function () {
-    it('returns true when qpdf is installed', function () {
-        Process::fake([
-            'qpdf --version' => Process::result(output: 'qpdf version 11.9.0'),
-        ]);
-
-        expect($this->service->isQpdfAvailable())->toBeTrue();
+        $this->service = new PdfDecryptionService;
     });
 
-    it('returns false when qpdf is not installed', function () {
-        Process::fake([
-            'qpdf --version' => Process::result(exitCode: 1, errorOutput: 'command not found'),
-        ]);
+    describe('isQpdfAvailable', function () {
+        it('returns true when qpdf is installed', function () {
+            Process::fake([
+                'qpdf --version' => Process::result(output: 'qpdf version 11.9.0'),
+            ]);
 
-        expect($this->service->isQpdfAvailable())->toBeFalse();
-    });
-});
+            expect($this->service->isQpdfAvailable())->toBeTrue();
+        });
 
-describe('PdfDecryptionService isPasswordProtected', function () {
-    it('returns true when PDF contains /Encrypt marker', function () {
-        Storage::put('statements/test.pdf', '%PDF-1.4 some content /Encrypt some more content');
+        it('returns false when qpdf is not installed', function () {
+            Process::fake([
+                'qpdf --version' => Process::result(exitCode: 1, errorOutput: 'command not found'),
+            ]);
 
-        expect($this->service->isPasswordProtected('statements/test.pdf'))->toBeTrue();
-    });
-
-    it('returns false when PDF does not contain /Encrypt marker', function () {
-        Storage::put('statements/test.pdf', '%PDF-1.4 normal unencrypted content');
-
-        expect($this->service->isPasswordProtected('statements/test.pdf'))->toBeFalse();
-    });
-
-    it('returns false when file does not exist', function () {
-        expect($this->service->isPasswordProtected('statements/nonexistent.pdf'))->toBeFalse();
-    });
-});
-
-describe('PdfDecryptionService decrypt', function () {
-    it('returns the decrypted file path on success', function () {
-        Storage::put('statements/test.pdf', 'encrypted-pdf-content');
-
-        Process::fake([
-            '*qpdf --password=*--decrypt*' => Process::result(exitCode: 0),
-        ]);
-
-        $result = $this->service->decrypt('statements/test.pdf', 'secret123');
-
-        expect($result)->toBe('statements/test_decrypted.pdf');
-
-        Process::assertRan(function ($process) {
-            return str_contains($process->command, 'secret123')
-                && str_contains($process->command, '--decrypt');
+            expect($this->service->isQpdfAvailable())->toBeFalse();
         });
     });
 
-    it('succeeds with warnings when qpdf returns exit code 3', function () {
-        Storage::put('statements/test.pdf', 'encrypted-pdf-content');
+    describe('isPasswordProtected', function () {
+        it('returns true when PDF contains /Encrypt marker', function () {
+            Storage::put('statements/test.pdf', '%PDF-1.4 some content /Encrypt some more content');
 
-        Process::fake([
-            '*qpdf --password=*--decrypt*' => Process::result(
-                exitCode: 3,
-                errorOutput: '/Perms field in encryption dictionary doesn\'t match expected value',
-            ),
-        ]);
+            expect($this->service->isPasswordProtected('statements/test.pdf'))->toBeTrue();
+        });
 
-        $result = $this->service->decrypt('statements/test.pdf', 'secret123');
+        it('returns false when PDF does not contain /Encrypt marker', function () {
+            Storage::put('statements/test.pdf', '%PDF-1.4 normal unencrypted content');
 
-        expect($result)->toBe('statements/test_decrypted.pdf');
+            expect($this->service->isPasswordProtected('statements/test.pdf'))->toBeFalse();
+        });
+
+        it('returns false when file does not exist', function () {
+            expect($this->service->isPasswordProtected('statements/nonexistent.pdf'))->toBeFalse();
+        });
     });
 
-    it('throws RuntimeException on wrong password', function () {
-        Storage::put('statements/test.pdf', 'encrypted-pdf-content');
+    describe('decrypt', function () {
+        it('returns the decrypted file path on success', function () {
+            Storage::put('statements/test.pdf', 'encrypted-pdf-content');
 
-        Process::fake([
-            '*qpdf --password=*--decrypt*' => Process::result(
-                exitCode: 2,
-                errorOutput: 'invalid password',
-            ),
-        ]);
+            Process::fake([
+                '*qpdf --password=*--decrypt*' => Process::result(exitCode: 0),
+            ]);
 
-        $this->service->decrypt('statements/test.pdf', 'wrong');
-    })->throws(RuntimeException::class, 'Failed to decrypt PDF');
+            $result = $this->service->decrypt('statements/test.pdf', 'secret123');
 
-    it('preserves original file after decryption', function () {
-        Storage::put('statements/test.pdf', 'original-content');
+            expect($result)->toBe('statements/test_decrypted.pdf');
 
-        Process::fake([
-            '*qpdf --password=*--decrypt*' => Process::result(exitCode: 0),
-        ]);
+            Process::assertRan(function ($process) {
+                return str_contains($process->command, 'secret123')
+                    && str_contains($process->command, '--decrypt');
+            });
+        });
 
-        $this->service->decrypt('statements/test.pdf', 'secret123');
+        it('succeeds with warnings when qpdf returns exit code 3', function () {
+            Storage::put('statements/test.pdf', 'encrypted-pdf-content');
 
-        Storage::disk('local')->assertExists('statements/test.pdf');
+            Process::fake([
+                '*qpdf --password=*--decrypt*' => Process::result(
+                    exitCode: 3,
+                    errorOutput: '/Perms field in encryption dictionary doesn\'t match expected value',
+                ),
+            ]);
+
+            $result = $this->service->decrypt('statements/test.pdf', 'secret123');
+
+            expect($result)->toBe('statements/test_decrypted.pdf');
+        });
+
+        it('throws RuntimeException on wrong password', function () {
+            Storage::put('statements/test.pdf', 'encrypted-pdf-content');
+
+            Process::fake([
+                '*qpdf --password=*--decrypt*' => Process::result(
+                    exitCode: 2,
+                    errorOutput: 'invalid password',
+                ),
+            ]);
+
+            $this->service->decrypt('statements/test.pdf', 'wrong');
+        })->throws(RuntimeException::class, 'Failed to decrypt PDF');
+
+        it('preserves original file after decryption', function () {
+            Storage::put('statements/test.pdf', 'original-content');
+
+            Process::fake([
+                '*qpdf --password=*--decrypt*' => Process::result(exitCode: 0),
+            ]);
+
+            $this->service->decrypt('statements/test.pdf', 'secret123');
+
+            Storage::disk('local')->assertExists('statements/test.pdf');
+        });
     });
 });

--- a/tests/Feature/Services/ReportingServiceTest.php
+++ b/tests/Feature/Services/ReportingServiceTest.php
@@ -8,12 +8,12 @@ use App\Models\TransactionAggregate;
 use App\Services\ReportingService;
 use Illuminate\Support\Carbon;
 
-beforeEach(function () {
-    asUser();
-    $this->service = app(ReportingService::class);
-});
-
 describe('ReportingService', function () {
+    beforeEach(function () {
+        asUser();
+        $this->service = app(ReportingService::class);
+    });
+
     describe('financialYearMonths', function () {
         it('returns 12 months from April to March for a date in the middle of the FY', function () {
             $months = $this->service->financialYearMonths(Carbon::create(2025, 8, 15));

--- a/tests/Feature/Services/TallyMasterImportServiceTest.php
+++ b/tests/Feature/Services/TallyMasterImportServiceTest.php
@@ -5,213 +5,215 @@ use App\Models\BankAccount;
 use App\Models\Company;
 use App\Services\TallyImport\TallyMasterImportService;
 
-beforeEach(function () {
-    $this->company = Company::factory()->create(['name' => 'Old Company Name']);
-    $this->service = new TallyMasterImportService;
-    $this->simpleXml = file_get_contents(base_path('tests/fixtures/tally-masters-simple.xml'));
-});
-
-describe('TallyMasterImportService::import() — Groups', function () {
-    it('creates groups as account heads', function () {
-        $result = $this->service->import($this->simpleXml, $this->company);
-
-        expect($result->groupsCreated)->toBe(2)
-            ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Sundry Debtors')->exists())->toBeTrue()
-            ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Bank Accounts')->exists())->toBeTrue();
+describe('TallyMasterImportService', function () {
+    beforeEach(function () {
+        $this->company = Company::factory()->create(['name' => 'Old Company Name']);
+        $this->service = new TallyMasterImportService;
+        $this->simpleXml = file_get_contents(base_path('tests/fixtures/tally-masters-simple.xml'));
     });
 
-    it('assigns tally_guid to imported groups', function () {
-        $this->service->import($this->simpleXml, $this->company);
+    describe('import() — Groups', function () {
+        it('creates groups as account heads', function () {
+            $result = $this->service->import($this->simpleXml, $this->company);
 
-        $group = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Sundry Debtors')
-            ->first();
+            expect($result->groupsCreated)->toBe(2)
+                ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Sundry Debtors')->exists())->toBeTrue()
+                ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Bank Accounts')->exists())->toBeTrue();
+        });
 
-        expect($group->tally_guid)->toBe('e5f6a7b8-c9d0-1234-5678-9abcdef01234');
+        it('assigns tally_guid to imported groups', function () {
+            $this->service->import($this->simpleXml, $this->company);
+
+            $group = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Sundry Debtors')
+                ->first();
+
+            expect($group->tally_guid)->toBe('e5f6a7b8-c9d0-1234-5678-9abcdef01234');
+        });
+
+        it('sets group_name to the group name itself for groups', function () {
+            $this->service->import($this->simpleXml, $this->company);
+
+            $group = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Sundry Debtors')
+                ->first();
+
+            expect($group->group_name)->toBe('Sundry Debtors');
+        });
+
+        it('handles parent hierarchy for child groups', function () {
+            $parentHead = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Current Assets',
+            ]);
+
+            $this->service->import($this->simpleXml, $this->company);
+
+            $sundryDebtors = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Sundry Debtors')
+                ->first();
+
+            expect($sundryDebtors->parent_id)->toBe($parentHead->id);
+        });
+
+        it('adds warning when parent group is not found', function () {
+            $result = $this->service->import($this->simpleXml, $this->company);
+
+            expect($result->warnings)->toContain(
+                "Parent group 'Current Assets' not found for group 'Sundry Debtors' — imported without parent."
+            );
+        });
     });
 
-    it('sets group_name to the group name itself for groups', function () {
-        $this->service->import($this->simpleXml, $this->company);
+    describe('import() — Ledgers', function () {
+        it('creates ledgers as account heads', function () {
+            $result = $this->service->import($this->simpleXml, $this->company);
 
-        $group = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Sundry Debtors')
-            ->first();
+            expect($result->ledgersCreated)->toBe(3)
+                ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Acme Corp')->exists())->toBeTrue()
+                ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Office Rent')->exists())->toBeTrue()
+                ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'ICICI Bank - Current A/c')->exists())->toBeTrue();
+        });
 
-        expect($group->group_name)->toBe('Sundry Debtors');
+        it('sets group_name to the parent group for ledgers', function () {
+            $this->service->import($this->simpleXml, $this->company);
+
+            $ledger = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Acme Corp')
+                ->first();
+
+            expect($ledger->group_name)->toBe('Sundry Debtors');
+        });
+
+        it('links ledger to parent group account head', function () {
+            $this->service->import($this->simpleXml, $this->company);
+
+            $parentGroup = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Sundry Debtors')
+                ->first();
+
+            $ledger = AccountHead::where('company_id', $this->company->id)
+                ->where('name', 'Acme Corp')
+                ->first();
+
+            expect($ledger->parent_id)->toBe($parentGroup->id);
+        });
     });
 
-    it('handles parent hierarchy for child groups', function () {
-        $parentHead = AccountHead::factory()->create([
-            'company_id' => $this->company->id,
-            'name' => 'Current Assets',
-        ]);
+    describe('import() — Bank Accounts', function () {
+        it('creates bank account for bank-type ledger', function () {
+            $result = $this->service->import($this->simpleXml, $this->company);
 
-        $this->service->import($this->simpleXml, $this->company);
+            expect($result->bankAccountsCreated)->toBe(1);
 
-        $sundryDebtors = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Sundry Debtors')
-            ->first();
+            $bank = BankAccount::where('company_id', $this->company->id)
+                ->where('name', 'ICICI Bank - Current A/c')
+                ->first();
 
-        expect($sundryDebtors->parent_id)->toBe($parentHead->id);
+            expect($bank)->not->toBeNull()
+                ->and($bank->account_number)->toBe('012345678901')
+                ->and($bank->ifsc_code)->toBe('ICIC0001234')
+                ->and($bank->branch)->toBe('MG Road, Bangalore');
+        });
+
+        it('does not create bank account for non-bank ledgers', function () {
+            $this->service->import($this->simpleXml, $this->company);
+
+            expect(BankAccount::where('company_id', $this->company->id)->count())->toBe(1);
+        });
     });
 
-    it('adds warning when parent group is not found', function () {
-        $result = $this->service->import($this->simpleXml, $this->company);
+    describe('import() — Company Info', function () {
+        it('updates company name from SVCURRENTCOMPANY', function () {
+            $result = $this->service->import($this->simpleXml, $this->company);
 
-        expect($result->warnings)->toContain(
-            "Parent group 'Current Assets' not found for group 'Sundry Debtors' — imported without parent."
-        );
-    });
-});
+            expect($result->companyUpdated)->toBeTrue()
+                ->and($this->company->fresh()->name)->toBe('Zysk Technologies Private Limited');
+        });
 
-describe('TallyMasterImportService::import() — Ledgers', function () {
-    it('creates ledgers as account heads', function () {
-        $result = $this->service->import($this->simpleXml, $this->company);
+        it('does not update company if name already matches', function () {
+            $this->company->update(['name' => 'Zysk Technologies Private Limited']);
 
-        expect($result->ledgersCreated)->toBe(3)
-            ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Acme Corp')->exists())->toBeTrue()
-            ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'Office Rent')->exists())->toBeTrue()
-            ->and(AccountHead::where('company_id', $this->company->id)->where('name', 'ICICI Bank - Current A/c')->exists())->toBeTrue();
+            $result = $this->service->import($this->simpleXml, $this->company);
+
+            expect($result->companyUpdated)->toBeFalse();
+        });
     });
 
-    it('sets group_name to the parent group for ledgers', function () {
-        $this->service->import($this->simpleXml, $this->company);
+    describe('import() — Idempotency', function () {
+        it('does not create duplicates on re-import', function () {
+            $this->service->import($this->simpleXml, $this->company);
+            $firstCount = AccountHead::where('company_id', $this->company->id)->count();
 
-        $ledger = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Acme Corp')
-            ->first();
+            $result = $this->service->import($this->simpleXml, $this->company);
 
-        expect($ledger->group_name)->toBe('Sundry Debtors');
+            expect(AccountHead::where('company_id', $this->company->id)->count())->toBe($firstCount)
+                ->and($result->groupsUpdated)->toBe(2)
+                ->and($result->ledgersUpdated)->toBe(3);
+        });
+
+        it('matches existing records by tally_guid', function () {
+            $existing = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Renamed Acme',
+                'tally_guid' => '11111111-1111-1111-1111-111111111111',
+            ]);
+
+            $this->service->import($this->simpleXml, $this->company);
+
+            expect($existing->fresh()->name)->toBe('Acme Corp');
+        });
+
+        it('updates bank account on re-import', function () {
+            $this->service->import($this->simpleXml, $this->company);
+            $result = $this->service->import($this->simpleXml, $this->company);
+
+            expect($result->bankAccountsUpdated)->toBe(1)
+                ->and($result->bankAccountsCreated)->toBe(0)
+                ->and(BankAccount::where('company_id', $this->company->id)->count())->toBe(1);
+        });
     });
 
-    it('links ledger to parent group account head', function () {
-        $this->service->import($this->simpleXml, $this->company);
+    describe('import() — Edge Cases', function () {
+        it('returns error for invalid XML', function () {
+            $result = $this->service->import('not xml at all', $this->company);
 
-        $parentGroup = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Sundry Debtors')
-            ->first();
+            expect($result->hasErrors())->toBeTrue()
+                ->and($result->errors[0])->toContain('Invalid XML');
+        });
 
-        $ledger = AccountHead::where('company_id', $this->company->id)
-            ->where('name', 'Acme Corp')
-            ->first();
+        it('returns zero counts for empty XML', function () {
+            $emptyXml = file_get_contents(base_path('tests/fixtures/tally-masters-empty.xml'));
 
-        expect($ledger->parent_id)->toBe($parentGroup->id);
-    });
-});
+            $result = $this->service->import($emptyXml, $this->company);
 
-describe('TallyMasterImportService::import() — Bank Accounts', function () {
-    it('creates bank account for bank-type ledger', function () {
-        $result = $this->service->import($this->simpleXml, $this->company);
+            expect($result->totalCreated())->toBe(0)
+                ->and($result->totalUpdated())->toBe(0)
+                ->and($result->hasErrors())->toBeFalse();
+        });
 
-        expect($result->bankAccountsCreated)->toBe(1);
+        it('handles UTF-16LE encoded file', function () {
+            $utf16Content = file_get_contents(base_path('tests/fixtures/tally-masters-utf16le.xml'));
 
-        $bank = BankAccount::where('company_id', $this->company->id)
-            ->where('name', 'ICICI Bank - Current A/c')
-            ->first();
+            $result = $this->service->import($utf16Content, $this->company);
 
-        expect($bank)->not->toBeNull()
-            ->and($bank->account_number)->toBe('012345678901')
-            ->and($bank->ifsc_code)->toBe('ICIC0001234')
-            ->and($bank->branch)->toBe('MG Road, Bangalore');
-    });
+            expect($result->groupsCreated)->toBe(2)
+                ->and($result->ledgersCreated)->toBe(3)
+                ->and($result->bankAccountsCreated)->toBe(1);
+        });
 
-    it('does not create bank account for non-bank ledgers', function () {
-        $this->service->import($this->simpleXml, $this->company);
+        it('scopes all records to the given company', function () {
+            $otherCompany = Company::factory()->create();
+            AccountHead::factory()->create([
+                'company_id' => $otherCompany->id,
+                'name' => 'Sundry Debtors',
+                'tally_guid' => 'different-guid',
+            ]);
 
-        expect(BankAccount::where('company_id', $this->company->id)->count())->toBe(1);
-    });
-});
+            $this->service->import($this->simpleXml, $this->company);
 
-describe('TallyMasterImportService::import() — Company Info', function () {
-    it('updates company name from SVCURRENTCOMPANY', function () {
-        $result = $this->service->import($this->simpleXml, $this->company);
-
-        expect($result->companyUpdated)->toBeTrue()
-            ->and($this->company->fresh()->name)->toBe('Zysk Technologies Private Limited');
-    });
-
-    it('does not update company if name already matches', function () {
-        $this->company->update(['name' => 'Zysk Technologies Private Limited']);
-
-        $result = $this->service->import($this->simpleXml, $this->company);
-
-        expect($result->companyUpdated)->toBeFalse();
-    });
-});
-
-describe('TallyMasterImportService::import() — Idempotency', function () {
-    it('does not create duplicates on re-import', function () {
-        $this->service->import($this->simpleXml, $this->company);
-        $firstCount = AccountHead::where('company_id', $this->company->id)->count();
-
-        $result = $this->service->import($this->simpleXml, $this->company);
-
-        expect(AccountHead::where('company_id', $this->company->id)->count())->toBe($firstCount)
-            ->and($result->groupsUpdated)->toBe(2)
-            ->and($result->ledgersUpdated)->toBe(3);
-    });
-
-    it('matches existing records by tally_guid', function () {
-        $existing = AccountHead::factory()->create([
-            'company_id' => $this->company->id,
-            'name' => 'Renamed Acme',
-            'tally_guid' => '11111111-1111-1111-1111-111111111111',
-        ]);
-
-        $this->service->import($this->simpleXml, $this->company);
-
-        expect($existing->fresh()->name)->toBe('Acme Corp');
-    });
-
-    it('updates bank account on re-import', function () {
-        $this->service->import($this->simpleXml, $this->company);
-        $result = $this->service->import($this->simpleXml, $this->company);
-
-        expect($result->bankAccountsUpdated)->toBe(1)
-            ->and($result->bankAccountsCreated)->toBe(0)
-            ->and(BankAccount::where('company_id', $this->company->id)->count())->toBe(1);
-    });
-});
-
-describe('TallyMasterImportService::import() — Edge Cases', function () {
-    it('returns error for invalid XML', function () {
-        $result = $this->service->import('not xml at all', $this->company);
-
-        expect($result->hasErrors())->toBeTrue()
-            ->and($result->errors[0])->toContain('Invalid XML');
-    });
-
-    it('returns zero counts for empty XML', function () {
-        $emptyXml = file_get_contents(base_path('tests/fixtures/tally-masters-empty.xml'));
-
-        $result = $this->service->import($emptyXml, $this->company);
-
-        expect($result->totalCreated())->toBe(0)
-            ->and($result->totalUpdated())->toBe(0)
-            ->and($result->hasErrors())->toBeFalse();
-    });
-
-    it('handles UTF-16LE encoded file', function () {
-        $utf16Content = file_get_contents(base_path('tests/fixtures/tally-masters-utf16le.xml'));
-
-        $result = $this->service->import($utf16Content, $this->company);
-
-        expect($result->groupsCreated)->toBe(2)
-            ->and($result->ledgersCreated)->toBe(3)
-            ->and($result->bankAccountsCreated)->toBe(1);
-    });
-
-    it('scopes all records to the given company', function () {
-        $otherCompany = Company::factory()->create();
-        AccountHead::factory()->create([
-            'company_id' => $otherCompany->id,
-            'name' => 'Sundry Debtors',
-            'tally_guid' => 'different-guid',
-        ]);
-
-        $this->service->import($this->simpleXml, $this->company);
-
-        expect(AccountHead::where('company_id', $this->company->id)->where('name', 'Sundry Debtors')->count())->toBe(1)
-            ->and(AccountHead::where('company_id', $otherCompany->id)->where('name', 'Sundry Debtors')->count())->toBe(1);
+            expect(AccountHead::where('company_id', $this->company->id)->where('name', 'Sundry Debtors')->count())->toBe(1)
+                ->and(AccountHead::where('company_id', $otherCompany->id)->where('name', 'Sundry Debtors')->count())->toBe(1);
+        });
     });
 });

--- a/tests/Feature/Services/ZohoInvoiceServiceTest.php
+++ b/tests/Feature/Services/ZohoInvoiceServiceTest.php
@@ -12,339 +12,341 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 
-beforeEach(function () {
-    Storage::fake('local');
-    Queue::fake();
+describe('ZohoInvoiceService', function () {
+    beforeEach(function () {
+        Storage::fake('local');
+        Queue::fake();
 
-    $this->company = Company::factory()->create();
-    $this->service = new ZohoInvoiceService;
-});
-
-describe('Token refresh', function () {
-    it('refreshes token when expiring soon', function () {
-        $connector = Connector::factory()->create([
-            'company_id' => $this->company->id,
-            'token_expires_at' => now()->addMinutes(3),
-            'access_token' => 'old-token',
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        Http::fake([
-            '*/oauth/v2/token' => Http::response([
-                'access_token' => 'new-access-token',
-                'expires_in' => 3600,
-            ]),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [],
-            ]),
-        ]);
-
-        $this->service->syncForCompany($connector);
-
-        $connector->refresh();
-        expect($connector->access_token)->toBe('new-access-token');
+        $this->company = Company::factory()->create();
+        $this->service = new ZohoInvoiceService;
     });
 
-    it('does not refresh token when not expiring soon', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+    describe('Token refresh', function () {
+        it('refreshes token when expiring soon', function () {
+            $connector = Connector::factory()->create([
+                'company_id' => $this->company->id,
+                'token_expires_at' => now()->addMinutes(3),
+                'access_token' => 'old-token',
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
 
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [],
-            ]),
-        ]);
+            Http::fake([
+                '*/oauth/v2/token' => Http::response([
+                    'access_token' => 'new-access-token',
+                    'expires_in' => 3600,
+                ]),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [],
+                ]),
+            ]);
 
-        $this->service->syncForCompany($connector);
+            $this->service->syncForCompany($connector);
 
-        Http::assertNotSent(fn ($request) => str_contains($request->url(), 'oauth/v2/token'));
+            $connector->refresh();
+            expect($connector->access_token)->toBe('new-access-token');
+        });
+
+        it('does not refresh token when not expiring soon', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [],
+                ]),
+            ]);
+
+            $this->service->syncForCompany($connector);
+
+            Http::assertNotSent(fn ($request) => str_contains($request->url(), 'oauth/v2/token'));
+        });
+
+        it('throws exception when token refresh fails', function () {
+            $connector = Connector::factory()->create([
+                'company_id' => $this->company->id,
+                'token_expires_at' => now()->addMinutes(3),
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/oauth/v2/token' => Http::response(['error' => 'invalid_grant'], 400),
+            ]);
+
+            expect(fn () => $this->service->syncForCompany($connector))
+                ->toThrow(RuntimeException::class, 'Failed to refresh Zoho OAuth token');
+        });
     });
 
-    it('throws exception when token refresh fails', function () {
-        $connector = Connector::factory()->create([
-            'company_id' => $this->company->id,
-            'token_expires_at' => now()->addMinutes(3),
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+    describe('Invoice fetch and ImportedFile creation', function () {
+        it('fetches invoices and creates ImportedFile records', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
 
-        Http::fake([
-            '*/oauth/v2/token' => Http::response(['error' => 'invalid_grant'], 400),
-        ]);
-
-        expect(fn () => $this->service->syncForCompany($connector))
-            ->toThrow(RuntimeException::class, 'Failed to refresh Zoho OAuth token');
-    });
-});
-
-describe('Invoice fetch and ImportedFile creation', function () {
-    it('fetches invoices and creates ImportedFile records', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [
-                    [
-                        'invoice_id' => 'INV-001',
-                        'invoice_number' => 'INV-2026-001',
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [
+                        [
+                            'invoice_id' => 'INV-001',
+                            'invoice_number' => 'INV-2026-001',
+                        ],
                     ],
-                ],
-            ]),
-        ]);
+                ]),
+            ]);
 
-        $count = $this->service->syncForCompany($connector);
+            $count = $this->service->syncForCompany($connector);
 
-        expect($count)->toBe(1);
+            expect($count)->toBe(1);
 
-        $importedFile = ImportedFile::where('company_id', $this->company->id)
-            ->where('source', ImportSource::Zoho)
-            ->first();
+            $importedFile = ImportedFile::where('company_id', $this->company->id)
+                ->where('source', ImportSource::Zoho)
+                ->first();
 
-        expect($importedFile)->not->toBeNull()
-            ->and($importedFile->statement_type)->toBe(StatementType::Invoice)
-            ->and($importedFile->status)->toBe(ImportStatus::Pending)
-            ->and($importedFile->source)->toBe(ImportSource::Zoho)
-            ->and($importedFile->original_filename)->toBe('INV-2026-001.pdf')
-            ->and($importedFile->source_metadata)->toBeArray()
-            ->and($importedFile->source_metadata['zoho_invoice_id'])->toBe('INV-001')
-            ->and($importedFile->source_metadata['zoho_org_id'])->toBe('12345678');
+            expect($importedFile)->not->toBeNull()
+                ->and($importedFile->statement_type)->toBe(StatementType::Invoice)
+                ->and($importedFile->status)->toBe(ImportStatus::Pending)
+                ->and($importedFile->source)->toBe(ImportSource::Zoho)
+                ->and($importedFile->original_filename)->toBe('INV-2026-001.pdf')
+                ->and($importedFile->source_metadata)->toBeArray()
+                ->and($importedFile->source_metadata['zoho_invoice_id'])->toBe('INV-001')
+                ->and($importedFile->source_metadata['zoho_org_id'])->toBe('12345678');
+        });
+
+        it('syncs multiple invoices', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-content-001'),
+                '*/invoices/v3/invoices/INV-002*' => Http::response('%PDF-content-002'),
+                '*/invoices/v3/invoices/INV-003*' => Http::response('%PDF-content-003'),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [
+                        ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-2026-001'],
+                        ['invoice_id' => 'INV-002', 'invoice_number' => 'INV-2026-002'],
+                        ['invoice_id' => 'INV-003', 'invoice_number' => 'INV-2026-003'],
+                    ],
+                ]),
+            ]);
+
+            $count = $this->service->syncForCompany($connector);
+
+            expect($count)->toBe(3);
+            expect(ImportedFile::where('company_id', $this->company->id)->count())->toBe(3);
+        });
+
+        it('stores PDF in private statements directory', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
+                ]),
+            ]);
+
+            $this->service->syncForCompany($connector);
+
+            $file = ImportedFile::first();
+            expect($file->file_path)->toStartWith('statements/')
+                ->and($file->file_path)->toEndWith('.pdf');
+
+            Storage::disk('local')->assertExists($file->file_path);
+        });
+
+        it('skips invoice when PDF download fails', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('', 500),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
+                ]),
+            ]);
+
+            $count = $this->service->syncForCompany($connector);
+
+            expect($count)->toBe(0);
+            expect(ImportedFile::count())->toBe(0);
+        });
+
+        it('throws when invoice fetch fails', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response('Server Error', 500),
+            ]);
+
+            expect(fn () => $this->service->syncForCompany($connector))
+                ->toThrow(RuntimeException::class, 'Failed to fetch invoices from Zoho');
+        });
+
+        it('handles empty invoice list', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
+            ]);
+
+            $count = $this->service->syncForCompany($connector);
+
+            expect($count)->toBe(0);
+        });
     });
 
-    it('syncs multiple invoices', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+    describe('Deduplication by zoho_invoice_id', function () {
+        it('skips invoices already imported', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
 
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-content-001'),
-            '*/invoices/v3/invoices/INV-002*' => Http::response('%PDF-content-002'),
-            '*/invoices/v3/invoices/INV-003*' => Http::response('%PDF-content-003'),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [
-                    ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-2026-001'],
-                    ['invoice_id' => 'INV-002', 'invoice_number' => 'INV-2026-002'],
-                    ['invoice_id' => 'INV-003', 'invoice_number' => 'INV-2026-003'],
-                ],
-            ]),
-        ]);
+            ImportedFile::factory()->fromZoho('INV-001')->create([
+                'company_id' => $this->company->id,
+            ]);
 
-        $count = $this->service->syncForCompany($connector);
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [
+                        ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
+                    ],
+                ]),
+            ]);
 
-        expect($count)->toBe(3);
-        expect(ImportedFile::where('company_id', $this->company->id)->count())->toBe(3);
+            $count = $this->service->syncForCompany($connector);
+
+            expect($count)->toBe(0);
+            expect(ImportedFile::where('company_id', $this->company->id)->count())->toBe(1);
+        });
+
+        it('does not treat different company invoices as duplicates', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            $otherCompany = Company::factory()->create();
+            ImportedFile::factory()->fromZoho('INV-001')->create([
+                'company_id' => $otherCompany->id,
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
+                ]),
+            ]);
+
+            $count = $this->service->syncForCompany($connector);
+
+            expect($count)->toBe(1);
+        });
     });
 
-    it('stores PDF in private statements directory', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+    describe('Job dispatch', function () {
+        it('dispatches ProcessImportedFile for each new invoice', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
 
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
-            ]),
-        ]);
+            Http::fake([
+                '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-content-001'),
+                '*/invoices/v3/invoices/INV-002*' => Http::response('%PDF-content-002'),
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [
+                        ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
+                        ['invoice_id' => 'INV-002', 'invoice_number' => 'INV-002'],
+                    ],
+                ]),
+            ]);
 
-        $this->service->syncForCompany($connector);
+            $this->service->syncForCompany($connector);
 
-        $file = ImportedFile::first();
-        expect($file->file_path)->toStartWith('statements/')
-            ->and($file->file_path)->toEndWith('.pdf');
+            Queue::assertPushed(ProcessImportedFile::class, 2);
+        });
 
-        Storage::disk('local')->assertExists($file->file_path);
+        it('does not dispatch job for duplicate invoices', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+            ]);
+
+            ImportedFile::factory()->fromZoho('INV-001')->create([
+                'company_id' => $this->company->id,
+            ]);
+
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response([
+                    'invoices' => [
+                        ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
+                    ],
+                ]),
+            ]);
+
+            $this->service->syncForCompany($connector);
+
+            Queue::assertNotPushed(ProcessImportedFile::class);
+        });
     });
 
-    it('skips invoice when PDF download fails', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+    describe('last_synced_at update', function () {
+        it('updates last_synced_at on connector after sync', function () {
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+                'last_synced_at' => null,
+            ]);
 
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('', 500),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
-            ]),
-        ]);
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
+            ]);
 
-        $count = $this->service->syncForCompany($connector);
+            $this->freezeTime();
+            $this->service->syncForCompany($connector);
 
-        expect($count)->toBe(0);
-        expect(ImportedFile::count())->toBe(0);
-    });
+            $connector->refresh();
+            expect($connector->last_synced_at)->not->toBeNull()
+                ->and($connector->last_synced_at->toDateTimeString())->toBe(now()->toDateTimeString());
+        });
 
-    it('throws when invoice fetch fails', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
+        it('passes last_synced_at as query parameter to Zoho API', function () {
+            $lastSynced = now()->subHours(2);
+            $connector = Connector::factory()->zohoConnected()->create([
+                'company_id' => $this->company->id,
+                'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
+                'last_synced_at' => $lastSynced,
+            ]);
 
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response('Server Error', 500),
-        ]);
+            Http::fake([
+                '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
+            ]);
 
-        expect(fn () => $this->service->syncForCompany($connector))
-            ->toThrow(RuntimeException::class, 'Failed to fetch invoices from Zoho');
-    });
+            $this->service->syncForCompany($connector);
 
-    it('handles empty invoice list', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
-        ]);
-
-        $count = $this->service->syncForCompany($connector);
-
-        expect($count)->toBe(0);
-    });
-});
-
-describe('Deduplication by zoho_invoice_id', function () {
-    it('skips invoices already imported', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        ImportedFile::factory()->fromZoho('INV-001')->create([
-            'company_id' => $this->company->id,
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [
-                    ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
-                ],
-            ]),
-        ]);
-
-        $count = $this->service->syncForCompany($connector);
-
-        expect($count)->toBe(0);
-        expect(ImportedFile::where('company_id', $this->company->id)->count())->toBe(1);
-    });
-
-    it('does not treat different company invoices as duplicates', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        $otherCompany = Company::factory()->create();
-        ImportedFile::factory()->fromZoho('INV-001')->create([
-            'company_id' => $otherCompany->id,
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-fake-content'),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001']],
-            ]),
-        ]);
-
-        $count = $this->service->syncForCompany($connector);
-
-        expect($count)->toBe(1);
-    });
-});
-
-describe('Job dispatch', function () {
-    it('dispatches ProcessImportedFile for each new invoice', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices/INV-001*' => Http::response('%PDF-content-001'),
-            '*/invoices/v3/invoices/INV-002*' => Http::response('%PDF-content-002'),
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [
-                    ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
-                    ['invoice_id' => 'INV-002', 'invoice_number' => 'INV-002'],
-                ],
-            ]),
-        ]);
-
-        $this->service->syncForCompany($connector);
-
-        Queue::assertPushed(ProcessImportedFile::class, 2);
-    });
-
-    it('does not dispatch job for duplicate invoices', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-        ]);
-
-        ImportedFile::factory()->fromZoho('INV-001')->create([
-            'company_id' => $this->company->id,
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response([
-                'invoices' => [
-                    ['invoice_id' => 'INV-001', 'invoice_number' => 'INV-001'],
-                ],
-            ]),
-        ]);
-
-        $this->service->syncForCompany($connector);
-
-        Queue::assertNotPushed(ProcessImportedFile::class);
-    });
-});
-
-describe('last_synced_at update', function () {
-    it('updates last_synced_at on connector after sync', function () {
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-            'last_synced_at' => null,
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
-        ]);
-
-        $this->freezeTime();
-        $this->service->syncForCompany($connector);
-
-        $connector->refresh();
-        expect($connector->last_synced_at)->not->toBeNull()
-            ->and($connector->last_synced_at->toDateTimeString())->toBe(now()->toDateTimeString());
-    });
-
-    it('passes last_synced_at as query parameter to Zoho API', function () {
-        $lastSynced = now()->subHours(2);
-        $connector = Connector::factory()->zohoConnected()->create([
-            'company_id' => $this->company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '12345678'],
-            'last_synced_at' => $lastSynced,
-        ]);
-
-        Http::fake([
-            '*/invoices/v3/invoices*' => Http::response(['invoices' => []]),
-        ]);
-
-        $this->service->syncForCompany($connector);
-
-        Http::assertSent(function ($request) use ($lastSynced) {
-            return str_contains($request->url(), 'invoices/v3/invoices')
-                && str_contains($request->url(), 'last_modified_time=')
-                && str_contains($request->url(), urlencode($lastSynced->format('Y-m-d')));
+            Http::assertSent(function ($request) use ($lastSynced) {
+                return str_contains($request->url(), 'invoices/v3/invoices')
+                    && str_contains($request->url(), 'last_modified_time=')
+                    && str_contains($request->url(), urlencode($lastSynced->format('Y-m-d')));
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

- Moves `beforeEach()` inside the appropriate `describe()` block in 4 test files where it was incorrectly defined at the top level
- For files with multiple sibling `describe` blocks, introduces a single outer `describe('ServiceName', ...)` wrapper that contains both the `beforeEach` and the inner describes
- For `ReportingServiceTest` (which already had an outer describe), simply moves `beforeEach` inside it

## Files changed

| File | Fix applied |
|------|-------------|
| `PdfDecryptionServiceTest.php` | New outer `describe('PdfDecryptionService')` wrapping 3 sibling describes |
| `ReportingServiceTest.php` | `beforeEach` moved inside existing outer `describe('ReportingService')` |
| `TallyMasterImportServiceTest.php` | New outer `describe('TallyMasterImportService')` wrapping 6 sibling describes |
| `ZohoInvoiceServiceTest.php` | New outer `describe('ZohoInvoiceService')` wrapping 5 sibling describes |

## Test plan

- [x] All 74 existing tests pass before refactor
- [x] All 74 existing tests pass after refactor (same count, same assertions)
- [x] Pint: Pass
- [x] PHPStan: Pass

## Related issues created during review

- zyni-ai/virtual-cfo#240 — repeated Zoho settings array in ZohoInvoiceServiceTest (pre-existing, out of scope)
- zyni-ai/virtual-cfo#241 — split `monthlyTotalsByHead` describe block in ReportingServiceTest (pre-existing, out of scope)

Closes #236