### PR TITLE
fix(tally-export): use vendor name as debit ledger for reconciled CC transactions

### DIFF
--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -122,6 +122,10 @@ class TallyExportService
         $bankName = $bankLedgerName ?? 'Bank Account';
         $voucherNumber = $this->nextVoucherNumber('Journal');
 
+        /** @var array<string, mixed> $raw */
+        $raw = $transaction->raw_data ?? [];
+        $vendorName = (string) ($raw['vendor_name'] ?? '') ?: null;
+
         $xml = '        <TALLYMESSAGE xmlns:UDF="TallyUDF">'."\n";
         $xml .= '          <VOUCHER VCHTYPE="Journal" ACTION="Create" OBJVIEW="Accounting Voucher View">'."\n";
         $xml .= '            <DATE>'.$date.'</DATE>'."\n";
@@ -129,6 +133,10 @@ class TallyExportService
         $xml .= '            <NARRATION>'.$this->escapeXml($transaction->description ?? '').'</NARRATION>'."\n";
         $xml .= '            <VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>'."\n";
         $xml .= '            <VOUCHERNUMBER>'.$voucherNumber.'</VOUCHERNUMBER>'."\n";
+
+        if ($vendorName !== null) {
+            $xml .= '            <PARTYLEDGERNAME>'.$this->escapeXml($vendorName).'</PARTYLEDGERNAME>'."\n";
+        }
 
         if ($company) {
             $xml .= '            <CMPGSTIN>'.$this->escapeXml($company->gstin ?? '').'</CMPGSTIN>'."\n";
@@ -144,7 +152,7 @@ class TallyExportService
         $xml .= '            <AUDITED>No</AUDITED>'."\n";
         $xml .= '            <HASCASHFLOW>No</HASCASHFLOW>'."\n";
 
-        $xml .= $this->generateBankJournalLedgerEntries($headName, $bankName, $amount, $isDebit);
+        $xml .= $this->generateBankJournalLedgerEntries($headName, $bankName, $amount, $isDebit, $vendorName);
 
         $xml .= '          </VOUCHER>'."\n";
         $xml .= '        </TALLYMESSAGE>'."\n";
@@ -458,14 +466,16 @@ class TallyExportService
      * Generate the two-leg journal entry for a bank/CC transaction.
      * Debit: ISDEEMEDPOSITIVE=Yes, negative amount. Credit: ISDEEMEDPOSITIVE=No, positive amount.
      * Both legs carry ISPARTYLEDGER=Yes — no BANKALLOCATIONS.LIST.
+     * vendor_name overrides headName as debit ledger to close the vendor payable opened by the purchase journal.
      */
-    private function generateBankJournalLedgerEntries(string $headName, string $bankName, float $amount, bool $isDebit): string
+    private function generateBankJournalLedgerEntries(string $headName, string $bankName, float $amount, bool $isDebit, ?string $vendorName = null): string
     {
         $formattedAmount = number_format($amount, 2, '.', '');
+        $debitLedgerName = $vendorName ?? $headName;
 
         [$debitLedger, $creditLedger] = $isDebit
-            ? [$headName, $bankName]
-            : [$bankName, $headName];
+            ? [$debitLedgerName, $bankName]
+            : [$bankName, $debitLedgerName];
 
         $xml = '';
 

--- a/tests/Feature/Services/TallyExportReconciledJournalTest.php
+++ b/tests/Feature/Services/TallyExportReconciledJournalTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\AccountHead;
+use App\Models\BankAccount;
+use App\Models\Company;
+use App\Models\ImportedFile;
+use App\Models\Transaction;
+use App\Services\TallyExport\TallyExportService;
+
+describe('TallyExportService reconciled journal vouchers', function () {
+    beforeEach(function () {
+        $this->company = Company::factory()->knownDefaults()->create();
+        $this->bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'Amazon ICICI Credit Card',
+        ]);
+        $this->file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => $this->bankAccount->id,
+        ]);
+        $this->service = new TallyExportService;
+    });
+
+    describe('when vendor_name is present in raw_data', function () {
+        beforeEach(function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Internet Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)
+                ->withRawData(['vendor_name' => 'M/S Reliance Jio Infocomm Limited'])
+                ->create([
+                    'company_id' => $this->company->id,
+                    'description' => 'RELIANCE RETAIL LIMITE NOIDA IN',
+                    'date' => '2026-03-17',
+                ]);
+        });
+
+        it('uses vendor_name as debit ledger instead of account head', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)
+                ->toContain('<LEDGERNAME>M/S Reliance Jio Infocomm Limited</LEDGERNAME>')
+                ->not->toContain('<LEDGERNAME>Internet Expense</LEDGERNAME>');
+        });
+
+        it('sets PARTYLEDGERNAME to vendor_name', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<PARTYLEDGERNAME>M/S Reliance Jio Infocomm Limited</PARTYLEDGERNAME>');
+        });
+
+        it('still uses CC account as credit ledger', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)
+                ->toContain('<LEDGERNAME>Amazon ICICI Credit Card</LEDGERNAME>')
+                ->toContain('<ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>');
+        });
+
+        it('generates correct debit and credit amounts', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)
+                ->toContain('<AMOUNT>-299.00</AMOUNT>')
+                ->toContain('<AMOUNT>299.00</AMOUNT>');
+        });
+
+        it('still exports as Journal voucher', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)
+                ->toContain('VCHTYPE="Journal"')
+                ->toContain('<VOUCHERTYPENAME>Journal</VOUCHERTYPENAME>')
+                ->toContain('<HASCASHFLOW>No</HASCASHFLOW>');
+        });
+    });
+
+    describe('when vendor_name is absent from raw_data', function () {
+        beforeEach(function () {
+            $head = AccountHead::factory()->create([
+                'company_id' => $this->company->id,
+                'name' => 'Internet Expense',
+            ]);
+            Transaction::factory()->mapped($head)->debit(299.00)->for($this->file)->create([
+                'company_id' => $this->company->id,
+                'date' => '2026-03-17',
+            ]);
+        });
+
+        it('uses account head as debit ledger', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->toContain('<LEDGERNAME>Internet Expense</LEDGERNAME>');
+        });
+
+        it('does not include PARTYLEDGERNAME', function () {
+            $xml = $this->service->exportForFile($this->file);
+
+            expect($xml)->not->toContain('<PARTYLEDGERNAME>');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- When a bank/CC transaction has `vendor_name` in `raw_data` (populated by reconciliation enrichment), the payment journal now uses the vendor as the debit ledger and sets `PARTYLEDGERNAME`
- This closes the vendor payable opened by the corresponding purchase invoice journal — matching the real Tally export format in `Journal_1520.xml`
- Unreconciled transactions (no `vendor_name`) continue to use the account head name unchanged

## Example (Jio CC payment reconciled with invoice)

```xml
<PARTYLEDGERNAME>M/S Reliance Jio Infocomm Limited</PARTYLEDGERNAME>
<ALLLEDGERENTRIES.LIST>
  <LEDGERNAME>M/S Reliance Jio Infocomm Limited</LEDGERNAME>  <!-- vendor, not "Internet Expense" -->
  <ISDEEMEDPOSITIVE>Yes</ISDEEMEDPOSITIVE>
  <AMOUNT>-299.00</AMOUNT>
</ALLLEDGERENTRIES.LIST>
<ALLLEDGERENTRIES.LIST>
  <LEDGERNAME>Amazon ICICI Credit Card</LEDGERNAME>
  <ISDEEMEDPOSITIVE>No</ISDEEMEDPOSITIVE>
  <AMOUNT>299.00</AMOUNT>
</ALLLEDGERENTRIES.LIST>
```

## Test plan

- [ ] `php artisan test --filter=TallyExportReconciledJournal --compact` — 7 tests, all green
- [ ] `php artisan test --filter=TallyExport --compact` — 62 tests, all green
- [ ] PHPStan: Pass | Pint: Pass

Note: depends on PR #260 (Journal voucher format fix) — this branch includes that merge.

Closes #261