### PR TITLE
refactor(test): extract repeated Zoho settings into withOrganization factory state

### DIFF
--- a/database/factories/ConnectorFactory.php
+++ b/database/factories/ConnectorFactory.php
@@ -52,6 +52,13 @@ class ConnectorFactory extends Factory
         ]);
     }
 
+    public function withOrganization(string $organizationId): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'settings' => array_merge($attributes['settings'], ['organization_id' => $organizationId]),
+        ]);
+    }
+
     public function expired(): static
     {
         return $this->state(fn (array $attributes) => [

--- a/tests/Feature/Commands/SyncZohoInvoicesTest.php
+++ b/tests/Feature/Commands/SyncZohoInvoicesTest.php
@@ -21,14 +21,8 @@ describe('SyncZohoInvoices command', function () {
         $company1 = Company::factory()->create();
         $company2 = Company::factory()->create();
 
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company1->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
-        ]);
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company2->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
-        ]);
+        Connector::factory()->zohoConnected()->withOrganization('111')->create(['company_id' => $company1->id]);
+        Connector::factory()->zohoConnected()->withOrganization('222')->create(['company_id' => $company2->id]);
 
         $this->artisan('connectors:sync-zoho')
             ->assertSuccessful()
@@ -38,10 +32,7 @@ describe('SyncZohoInvoices command', function () {
     it('skips inactive connectors', function () {
         $company = Company::factory()->create();
 
-        Connector::factory()->zohoConnected()->inactive()->create([
-            'company_id' => $company->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
-        ]);
+        Connector::factory()->zohoConnected()->inactive()->create(['company_id' => $company->id]);
 
         $this->artisan('connectors:sync-zoho')
             ->assertSuccessful()
@@ -52,14 +43,8 @@ describe('SyncZohoInvoices command', function () {
         $company1 = Company::factory()->create();
         $company2 = Company::factory()->create();
 
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company1->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
-        ]);
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company2->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
-        ]);
+        Connector::factory()->zohoConnected()->withOrganization('111')->create(['company_id' => $company1->id]);
+        Connector::factory()->zohoConnected()->withOrganization('222')->create(['company_id' => $company2->id]);
 
         $this->artisan("connectors:sync-zoho --company={$company1->id}")
             ->assertSuccessful()
@@ -70,14 +55,8 @@ describe('SyncZohoInvoices command', function () {
         $company1 = Company::factory()->create();
         $company2 = Company::factory()->create();
 
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company1->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '111'],
-        ]);
-        Connector::factory()->zohoConnected()->create([
-            'company_id' => $company2->id,
-            'settings' => ['data_center' => 'in', 'client_id' => 'test-client', 'client_secret' => 'test-secret', 'organization_id' => '222'],
-        ]);
+        Connector::factory()->zohoConnected()->withOrganization('111')->create(['company_id' => $company1->id]);
+        Connector::factory()->zohoConnected()->withOrganization('222')->create(['company_id' => $company2->id]);
 
         $this->partialMock(ZohoInvoiceService::class, function ($mock) {
             $mock->shouldReceive('syncForCompany')


### PR DESCRIPTION
## Summary
- Add `withOrganization(string $organizationId)` state to `ConnectorFactory` that merges only `organization_id` into existing settings — no more repeating all 4 keys inline
- Update 4 test cases in `SyncZohoInvoicesTest` to use the new state
- `skips inactive connectors` drops its settings override entirely (org ID is irrelevant when the connector is inactive)

## Test plan
- [ ] All 6 existing `SyncZohoInvoicesTest` tests pass (14 assertions)
- [ ] Pint, PHPStan, and full test suite pass

Closes #247