### PR TITLE
fix(tally-export): export bank/CC transactions as Journal vouchers

### DIFF
--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -71,7 +71,7 @@ class TallyExportService
         $xml .= '  <BODY>'."\n";
         $xml .= '    <IMPORTDATA>'."\n";
         $xml .= '      <REQUESTDESC>'."\n";
-        $reportName = $this->isSalesInvoiceExport($transactions, $importedFile) ? 'Vouchers' : 'All Masters';
+        $reportName = $this->isAllMastersExport($transactions, $importedFile) ? 'All Masters' : 'Vouchers';
         $xml .= '        <REPORTNAME>'.$reportName.'</REPORTNAME>'."\n";
         $xml .= '        <STATICVARIABLES>'."\n";
         $xml .= '          <SVCURRENTCOMPANY>'.$this->escapeXml($companyName).'</SVCURRENTCOMPANY>'."\n";
@@ -111,9 +111,8 @@ class TallyExportService
             return $this->generateInvoiceJournalVoucher($transaction, $company);
         }
 
-        $isPayment = $transaction->debit !== null;
-        $voucherType = $isPayment ? 'Payment' : 'Receipt';
-        $amount = (float) ($isPayment ? $transaction->debit : $transaction->credit);
+        $isDebit = $transaction->debit !== null;
+        $amount = (float) ($isDebit ? $transaction->debit : $transaction->credit);
         /** @var Carbon $transactionDate */
         $transactionDate = $transaction->date;
         $date = $transactionDate->format('Ymd');
@@ -121,16 +120,15 @@ class TallyExportService
         $accountHead = $transaction->accountHead;
         $headName = $accountHead?->name ?? 'Unknown';
         $bankName = $bankLedgerName ?? 'Bank Account';
-        $voucherNumber = $this->nextVoucherNumber($voucherType);
+        $voucherNumber = $this->nextVoucherNumber('Journal');
 
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
-        $xml .= '          <VOUCHER VCHTYPE="'.$this->escapeXml($voucherType).'" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
+        $xml .= '          <VOUCHER VCHTYPE="Journal" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
         $xml .= '            <DATE>'.$date.'</DATE>'."\n";
         $xml .= '            <VCHSTATUSDATE>'.$date.'</VCHSTATUSDATE>'."\n";
         $xml .= '            <NARRATION>'.$this->escapeXml($transaction->description ?? '').'</NARRATION>'."\n";
-        $xml .= '            <VOUCHERTYPENAME>'.$this->escapeXml($voucherType).'</VOUCHERTYPENAME>'."\n";
+        $xml .= '            <VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>'."\n";
         $xml .= '            <VOUCHERNUMBER>'.$voucherNumber.'</VOUCHERNUMBER>'."\n";
-        $xml .= '            <PARTYLEDGERNAME>'.$this->escapeXml($headName).'</PARTYLEDGERNAME>'."\n";
 
         if ($company) {
             $xml .= '            <CMPGSTIN>'.$this->escapeXml($company->gstin ?? '').'</CMPGSTIN>'."\n";
@@ -144,13 +142,9 @@ class TallyExportService
         $xml .= '            <ISONHOLD>No</ISONHOLD>'."\n";
         $xml .= '            <ISOPTIONAL>No</ISOPTIONAL>'."\n";
         $xml .= '            <AUDITED>No</AUDITED>'."\n";
-        $xml .= '            <HASCASHFLOW>Yes</HASCASHFLOW>'."\n";
+        $xml .= '            <HASCASHFLOW>No</HASCASHFLOW>'."\n";
 
-        if ($isPayment) {
-            $xml .= $this->generatePaymentLedgerEntries($headName, $bankName, $amount, $date);
-        } else {
-            $xml .= $this->generateReceiptLedgerEntries($headName, $bankName, $amount, $date);
-        }
+        $xml .= $this->generateBankJournalLedgerEntries($headName, $bankName, $amount, $isDebit);
 
         $xml .= '          </VOUCHER>'."\n";
         $xml .= '        </TALLYMESSAGE>'."\n";
@@ -461,65 +455,31 @@ class TallyExportService
     }
 
     /**
-     * Generate ledger entries for a Payment voucher.
-     * Debit: expense/party (negative amount, ISDEEMEDPOSITIVE=Yes)
-     * Credit: bank (positive amount, ISDEEMEDPOSITIVE=No)
+     * Generate the two-leg journal entry for a bank/CC transaction.
+     * Debit: ISDEEMEDPOSITIVE=Yes, negative amount. Credit: ISDEEMEDPOSITIVE=No, positive amount.
+     * Both legs carry ISPARTYLEDGER=Yes — no BANKALLOCATIONS.LIST.
      */
-    private function generatePaymentLedgerEntries(string $headName, string $bankName, float $amount, string $date): string
+    private function generateBankJournalLedgerEntries(string $headName, string $bankName, float $amount, bool $isDebit): string
     {
         $formattedAmount = number_format($amount, 2, '.', '');
+
+        [$debitLedger, $creditLedger] = $isDebit
+            ? [$headName, $bankName]
+            : [$bankName, $headName];
 
         $xml = '';
 
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$this->escapeXml($headName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($debitLedger).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <ISPARTYLEDGER>Yes</ISPARTYLEDGER>'."\n";
         $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
 
         $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$this->escapeXml($bankName).'</LEDGERNAME>'."\n";
+        $xml .= '              <LEDGERNAME>'.$this->escapeXml($creditLedger).'</LEDGERNAME>'."\n";
         $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
-        $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
-        $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
-        $xml .= '                <DATE>'.$date.'</DATE>'."\n";
-        $xml .= '                <INSTRUMENTDATE>'.$date.'</INSTRUMENTDATE>'."\n";
-        $xml .= '                <BANKERSDATE>'.$date.'</BANKERSDATE>'."\n";
-        $xml .= '                <TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>'."\n";
-        $xml .= '                <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
-        $xml .= '              </BANKALLOCATIONS.LIST>'."\n";
-        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
-
-        return $xml;
-    }
-
-    /**
-     * Generate ledger entries for a Receipt voucher.
-     * Debit: bank (negative amount, ISDEEMEDPOSITIVE=Yes)
-     * Credit: party/income (positive amount, ISDEEMEDPOSITIVE=No)
-     */
-    private function generateReceiptLedgerEntries(string $headName, string $bankName, float $amount, string $date): string
-    {
-        $formattedAmount = number_format($amount, 2, '.', '');
-
-        $xml = '';
-
-        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$this->escapeXml($bankName).'</LEDGERNAME>'."\n";
-        $xml .= '              <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>'."\n";
-        $xml .= '              <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
-        $xml .= '              <BANKALLOCATIONS.LIST>'."\n";
-        $xml .= '                <DATE>'.$date.'</DATE>'."\n";
-        $xml .= '                <INSTRUMENTDATE>'.$date.'</INSTRUMENTDATE>'."\n";
-        $xml .= '                <BANKERSDATE>'.$date.'</BANKERSDATE>'."\n";
-        $xml .= '                <TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>'."\n";
-        $xml .= '                <AMOUNT>-'.$formattedAmount.'</AMOUNT>'."\n";
-        $xml .= '              </BANKALLOCATIONS.LIST>'."\n";
-        $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
-
-        $xml .= '            <ALLLEDGERENTRIES.LIST>'."\n";
-        $xml .= '              <LEDGERNAME>'.$this->escapeXml($headName).'</LEDGERNAME>'."\n";
-        $xml .= '              <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>'."\n";
+        $xml .= '              <ISPARTYLEDGER>Yes</ISPARTYLEDGER>'."\n";
         $xml .= '              <AMOUNT>'.$formattedAmount.'</AMOUNT>'."\n";
         $xml .= '            </ALLLEDGERENTRIES.LIST>'."\n";
 
@@ -545,13 +505,12 @@ class TallyExportService
     }
 
     /**
-     * Determine whether the export should use the Sales voucher format.
-     * Invoice files whose first transaction carries a 'buyer_name' in raw_data
-     * are outward (sales) invoices; all others use the Journal format.
+     * Only purchase invoice Journal exports use REPORTNAME=All Masters.
+     * Sales invoices and bank/CC journal exports both use Vouchers.
      *
      * @param  Collection<int, Transaction>  $transactions
      */
-    private function isSalesInvoiceExport(Collection $transactions, ?ImportedFile $importedFile): bool
+    private function isAllMastersExport(Collection $transactions, ?ImportedFile $importedFile): bool
     {
         if ($importedFile?->statement_type !== StatementType::Invoice) {
             return false;
@@ -560,10 +519,14 @@ class TallyExportService
         /** @var Transaction|null $first */
         $first = $transactions->first();
 
-        /** @var array<string, mixed> $raw */
-        $raw = $first?->raw_data ?? [];
+        if ($first === null) {
+            return false;
+        }
 
-        return isset($raw['buyer_name']);
+        /** @var array<string, mixed> $raw */
+        $raw = $first->raw_data ?? [];
+
+        return ! isset($raw['buyer_name']);
     }
 
     /**

--- a/tests/Feature/Services/TallyExportBankJournalVoucherTest.php
+++ b/tests/Feature/Services/TallyExportBankJournalVoucherTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Models\AccountHead;
+use App\Models\BankAccount;
+use App\Models\Company;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\TallyExport\TallyExportService;
+
+describe('TallyExportService bank/CC journal vouchers', function () {
+    beforeEach(function () {
+        $this->company = Company::factory()->knownDefaults()->create();
+        $this->bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Amazon ICICI Credit Card',
+        ]);
+        $this->file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => $this->bankAccount->id,
+        ]);
+        $this->service = new TallyExportService;
+    });
+
+    it('exports bank/CC debit as Journal voucher not Payment', function () {
+        $head = AccountHead::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Reliance Jio',
+        ]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'description' => 'TOP UP DONE THRG AMAZON CARD',
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)
+            ->toContain('VCHTYPE="Journal"')
+            ->toContain('<VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>')
+            ->not->toContain('VCHTYPE="Payment"')
+            ->not->toContain('VCHTYPE="Receipt"');
+    });
+
+    it('exports bank/CC credit as Journal voucher not Receipt', function () {
+        $head = AccountHead::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Client Income',
+        ]);
+        Transaction::factory()->mapped($head)->credit(50000.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'description' => 'Payment received',
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)
+            ->toContain('VCHTYPE="Journal"')
+            ->toContain('<VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>')
+            ->not->toContain('VCHTYPE="Receipt"');
+    });
+
+    it('uses REPORTNAME Vouchers for bank/CC export', function () {
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)
+            ->toContain('<REPORTNAME>Vouchers</REPORTNAME>')
+            ->not->toContain('<REPORTNAME>All Masters</REPORTNAME>');
+    });
+
+    it('sets HASCASHFLOW to No on bank/CC journal voucher', function () {
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)->toContain('<HASCASHFLOW>No</HASCASHFLOW>');
+    });
+
+    it('sets ISPARTYLEDGER Yes on both ledger legs for a debit journal', function () {
+        $head = AccountHead::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Reliance Jio',
+        ]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect(substr_count($xml, '<ISPARTYLEDGER>Yes</ISPARTYLEDGER>'))->toBe(2);
+    });
+
+    it('generates correct debit journal legs: expense head debit, bank/CC credit', function () {
+        $head = AccountHead::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Reliance Jio',
+        ]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)
+            ->toContain('<LEDGERNAME>Reliance Jio</LEDGERNAME>')
+            ->toContain('<ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>')
+            ->toContain('<AMOUNT>-299.00</AMOUNT>')
+            ->toContain('<LEDGERNAME>Amazon ICICI Credit Card</LEDGERNAME>')
+            ->toContain('<ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>')
+            ->toContain('<AMOUNT>299.00</AMOUNT>');
+    });
+
+    it('generates correct credit journal legs: bank/CC debit, income head credit', function () {
+        $head = AccountHead::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Client Income',
+        ]);
+        Transaction::factory()->mapped($head)->credit(50000.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)
+            ->toContain('<LEDGERNAME>Amazon ICICI Credit Card</LEDGERNAME>')
+            ->toContain('<ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>')
+            ->toContain('<AMOUNT>-50000.00</AMOUNT>')
+            ->toContain('<LEDGERNAME>Client Income</LEDGERNAME>')
+            ->toContain('<ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>')
+            ->toContain('<AMOUNT>50000.00</AMOUNT>');
+    });
+
+    it('does not include BANKALLOCATIONS.LIST in journal voucher', function () {
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id]);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($this->file);
+
+        expect($xml)->not->toContain('<BANKALLOCATIONS.LIST>');
+    });
+});

--- a/tests/Feature/Services/TallyExportServiceTest.php
+++ b/tests/Feature/Services/TallyExportServiceTest.php
@@ -41,7 +41,7 @@ describe('TallyExportService', function () {
                 ->and($xml)->toContain('<TALLYREQUEST>Import Data</TALLYREQUEST>')
                 ->and($xml)->toContain('<IMPORTDATA>')
                 ->and($xml)->toContain('<REQUESTDESC>')
-                ->and($xml)->toContain('<REPORTNAME>All Masters</REPORTNAME>')
+                ->and($xml)->toContain('<REPORTNAME>Vouchers</REPORTNAME>')
                 ->and($xml)->toContain('<SVCURRENTCOMPANY>Acme Corp Private Limited - 2025 - 2026</SVCURRENTCOMPANY>')
                 ->and($xml)->toContain('<REQUESTDATA>')
                 ->and($xml)->toContain('</ENVELOPE>');
@@ -60,8 +60,8 @@ describe('TallyExportService', function () {
         });
     });
 
-    describe('payment vouchers', function () {
-        it('generates payment voucher for debit transactions', function () {
+    describe('debit journal vouchers', function () {
+        it('generates journal voucher for debit transactions', function () {
             $head = AccountHead::factory()->create([
                 'company_id' => $this->company->id,
                 'name' => 'TATA CAPITAL LIMITED',
@@ -74,12 +74,11 @@ describe('TallyExportService', function () {
 
             $xml = $this->service->exportForFile($this->file);
 
-            expect($xml)->toContain('VCHTYPE="Payment"')
+            expect($xml)->toContain('VCHTYPE="Journal"')
                 ->and($xml)->toContain('ACTION="Create"')
                 ->and($xml)->toContain('<DATE>20250401</DATE>')
-                ->and($xml)->toContain('<VOUCHERTYPENAME>Payment</VOUCHERTYPENAME>')
+                ->and($xml)->toContain('<VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>')
                 ->and($xml)->toContain('<NARRATION>ACH/TATACAPFINSERLTD</NARRATION>')
-                ->and($xml)->toContain('<PARTYLEDGERNAME>TATA CAPITAL LIMITED</PARTYLEDGERNAME>')
                 ->and($xml)->toContain('<CMPGSTIN>27AABCA5012F1ZA</CMPGSTIN>')
                 ->and($xml)->toContain('<CMPGSTREGISTRATIONTYPE>Regular</CMPGSTREGISTRATIONTYPE>')
                 ->and($xml)->toContain('<CMPGSTSTATE>Maharashtra</CMPGSTSTATE>');
@@ -108,7 +107,7 @@ describe('TallyExportService', function () {
                 ->and($xml)->toContain('<AMOUNT>50000.00</AMOUNT>');
         });
 
-        it('includes BANKALLOCATIONS.LIST on bank credit leg', function () {
+        it('does not include BANKALLOCATIONS.LIST in journal vouchers', function () {
             $head = AccountHead::factory()->create([
                 'company_id' => $this->company->id,
                 'name' => 'Office Supplies',
@@ -120,13 +119,12 @@ describe('TallyExportService', function () {
 
             $xml = $this->service->exportForFile($this->file);
 
-            expect($xml)->toContain('<BANKALLOCATIONS.LIST>')
-                ->and($xml)->toContain('<TRANSACTIONTYPE>Cheque</TRANSACTIONTYPE>');
+            expect($xml)->not->toContain('<BANKALLOCATIONS.LIST>');
         });
     });
 
-    describe('receipt vouchers', function () {
-        it('generates receipt voucher for credit transactions', function () {
+    describe('credit journal vouchers', function () {
+        it('generates journal voucher for credit transactions', function () {
             $head = AccountHead::factory()->create([
                 'company_id' => $this->company->id,
                 'name' => 'METAFIRST TECHNOLOGIES',
@@ -139,8 +137,8 @@ describe('TallyExportService', function () {
 
             $xml = $this->service->exportForFile($this->file);
 
-            expect($xml)->toContain('VCHTYPE="Receipt"')
-                ->and($xml)->toContain('<VOUCHERTYPENAME>Receipt</VOUCHERTYPENAME>');
+            expect($xml)->toContain('VCHTYPE="Journal"')
+                ->and($xml)->toContain('<VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>');
         });
 
         it('generates correct ledger entries for receipt voucher', function () {


### PR DESCRIPTION
## Summary

- Bank and credit card statement transactions now export as `VCHTYPE="Journal"` with `REPORTNAME=Vouchers`, matching the real Tally day-book format
- Removed `HASCASHFLOW=Yes` and `BANKALLOCATIONS.LIST` (Payment/Receipt-specific fields); added `HASCASHFLOW=No` and `ISPARTYLEDGER=Yes` on both ledger legs
- Removed dead `generatePaymentLedgerEntries` / `generateReceiptLedgerEntries` methods; replaced with a single `generateBankJournalLedgerEntries` that handles both debit and credit directions via destructuring

## Test plan

- [ ] `php artisan test --filter=TallyExportBankJournalVoucher` — 8 new tests, all green
- [ ] `php artisan test --filter=TallyExport` — 50 tests, all green
- [ ] PHPStan level 6 — no errors
- [ ] Pint — no formatting issues

Closes #259