### PR TITLE
fix(widgets): add RLS to transaction_aggregates and scope dashboard charts to tenant

### DIFF
--- a/app/Filament/Widgets/MappingStatusChart.php
+++ b/app/Filament/Widgets/MappingStatusChart.php
@@ -21,6 +21,10 @@ class MappingStatusChart extends ChartWidget
             ->groupBy('mapping_type')
             ->pluck('total', 'mapping_type');
 
+        if ($counts->isEmpty()) {
+            return ['datasets' => [], 'labels' => []];
+        }
+
         $labels = [];
         $data = [];
         $colors = [];

--- a/app/Filament/Widgets/MonthlyDebitCreditChart.php
+++ b/app/Filament/Widgets/MonthlyDebitCreditChart.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Models\TransactionAggregate;
+use Filament\Facades\Filament;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -23,6 +24,7 @@ class MonthlyDebitCreditChart extends ChartWidget
 
         /** @var Collection<int, TransactionAggregate> $aggregates */
         $aggregates = TransactionAggregate::query()
+            ->where('company_id', Filament::getTenant()->getKey())
             ->where('year_month', '>=', $startMonth)
             ->select('year_month')
             ->addSelect(DB::raw('SUM(total_debit) as sum_debit'))

--- a/app/Filament/Widgets/TopAccountHeadsChart.php
+++ b/app/Filament/Widgets/TopAccountHeadsChart.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets;
 
 use App\Models\AccountHead;
 use App\Models\TransactionAggregate;
+use Filament\Facades\Filament;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -20,6 +21,7 @@ class TopAccountHeadsChart extends ChartWidget
     {
         /** @var Collection<int, TransactionAggregate> $aggregates */
         $aggregates = TransactionAggregate::query()
+            ->where('company_id', Filament::getTenant()->getKey())
             ->whereNotNull('account_head_id')
             ->select('account_head_id')
             ->addSelect(DB::raw('SUM(total_debit + total_credit) as total_amount'))
@@ -27,6 +29,10 @@ class TopAccountHeadsChart extends ChartWidget
             ->orderByDesc('total_amount')
             ->limit(10)
             ->get();
+
+        if ($aggregates->isEmpty()) {
+            return ['datasets' => [], 'labels' => []];
+        }
 
         $headNames = AccountHead::query()
             ->whereIn('id', $aggregates->pluck('account_head_id'))

--- a/database/migrations/2026_04_16_114005_enable_row_level_security_on_transaction_aggregates.php
+++ b/database/migrations/2026_04_16_114005_enable_row_level_security_on_transaction_aggregates.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE transaction_aggregates ENABLE ROW LEVEL SECURITY');
+        DB::statement('ALTER TABLE transaction_aggregates FORCE ROW LEVEL SECURITY');
+
+        DB::statement("
+            CREATE POLICY tenant_isolation_transaction_aggregates ON transaction_aggregates
+                USING (
+                    CASE
+                        WHEN current_setting('app.current_company_id', true) IS NULL
+                             OR current_setting('app.current_company_id', true) = ''
+                        THEN true
+                        ELSE company_id = current_setting('app.current_company_id', true)::bigint
+                    END
+                )
+                WITH CHECK (
+                    CASE
+                        WHEN current_setting('app.current_company_id', true) IS NULL
+                             OR current_setting('app.current_company_id', true) = ''
+                        THEN true
+                        ELSE company_id = current_setting('app.current_company_id', true)::bigint
+                    END
+                )
+        ");
+    }
+};

--- a/tests/Feature/Filament/ChartWidgetTest.php
+++ b/tests/Feature/Filament/ChartWidgetTest.php
@@ -4,7 +4,9 @@ use App\Filament\Widgets\MappingStatusChart;
 use App\Filament\Widgets\MonthlyDebitCreditChart;
 use App\Filament\Widgets\TopAccountHeadsChart;
 use App\Models\AccountHead;
+use App\Models\Company;
 use App\Models\Transaction;
+use App\Models\TransactionAggregate;
 
 use function Pest\Livewire\livewire;
 
@@ -61,6 +63,13 @@ describe('MappingStatusChart widget', function () {
             ->and($map['Manual'])->toBe(3)
             ->and($map['AI Matched'])->toBe(4);
     });
+
+    it('returns empty datasets and labels when company has no transactions', function () {
+        $data = getChartData(MappingStatusChart::class);
+
+        expect($data['datasets'])->toBeEmpty()
+            ->and($data['labels'])->toBeEmpty();
+    });
 });
 
 describe('TopAccountHeadsChart widget', function () {
@@ -112,6 +121,30 @@ describe('TopAccountHeadsChart widget', function () {
         expect($data['labels'])->toHaveCount(1)
             ->and($data['datasets'][0]['data'])->toHaveCount(1)
             ->and($data['datasets'][0]['data'][0])->toBe(500.0);
+    });
+
+    it('returns empty datasets and labels when company has no aggregates', function () {
+        $data = getChartData(TopAccountHeadsChart::class);
+
+        expect($data['datasets'])->toBeEmpty()
+            ->and($data['labels'])->toBeEmpty();
+    });
+
+    it('does not show data from other companies', function () {
+        $otherCompany = Company::factory()->create();
+        $head = AccountHead::factory()->create(['company_id' => $otherCompany->id]);
+
+        TransactionAggregate::factory()->create([
+            'company_id' => $otherCompany->id,
+            'account_head_id' => $head->id,
+            'total_debit' => 5000,
+            'total_credit' => 5000,
+        ]);
+
+        $data = getChartData(TopAccountHeadsChart::class);
+
+        expect($data['datasets'])->toBeEmpty()
+            ->and($data['labels'])->toBeEmpty();
     });
 });
 
@@ -194,5 +227,24 @@ describe('MonthlyDebitCreditChart widget', function () {
         // 2 months ago
         $idx = count($creditDataset['data']) - 3;
         expect($creditDataset['data'][$idx])->toBe(5000.0);
+    });
+
+    it('does not show data from other companies', function () {
+        $otherCompany = Company::factory()->create();
+
+        TransactionAggregate::factory()->create([
+            'company_id' => $otherCompany->id,
+            'year_month' => now()->format('Y-m'),
+            'total_debit' => 9999,
+            'total_credit' => 9999,
+        ]);
+
+        $data = getChartData(MonthlyDebitCreditChart::class);
+
+        $debitDataset = collect($data['datasets'])->firstWhere('label', 'Debits');
+        $creditDataset = collect($data['datasets'])->firstWhere('label', 'Credits');
+
+        expect(array_sum($debitDataset['data']))->toEqual(0)
+            ->and(array_sum($creditDataset['data']))->toEqual(0);
     });
 });


### PR DESCRIPTION
## Summary

- Enable RLS on `transaction_aggregates` — the only aggregate table missing from the tenant isolation policy, allowing cross-company data leakage
- Scope `TopAccountHeadsChart` and `MonthlyDebitCreditChart` queries to the current tenant with `company_id` filter, matching the existing `ExpenseBySourceWidget` pattern
- Add empty-state early return to all three widgets so new companies see empty charts instead of 'Unknown'-labelled bars

## Test plan

- [ ] New company shows empty charts on dashboard (no 'Unknown' labels)
- [ ] Existing company data is unaffected
- [ ] 16 ChartWidget tests pass: `php artisan test --filter=ChartWidgetTest --compact`
- [ ] Pint: Pass | PHPStan: Pass

Closes #252