### PR TITLE
fix(imported-files): remove sales_invoice enum, route Tally format by raw_data within invoice type

### DIFF
--- a/app/Enums/StatementType.php
+++ b/app/Enums/StatementType.php
@@ -9,7 +9,6 @@ enum StatementType: string implements HasLabel
     case Bank = 'bank';
     case CreditCard = 'credit_card';
     case Invoice = 'invoice';
-    case SalesInvoice = 'sales_invoice';
 
     public function getLabel(): string
     {
@@ -17,7 +16,6 @@ enum StatementType: string implements HasLabel
             self::Bank => 'Bank Statement',
             self::CreditCard => 'Credit Card Statement',
             self::Invoice => 'Invoice',
-            self::SalesInvoice => 'Sales Invoice',
         };
     }
 }

--- a/app/Services/DocumentProcessor/DocumentProcessor.php
+++ b/app/Services/DocumentProcessor/DocumentProcessor.php
@@ -257,7 +257,6 @@ class DocumentProcessor
             match ($statementType) {
                 StatementType::Bank, StatementType::CreditCard => $this->parsePdfStatement($file, $filePath),
                 StatementType::Invoice => $this->parsePdfInvoice($file, $filePath),
-                StatementType::SalesInvoice => throw new \LogicException('SalesInvoice files are not parsed via PDF processing.'),
             };
         } finally {
             if ($decryptedPath !== null) {

--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -71,7 +71,7 @@ class TallyExportService
         $xml .= '  <BODY>'."\n";
         $xml .= '    <IMPORTDATA>'."\n";
         $xml .= '      <REQUESTDESC>'."\n";
-        $reportName = $importedFile?->statement_type === StatementType::SalesInvoice ? 'Vouchers' : 'All Masters';
+        $reportName = $this->isSalesInvoiceExport($transactions, $importedFile) ? 'Vouchers' : 'All Masters';
         $xml .= '        <REPORTNAME>'.$reportName.'</REPORTNAME>'."\n";
         $xml .= '        <STATICVARIABLES>'."\n";
         $xml .= '          <SVCURRENTCOMPANY>'.$this->escapeXml($companyName).'</SVCURRENTCOMPANY>'."\n";
@@ -100,11 +100,14 @@ class TallyExportService
      */
     private function generateVoucher(Transaction $transaction, ?Company $company, ?string $bankLedgerName, ?ImportedFile $importedFile = null): string
     {
-        if ($importedFile?->statement_type === StatementType::SalesInvoice) {
-            return $this->generateSalesVoucher($transaction, $company);
-        }
-
         if ($importedFile?->statement_type === StatementType::Invoice) {
+            /** @var array<string, mixed> $raw */
+            $raw = $transaction->raw_data ?? [];
+
+            if (isset($raw['buyer_name'])) {
+                return $this->generateSalesVoucher($transaction, $company);
+            }
+
             return $this->generateInvoiceJournalVoucher($transaction, $company);
         }
 
@@ -532,6 +535,28 @@ class TallyExportService
         $xml .= '        </TALLYMESSAGE>'."\n";
 
         return $xml;
+    }
+
+    /**
+     * Determine whether the export should use the Sales voucher format.
+     * Invoice files whose first transaction carries a 'buyer_name' in raw_data
+     * are outward (sales) invoices; all others use the Journal format.
+     *
+     * @param  Collection<int, Transaction>  $transactions
+     */
+    private function isSalesInvoiceExport(Collection $transactions, ?ImportedFile $importedFile): bool
+    {
+        if ($importedFile?->statement_type !== StatementType::Invoice) {
+            return false;
+        }
+
+        /** @var Transaction|null $first */
+        $first = $transactions->first();
+
+        /** @var array<string, mixed> $raw */
+        $raw = $first?->raw_data ?? [];
+
+        return isset($raw['buyer_name']);
     }
 
     /**

--- a/database/migrations/2026_04_15_060900_migrate_sales_invoice_to_invoice_in_imported_files.php
+++ b/database/migrations/2026_04_15_060900_migrate_sales_invoice_to_invoice_in_imported_files.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Migrate stale 'sales_invoice' rows to 'invoice'.
+     *
+     * sales_invoice was removed as a separate StatementType enum case.
+     * Sales invoices are now distinguished from purchase invoices by the
+     * presence of 'buyer_name' in the transaction raw_data at export time.
+     */
+    public function up(): void
+    {
+        DB::table('imported_files')
+            ->where('statement_type', 'sales_invoice')
+            ->update(['statement_type' => 'invoice']);
+    }
+};

--- a/tests/Feature/Services/TallyExportSalesVoucherTest.php
+++ b/tests/Feature/Services/TallyExportSalesVoucherTest.php
@@ -13,7 +13,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('exports sales invoice as Sales voucher not Journal', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -52,7 +52,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('uses REPORTNAME Vouchers for sales invoice export', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -82,7 +82,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('generates intrastate 4-leg voucher: party debit, sales credit, CGST credit, SGST credit', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create([
@@ -128,7 +128,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('generates interstate 3-leg voucher: party debit, sales credit, IGST credit', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create([
@@ -168,7 +168,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('sets party ledger amount to exact mathematical sum with no rounding entry', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -199,7 +199,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('includes GSTHSNNAME, GSTOVRDNTAXABILITY and GSTOVRDNTYPEOFSUPPLY in sales ledger entry', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create([
@@ -234,7 +234,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('includes RATEOFINVOICETAX in each tax ledger entry', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -264,7 +264,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('populates ADDRESS.LIST from buyer_address', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -296,7 +296,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('includes buyer GSTIN as PARTYGSTIN', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -325,7 +325,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('uses invoice_date from raw_data not the transaction date', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -355,7 +355,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('falls back to transaction date when invoice_date is absent', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -383,7 +383,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('includes ISINVOICE Yes in sales voucher', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
@@ -443,7 +443,7 @@ describe('TallyExportService sales voucher', function () {
 
     it('includes PLACEOFSUPPLY and STATENAME from raw_data', function () {
         $file = ImportedFile::factory()->create([
-            'statement_type' => StatementType::SalesInvoice,
+            'statement_type' => StatementType::Invoice,
             'company_id' => tenant()->id,
         ]);
         $head = AccountHead::factory()->create(['company_id' => tenant()->id]);


### PR DESCRIPTION
## Summary

- Removes `StatementType::SalesInvoice` — the `invoice` type now covers both outward (sales) and inward (purchase) invoices
- `TallyExportService` detects outward invoices by checking for `buyer_name` in `transaction.raw_data` within the `Invoice` branch — routes to `generateSalesVoucher`; otherwise uses `generateInvoiceJournalVoucher`
- Data migration updates the 2 stale `sales_invoice` rows in `imported_files` to `invoice`, fixing the `ValueError` crash on the infolist page
- Removes the now-redundant `LogicException` arm in `DocumentProcessor`

## Test plan

- [x] All 13 existing sales voucher tests updated to use `StatementType::Invoice` — all green
- [x] PHPStan level 6 — no errors on changed files
- [x] Pint — no formatting issues
- [x] Migration verified on local DB: 2 stale rows now read as `invoice`
- [x] Previously-crashing imported file (id 2) now hydrates without `ValueError`

Closes #243