### PR TITLE
feat(tally-export): include line item descriptions in voucher narration

### DIFF
--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -191,6 +191,12 @@ class TallyExportService
             ? "Invoice No: {$invoiceNumber} payment towards {$vendorName}"
             : "Invoice payment towards {$vendorName}";
 
+        $lineItemNarration = $this->buildLineItemNarration($raw);
+
+        if ($lineItemNarration !== null) {
+            $narration .= "\n{$lineItemNarration}";
+        }
+
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
         $xml .= '          <VOUCHER VCHTYPE="Journal" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
         $xml .= '            <DATE>'.$date.'</DATE>'."\n";
@@ -268,7 +274,8 @@ class TallyExportService
         $placeOfSupply = (string) ($raw['place_of_supply'] ?? '');
         $serviceName = (string) ($raw['service_name'] ?? ($accountHead?->name ?? 'Unknown'));
         $hsnSac = (string) ($raw['hsn_sac'] ?? '');
-        $narration = (string) ($raw['description'] ?? $transaction->description ?? '');
+        $narration = $this->buildLineItemNarration($raw)
+            ?? (string) ($raw['description'] ?? $transaction->description ?? '');
         $baseAmount = (float) ($raw['base_amount'] ?? 0);
         $cgstRate = $raw['cgst_rate'] ?? null;
         $cgstAmount = (float) ($raw['cgst_amount'] ?? 0);
@@ -569,6 +576,20 @@ class TallyExportService
         }
 
         return ++$this->voucherCounters[$voucherType];
+    }
+
+    /** @param array<string, mixed> $raw */
+    private function buildLineItemNarration(array $raw): ?string
+    {
+        $lineItems = is_array($raw['line_items'] ?? null) ? $raw['line_items'] : [];
+
+        if (empty($lineItems)) {
+            return null;
+        }
+
+        $descriptions = array_filter(array_column($lineItems, 'description'));
+
+        return empty($descriptions) ? null : implode("\n", $descriptions);
     }
 
     private function escapeXml(string $value): string

--- a/tests/Feature/Services/TallyExportInvoiceTest.php
+++ b/tests/Feature/Services/TallyExportInvoiceTest.php
@@ -141,6 +141,69 @@ describe('TallyExportService invoice Journal voucher', function () {
             ->not->toContain('Input Sgst');
     });
 
+    it('appends line item descriptions to narration in journal voucher', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'invoice_number' => 'INV/001',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+                'line_items' => [
+                    ['description' => 'Manpower Supply - March 2025', 'amount' => 27500.00],
+                ],
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<NARRATION>Invoice No: INV/001 payment towards Test Vendor Pvt Ltd'."\n".'Manpower Supply - March 2025</NARRATION>');
+    });
+
+    it('falls back gracefully when line_items absent in journal voucher', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'debit' => '31900',
+            'date' => '2025-04-01',
+            'raw_data' => [
+                'vendor_name' => 'Test Vendor Pvt Ltd',
+                'invoice_number' => 'INV/002',
+                'base_amount' => 27500.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 2475.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 2475.00,
+                'igst_amount' => null,
+                'tds_amount' => 0,
+                'total_amount' => 31900.00,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<NARRATION>Invoice No: INV/002 payment towards Test Vendor Pvt Ltd</NARRATION>');
+    });
+
     it('includes vendor party ledger as credit leg', function () {
         $file = ImportedFile::factory()->create([
             'statement_type' => StatementType::Invoice,

--- a/tests/Feature/Services/TallyExportSalesVoucherTest.php
+++ b/tests/Feature/Services/TallyExportSalesVoucherTest.php
@@ -441,6 +441,98 @@ describe('TallyExportService sales voucher', function () {
             ->not->toContain('VCHTYPE="Sales"');
     });
 
+    it('includes line item description in narration when line_items present', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'VYGNIK BEHAVIORAL SERVICES PRIVATE LIMITED',
+                'service_name' => 'Website Maintenance',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+                'line_items' => [
+                    ['description' => 'Website Maintenance - AWS, Vercel, Digital Ocean & AWS Lambda', 'amount' => 3258.00],
+                ],
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<NARRATION>Website Maintenance - AWS, Vercel, Digital Ocean &amp; AWS Lambda</NARRATION>');
+    });
+
+    it('joins multiple line item descriptions with newlines in narration', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '5000.00',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'base_amount' => 5000.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 450.00,
+                'sgst_rate' => 9,
+                'sgst_amount' => 450.00,
+                'total_amount' => 5900.00,
+                'line_items' => [
+                    ['description' => 'Website Maintenance - AWS, Vercel', 'amount' => 3000.00],
+                    ['description' => 'Domain Renewal - example.com', 'amount' => 2000.00],
+                ],
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain("Website Maintenance - AWS, Vercel\nDomain Renewal - example.com");
+    });
+
+    it('falls back to description field when line_items absent in sales voucher', function () {
+        $file = ImportedFile::factory()->create([
+            'statement_type' => StatementType::Invoice,
+            'company_id' => tenant()->id,
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => tenant()->id]);
+        Transaction::factory()->mapped($head)->create([
+            'imported_file_id' => $file->id,
+            'company_id' => tenant()->id,
+            'credit' => '3844.44',
+            'date' => '2026-04-01',
+            'raw_data' => [
+                'buyer_name' => 'Test Client',
+                'service_name' => 'IT Services',
+                'description' => 'Fallback description',
+                'base_amount' => 3258.00,
+                'cgst_rate' => 9,
+                'cgst_amount' => 293.22,
+                'sgst_rate' => 9,
+                'sgst_amount' => 293.22,
+                'total_amount' => 3844.44,
+            ],
+        ]);
+
+        $xml = app(TallyExportService::class)->exportForFile($file);
+
+        expect($xml)->toContain('<NARRATION>Fallback description</NARRATION>');
+    });
+
     it('includes PLACEOFSUPPLY and STATENAME from raw_data', function () {
         $file = ImportedFile::factory()->create([
             'statement_type' => StatementType::Invoice,


### PR DESCRIPTION
## Summary

- Added `buildLineItemNarration()` helper that joins `raw_data['line_items'][*]['description']` with newlines
- Sales vouchers now use line item descriptions as `<NARRATION>` (falls back to `raw_data['description']` or `transaction->description` when absent)
- Journal vouchers append line item descriptions to the existing invoice reference narration (e.g. `Invoice No: ZY26-0002 payment towards Zysk\nWebsite Maintenance - AWS, Vercel, Digital Ocean & AWS Lambda`)

## Test plan

- [ ] Verify `<NARRATION>` in a sales XML voucher includes the line item descriptions
- [ ] Verify `<NARRATION>` in a journal XML voucher includes invoice reference + line item descriptions
- [ ] Verify fallback when `line_items` is absent (both voucher types)
- [ ] Run `php artisan test --filter="TallyExportInvoiceTest|TallyExportSalesVoucherTest"` — all 25 tests pass

Closes #245