### PR TITLE
fix(tally-export): normalize account head names and remove display_name from ledger fallback

### DIFF
--- a/app/Models/AccountHead.php
+++ b/app/Models/AccountHead.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Services\AggregateService;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,6 +12,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+/**
+ * @property string $name
+ */
 class AccountHead extends Model
 {
     use HasFactory;
@@ -64,6 +68,14 @@ class AccountHead extends Model
         return [
             'is_active' => 'boolean',
         ];
+    }
+
+    /** @return Attribute<string, string> */
+    protected function name(): Attribute
+    {
+        return Attribute::make(
+            set: fn (string $value) => (string) preg_replace('/\s+/', ' ', trim($value)),
+        );
     }
 
     /** @return BelongsTo<Company, $this> */

--- a/app/Services/HeadMatcher/HeadMatcherService.php
+++ b/app/Services/HeadMatcher/HeadMatcherService.php
@@ -222,7 +222,8 @@ class HeadMatcherService
 
         // Fallback: lookup by name scoped to this company
         if (isset($match['suggested_head_name'])) {
-            $head = AccountHead::where('name', $match['suggested_head_name'])
+            $normalizedName = (string) preg_replace('/\s+/', ' ', trim($match['suggested_head_name']));
+            $head = AccountHead::where('name', $normalizedName)
                 ->where('company_id', $companyId)
                 ->first();
 

--- a/app/Services/TallyExport/TallyExportService.php
+++ b/app/Services/TallyExport/TallyExportService.php
@@ -179,7 +179,6 @@ class TallyExportService
         $accountHead = $transaction->accountHead;
         $headName = $accountHead?->name ?? 'Unknown';
         $bankName = $effectiveFile?->bankAccount?->name
-            ?? $effectiveFile?->display_name
             ?? $bankLedgerName
             ?? 'Bank Account';
         $voucherNumber = $this->nextVoucherNumber('Journal');
@@ -533,6 +532,14 @@ class TallyExportService
      * Generate the two-leg journal entry for a bank/CC transaction.
      * BY (debit, ISDEEMEDPOSITIVE=Yes): account head mapped by the user.
      * TO (credit, ISDEEMEDPOSITIVE=No): bank/CC card ledger name.
+     *
+     * Design note (see #261 → #262): reconciled CC transactions always use the
+     * account head as the debit ledger, not vendor_name from raw_data. This is
+     * intentional — the CC statement export is treated as a standalone single-entry
+     * journal (expense → CC account). Invoices are exported independently via their
+     * own Journal/All Masters export, which handles the vendor payable leg. Exporting
+     * both an invoice AND its matched CC payment with vendor_name as debit would
+     * double-debit the expense head.
      */
     private function generateBankJournalLedgerEntries(string $headName, string $bankName, float $amount, bool $isDebit): string
     {

--- a/database/migrations/2026_07_14_000001_backfill_normalize_account_head_names.php
+++ b/database/migrations/2026_07_14_000001_backfill_normalize_account_head_names.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Backfill: normalize all existing account_heads.name values.
+     *
+     * The AccountHead Eloquent mutator (added in PR #275) trims and collapses
+     * whitespace on every new write, but rows persisted before that change may
+     * still contain artifacts like trailing newlines or double spaces. This
+     * migration applies the same rule retroactively in a single SQL pass.
+     *
+     * PostgreSQL equivalent of PHP: (string) preg_replace('/\s+/', ' ', trim($value))
+     *   - trim(name)           -> strip leading/trailing whitespace (including \n, \t)
+     *   - regexp_replace(...)  -> collapse any internal whitespace run to a single space
+     */
+    public function up(): void
+    {
+        DB::statement(
+            "UPDATE account_heads
+             SET name = trim(regexp_replace(name, '\\s+', ' ', 'g'))
+             WHERE name <> trim(regexp_replace(name, '\\s+', ' ', 'g'))"
+        );
+    }
+};

--- a/tests/Feature/Models/AccountHeadTest.php
+++ b/tests/Feature/Models/AccountHeadTest.php
@@ -150,6 +150,46 @@ describe('AccountHead soft-delete cascade', function () {
     });
 });
 
+describe('AccountHead name normalization', function () {
+    it('trims leading and trailing whitespace from name on create', function () {
+        $head = AccountHead::factory()->create(['name' => '  Internet Expense  ']);
+
+        expect($head->fresh()->name)->toBe('Internet Expense');
+    });
+
+    it('strips trailing newline from name on create', function () {
+        $head = AccountHead::factory()->create(['name' => "AMAZON WEB SERVICES INDIA PRIVATE LIMITED\n"]);
+
+        expect($head->fresh()->name)->toBe('AMAZON WEB SERVICES INDIA PRIVATE LIMITED');
+    });
+
+    it('collapses double internal spaces to single space on create', function () {
+        $head = AccountHead::factory()->create(['name' => 'Godaddy India  - Subscription']);
+
+        expect($head->fresh()->name)->toBe('Godaddy India - Subscription');
+    });
+
+    it('normalizes name with mixed whitespace artifacts', function () {
+        $head = AccountHead::factory()->create(['name' => "  AWS  India  \n"]);
+
+        expect($head->fresh()->name)->toBe('AWS India');
+    });
+
+    it('leaves already-clean names unchanged', function () {
+        $head = AccountHead::factory()->create(['name' => 'Internet Expense']);
+
+        expect($head->fresh()->name)->toBe('Internet Expense');
+    });
+
+    it('normalizes name on update too', function () {
+        $head = AccountHead::factory()->create(['name' => 'Internet Expense']);
+
+        $head->update(['name' => "Telecom Expense  \n"]);
+
+        expect($head->fresh()->name)->toBe('Telecom Expense');
+    });
+});
+
 describe('AccountHead relationships', function () {
     it('has children', function () {
         $parent = AccountHead::factory()->create();

--- a/tests/Feature/Services/HeadMatcherServiceTest.php
+++ b/tests/Feature/Services/HeadMatcherServiceTest.php
@@ -383,6 +383,37 @@ describe('HeadMatcherService::resolveAccountHead()', function () {
 
         expect($result)->toBeNull();
     });
+
+    it('name fallback normalizes whitespace in suggested_head_name before querying', function () {
+        $head = AccountHead::factory()->create(['name' => 'Internet Expense']);
+        $service = new HeadMatcherService(new RuleBasedMatcher);
+
+        $method = new ReflectionMethod($service, 'resolveAccountHead');
+
+        // LLM returns the name with a trailing newline — ID is wrong to force the name fallback
+        $result = $method->invoke($service, [
+            'suggested_head_id' => 99999,
+            'suggested_head_name' => "Internet Expense\n",
+        ], $head->company_id);
+
+        expect($result)->not->toBeNull()
+            ->and($result->id)->toBe($head->id);
+    });
+
+    it('name fallback normalizes double internal spaces in suggested_head_name', function () {
+        $head = AccountHead::factory()->create(['name' => 'Godaddy - Subscription']);
+        $service = new HeadMatcherService(new RuleBasedMatcher);
+
+        $method = new ReflectionMethod($service, 'resolveAccountHead');
+
+        $result = $method->invoke($service, [
+            'suggested_head_id' => 99999,
+            'suggested_head_name' => 'Godaddy  - Subscription',
+        ], $head->company_id);
+
+        expect($result)->not->toBeNull()
+            ->and($result->id)->toBe($head->id);
+    });
 });
 
 describe('HeadMatcherService company isolation', function () {

--- a/tests/Feature/Services/HeadMatcherServiceTest.php
+++ b/tests/Feature/Services/HeadMatcherServiceTest.php
@@ -384,35 +384,78 @@ describe('HeadMatcherService::resolveAccountHead()', function () {
         expect($result)->toBeNull();
     });
 
-    it('name fallback normalizes whitespace in suggested_head_name before querying', function () {
-        $head = AccountHead::factory()->create(['name' => 'Internet Expense']);
-        $service = new HeadMatcherService(new RuleBasedMatcher);
+    it('name fallback normalizes trailing newline in suggested_head_name before querying', function () {
+        $company = Company::factory()->create();
+        $head = AccountHead::factory()->create([
+            'company_id' => $company->id,
+            'name' => 'Internet Expense',
+            'is_active' => true,
+        ]);
 
-        $method = new ReflectionMethod($service, 'resolveAccountHead');
+        $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+        $transaction = Transaction::factory()->unmapped()->for($file)->create([
+            'description' => 'MONTHLY INTERNET BILL',
+            'debit' => '999',
+        ]);
 
-        // LLM returns the name with a trailing newline — ID is wrong to force the name fallback
-        $result = $method->invoke($service, [
-            'suggested_head_id' => 99999,
-            'suggested_head_name' => "Internet Expense\n",
-        ], $head->company_id);
+        // LLM returns the name with a trailing newline — wrong ID forces the name-fallback path
+        HeadMatcher::fake([
+            [
+                'matches' => [
+                    [
+                        'transaction_id' => $transaction->id,
+                        'suggested_head_id' => 99999,
+                        'suggested_head_name' => "Internet Expense\n",
+                        'confidence' => 0.90,
+                        'reasoning' => 'Internet bill',
+                    ],
+                ],
+            ],
+        ]);
 
-        expect($result)->not->toBeNull()
-            ->and($result->id)->toBe($head->id);
+        $service = app(HeadMatcherService::class);
+        $results = $service->matchForFile($file);
+
+        expect($results['ai_matched'])->toBe(1);
+        $transaction->refresh();
+        expect($transaction->account_head_id)->toBe($head->id);
     });
 
-    it('name fallback normalizes double internal spaces in suggested_head_name', function () {
-        $head = AccountHead::factory()->create(['name' => 'Godaddy - Subscription']);
-        $service = new HeadMatcherService(new RuleBasedMatcher);
+    it('name fallback normalizes double internal spaces in suggested_head_name before querying', function () {
+        $company = Company::factory()->create();
+        $head = AccountHead::factory()->create([
+            'company_id' => $company->id,
+            'name' => 'Godaddy - Subscription',
+            'is_active' => true,
+        ]);
 
-        $method = new ReflectionMethod($service, 'resolveAccountHead');
+        $file = ImportedFile::factory()->create(['company_id' => $company->id]);
+        $transaction = Transaction::factory()->unmapped()->for($file)->create([
+            'description' => 'GODADDY DOMAIN RENEWAL',
+            'debit' => '1499',
+        ]);
 
-        $result = $method->invoke($service, [
-            'suggested_head_id' => 99999,
-            'suggested_head_name' => 'Godaddy  - Subscription',
-        ], $head->company_id);
+        // LLM returns double space — wrong ID forces the name-fallback path
+        HeadMatcher::fake([
+            [
+                'matches' => [
+                    [
+                        'transaction_id' => $transaction->id,
+                        'suggested_head_id' => 99999,
+                        'suggested_head_name' => 'Godaddy  - Subscription',
+                        'confidence' => 0.88,
+                        'reasoning' => 'Domain subscription',
+                    ],
+                ],
+            ],
+        ]);
 
-        expect($result)->not->toBeNull()
-            ->and($result->id)->toBe($head->id);
+        $service = app(HeadMatcherService::class);
+        $results = $service->matchForFile($file);
+
+        expect($results['ai_matched'])->toBe(1);
+        $transaction->refresh();
+        expect($transaction->account_head_id)->toBe($head->id);
     });
 });
 

--- a/tests/Feature/Services/TallyExportBankJournalVoucherTest.php
+++ b/tests/Feature/Services/TallyExportBankJournalVoucherTest.php
@@ -155,3 +155,67 @@ describe('TallyExportService bank/CC journal vouchers', function () {
         expect($xml)->toContain('<BANKALLOCATIONS.LIST>');
     });
 });
+
+describe('TallyExportService bank/CC ledger name fallback', function () {
+    beforeEach(function () {
+        $this->company = Company::factory()->knownDefaults()->create();
+        $this->service = new TallyExportService;
+    });
+
+    it('does not use display_name as the bank/CC ledger name when bank_account is null', function () {
+        $file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => null,
+            'display_name' => 'ICICI Platinum April 2026',
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id, 'name' => 'Internet Expense']);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($file);
+
+        expect($xml)->not->toContain('<LEDGERNAME>ICICI Platinum April 2026</LEDGERNAME>');
+    });
+
+    it('falls back to Bank Account sentinel when bank_account and bank_name are both null', function () {
+        $file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => null,
+            'display_name' => 'ICICI Platinum April 2026',
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id, 'name' => 'Internet Expense']);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($file);
+
+        expect($xml)->toContain('<LEDGERNAME>Bank Account</LEDGERNAME>');
+    });
+
+    it('uses bankAccount name when set, ignoring display_name', function () {
+        $bankAccount = BankAccount::factory()->create([
+            'company_id' => $this->company->id,
+            'name' => 'ICICI Platinum',
+        ]);
+        $file = ImportedFile::factory()->create([
+            'company_id' => $this->company->id,
+            'bank_account_id' => $bankAccount->id,
+            'display_name' => 'ICICI Platinum April 2026',
+        ]);
+        $head = AccountHead::factory()->create(['company_id' => $this->company->id, 'name' => 'Internet Expense']);
+        Transaction::factory()->mapped($head)->debit(299.00)->for($file)->create([
+            'company_id' => $this->company->id,
+            'date' => '2026-03-26',
+        ]);
+
+        $xml = $this->service->exportForFile($file);
+
+        expect($xml)
+            ->toContain('<LEDGERNAME>ICICI Platinum</LEDGERNAME>')
+            ->not->toContain('<LEDGERNAME>ICICI Platinum April 2026</LEDGERNAME>');
+    });
+});


### PR DESCRIPTION
## Summary

- **Bug 1:** Account head names from the LLM can contain whitespace artifacts (`\n`, double spaces). Tally does exact ledger name matching, so `"AWS INDIA\n"` silently fails with \"Referenced master is missing\". Added a write-time Eloquent mutator on `AccountHead` that trims and collapses all whitespace before persisting — covers Filament form, Tally XML import, and any future path automatically.
- **Bug 2:** `TallyExportService` was falling back to `ImportedFile.display_name` when `bankAccount.name` was null. `display_name` includes the month/year (e.g. `ICICI Platinum April 2026`), causing Tally to create a new ledger each month. Removed `display_name` from the fallback chain.
- **Bug 3:** `HeadMatcherService::resolveAccountHead()` name-fallback path queried the DB with the raw LLM-returned string. If the LLM returned `"Internet Expense\n"`, the `where('name', ...)` lookup failed to find the clean stored record, leaving the transaction unmapped. Applied the same normalization on the query side that the AccountHead mutator now applies on the write side.
- **Design doc:** Added a code comment on `generateBankJournalLedgerEntries` explaining why reconciled CC transactions use the account head (not `vendor_name`) as the debit ledger, documenting the intentional reversal from #261 → #262.

## Test plan

- [ ] `AccountHead name normalization` — 6 new tests: trailing newline, double spaces, mixed artifacts, trim, update path, no-op on clean names
- [ ] `TallyExportService bank/CC ledger name fallback` — 3 new tests: `display_name` not used, `Bank Account` fallback, `bankAccount.name` takes priority
- [ ] `HeadMatcherService::resolveAccountHead()` — 2 new tests: trailing newline and double-space normalization in name fallback
- [ ] All 34 HeadMatcher tests + 134 AccountHead/TallyExport tests still pass
- [ ] Pint: Pass | PHPStan: Pass

Closes #270