### PR TITLE
fix(tenancy): redirect to last used company on login

### DIFF
--- a/app/Http/Middleware/SetTenantDatabaseContext.php
+++ b/app/Http/Middleware/SetTenantDatabaseContext.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\User;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
@@ -21,6 +22,7 @@ class SetTenantDatabaseContext
 
         if ($tenant) {
             DB::statement("SET app.current_company_id = '{$tenant->getKey()}'");
+            $this->recordLastUsedCompany($request, $tenant->getKey());
         }
 
         return $next($request);
@@ -32,5 +34,20 @@ class SetTenantDatabaseContext
     public function terminate(Request $request, Response $response): void
     {
         DB::statement("SET app.current_company_id = ''");
+    }
+
+    private function recordLastUsedCompany(Request $request, int|string $companyId): void
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return;
+        }
+
+        if ((int) $user->last_used_company_id === (int) $companyId) {
+            return;
+        }
+
+        $user->updateQuietly(['last_used_company_id' => $companyId]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,7 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
         'role',
         'toured_pages',
         'dismissed_suggestions',
+        'last_used_company_id',
     ];
 
     protected $hidden = [
@@ -76,7 +77,17 @@ class User extends Authenticatable implements FilamentUser, HasAppAuthentication
 
     public function getDefaultTenant(Panel $panel): ?Model
     {
-        return $this->companies->first();
+        $companies = $this->companies;
+
+        if ($this->last_used_company_id) {
+            $lastUsed = $companies->firstWhere('id', $this->last_used_company_id);
+
+            if ($lastUsed) {
+                return $lastUsed;
+            }
+        }
+
+        return $companies->first();
     }
 
     /** @var array<int, UserRole|null> */

--- a/database/migrations/2026_04_16_102718_add_last_used_company_id_to_users_table.php
+++ b/database/migrations/2026_04_16_102718_add_last_used_company_id_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('last_used_company_id')
+                ->nullable()
+                ->constrained('companies')
+                ->nullOnDelete()
+                ->after('dismissed_suggestions');
+
+            $table->index('last_used_company_id');
+        });
+    }
+};

--- a/tests/Feature/Filament/CompanyTenancyTest.php
+++ b/tests/Feature/Filament/CompanyTenancyTest.php
@@ -3,6 +3,7 @@
 use App\Enums\UserRole;
 use App\Filament\Pages\Tenancy\EditCompanySettings;
 use App\Filament\Pages\Tenancy\RegisterCompany;
+use App\Http\Middleware\SetTenantDatabaseContext;
 use App\Models\AccountHead;
 use App\Models\Company;
 use App\Models\ImportedFile;
@@ -10,6 +11,7 @@ use App\Models\Transaction;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
+use Illuminate\Http\Request;
 
 use function Pest\Livewire\livewire;
 
@@ -40,12 +42,44 @@ describe('User tenancy contracts', function () {
         expect($user->canAccessTenant($company))->toBeFalse();
     });
 
-    it('returns first company as default tenant', function () {
+    it('returns first company as default tenant when no last_used_company_id is set', function () {
         $user = User::factory()->admin()->create();
         $company1 = Company::factory()->create();
         $company2 = Company::factory()->create();
         $company1->users()->attach($user);
         $company2->users()->attach($user);
+
+        $default = $user->getDefaultTenant(Filament::getPanel('admin'));
+
+        expect($default)->not->toBeNull()
+            ->and($default->id)->toBe($company1->id);
+    });
+
+    it('returns last used company as default tenant when last_used_company_id is set', function () {
+        $user = User::factory()->admin()->create();
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+        $company1->users()->attach($user);
+        $company2->users()->attach($user);
+
+        $user->update(['last_used_company_id' => $company2->id]);
+        $user->refresh();
+
+        $default = $user->getDefaultTenant(Filament::getPanel('admin'));
+
+        expect($default)->not->toBeNull()
+            ->and($default->id)->toBe($company2->id);
+    });
+
+    it('falls back to first company if last_used_company_id points to a company the user no longer belongs to', function () {
+        $user = User::factory()->admin()->create();
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+        $company1->users()->attach($user);
+
+        // company2 is set as last used but user is not a member
+        $user->update(['last_used_company_id' => $company2->id]);
+        $user->refresh();
 
         $default = $user->getDefaultTenant(Filament::getPanel('admin'));
 
@@ -251,5 +285,69 @@ describe('Edit Company Settings page', function () {
 
         tenant()->refresh();
         expect(tenant()->state)->toBe('California');
+    });
+});
+
+describe('SetTenantDatabaseContext middleware updates last_used_company_id', function () {
+    beforeEach(function () {
+        $this->user = User::factory()->admin()->create();
+        $this->actingAs($this->user);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+        Filament::bootCurrentPanel();
+    });
+
+    it('stores the current tenant id on the user when a tenant is active', function () {
+        $company = Company::factory()->create();
+        $company->users()->attach($this->user, ['role' => 'admin']);
+
+        expect($this->user->last_used_company_id)->toBeNull();
+
+        Filament::setTenant($company);
+
+        $request = Request::create('/admin/'.$company->id);
+        $request->setUserResolver(fn () => $this->user);
+
+        (new SetTenantDatabaseContext)->handle($request, fn ($r) => response('ok'));
+
+        $this->user->refresh();
+        expect($this->user->last_used_company_id)->toBe($company->id);
+    });
+
+    it('updates last_used_company_id when switching to a different company', function () {
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+        $company1->users()->attach($this->user, ['role' => 'admin']);
+        $company2->users()->attach($this->user, ['role' => 'admin']);
+
+        $this->user->update(['last_used_company_id' => $company1->id]);
+
+        Filament::setTenant($company2);
+
+        $request = Request::create('/admin/'.$company2->id);
+        $request->setUserResolver(fn () => $this->user);
+
+        (new SetTenantDatabaseContext)->handle($request, fn ($r) => response('ok'));
+
+        $this->user->refresh();
+        expect($this->user->last_used_company_id)->toBe($company2->id);
+    });
+
+    it('does not update last_used_company_id if company has not changed', function () {
+        $company = Company::factory()->create();
+        $company->users()->attach($this->user, ['role' => 'admin']);
+        $this->user->update(['last_used_company_id' => $company->id]);
+        $this->user->refresh();
+        $originalUpdatedAt = $this->user->updated_at;
+
+        Filament::setTenant($company);
+
+        $request = Request::create('/admin/'.$company->id);
+        $request->setUserResolver(fn () => $this->user);
+
+        (new SetTenantDatabaseContext)->handle($request, fn ($r) => response('ok'));
+
+        $this->user->refresh();
+        expect($this->user->last_used_company_id)->toBe($company->id)
+            ->and($this->user->updated_at->eq($originalUpdatedAt))->toBeTrue();
     });
 });


### PR DESCRIPTION
## Summary

- Adds `last_used_company_id` to the `users` table to track which company a user last accessed
- `SetTenantDatabaseContext` middleware writes this field on every tenant switch (skips if unchanged)
- `User::getDefaultTenant()` now returns the last-used company on login, falling back to the first company if the field is unset or the user no longer belongs to that company

## Test plan

- [ ] Log in as a user with multiple companies — confirm you land on the last-accessed company, not always the first
- [ ] Switch to a different company, log out, log back in — confirm you land on the company you switched to
- [ ] All 29 Pest tests in `CompanyTenancyTest` pass
- [ ] PHPStan level 6 passes
- [ ] Pint passes

Closes #251