### PR TITLE
refactor(test): consolidate split monthlyTotalsByHead describe block

### DIFF
--- a/tests/Feature/Services/ReportingServiceTest.php
+++ b/tests/Feature/Services/ReportingServiceTest.php
@@ -237,6 +237,25 @@ describe('ReportingService', function () {
 
             expect($result['heads'])->toBeEmpty();
         });
+
+        it('uses the account head name even when the head is soft-deleted', function () {
+            $company = tenant();
+            $head = AccountHead::factory()->create(['company_id' => $company->id, 'name' => 'Deleted Head']);
+
+            TransactionAggregate::factory()->create([
+                'company_id' => $company->id,
+                'account_head_id' => $head->id,
+                'year_month' => '2025-04',
+                'total_debit' => 10000,
+            ]);
+
+            $head->delete();
+
+            $result = $this->service->monthlyTotalsByHead();
+
+            expect($result['heads'])->toHaveCount(1)
+                ->and($result['heads'][0]['name'])->toBe('Deleted Head');
+        });
     });
 
     describe('periodComparison', function () {
@@ -428,24 +447,4 @@ describe('ReportingService', function () {
         });
     });
 
-    describe('monthlyTotalsByHead', function () {
-        it('uses the account head name even when the head is soft-deleted', function () {
-            $company = tenant();
-            $head = AccountHead::factory()->create(['company_id' => $company->id, 'name' => 'Deleted Head']);
-
-            TransactionAggregate::factory()->create([
-                'company_id' => $company->id,
-                'account_head_id' => $head->id,
-                'year_month' => '2025-04',
-                'total_debit' => 10000,
-            ]);
-
-            $head->delete();
-
-            $result = $this->service->monthlyTotalsByHead();
-
-            expect($result['heads'])->toHaveCount(1)
-                ->and($result['heads'][0]['name'])->toBe('Deleted Head');
-        });
-    });
 });


### PR DESCRIPTION
## Summary

- The `describe('monthlyTotalsByHead')` block in `ReportingServiceTest` was split across two locations: the core tests near the top and a single soft-delete test near the bottom
- Moved the soft-delete `it()` block into the first `describe` so all four tests for that method are co-located
- Removed the now-empty second `describe` wrapper

## Test plan

- [ ] All 26 existing tests pass (`php artisan test --filter=ReportingServiceTest --compact`)
- [ ] No tests added or removed — same assertions, different structural position
- [ ] Pint and PHPStan both pass

Closes #241