### PR TITLE
fix(mapping): show danger notification for duplicate rule in TransactionsRelationManager

### DIFF
--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -27,11 +27,13 @@ use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Exceptions\Halt;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Maatwebsite\Excel\Facades\Excel;
@@ -178,14 +180,24 @@ class TransactionsRelationManager extends RelationManager
                             /** @var Company|null $tenant */
                             $tenant = Filament::getTenant();
 
-                            HeadMapping::create([
-                                'pattern' => $data['pattern'],
-                                'match_type' => $data['match_type'],
-                                'account_head_id' => $data['account_head_id'],
-                                'bank_name' => $data['bank_name'] ?: null,
-                                'company_id' => $tenant?->id,
-                                'created_by' => Auth::id(),
-                            ]);
+                            try {
+                                HeadMapping::create([
+                                    'pattern' => $data['pattern'],
+                                    'match_type' => $data['match_type'],
+                                    'account_head_id' => $data['account_head_id'],
+                                    'bank_name' => $data['bank_name'] ?: null,
+                                    'company_id' => $tenant?->id,
+                                    'created_by' => Auth::id(),
+                                ]);
+                            } catch (UniqueConstraintViolationException) {
+                                Notification::make()
+                                    ->danger()
+                                    ->title('Duplicate rule')
+                                    ->body('A mapping rule with this pattern, match type, and account head already exists.')
+                                    ->send();
+
+                                throw new Halt;
+                            }
 
                             Notification::make()
                                 ->title('Mapping rule created')

--- a/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
+++ b/app/Filament/Resources/ImportedFileResource/RelationManagers/TransactionsRelationManager.php
@@ -181,14 +181,14 @@ class TransactionsRelationManager extends RelationManager
                             $tenant = Filament::getTenant();
 
                             try {
-                                HeadMapping::create([
+                                DB::transaction(fn () => HeadMapping::create([
                                     'pattern' => $data['pattern'],
                                     'match_type' => $data['match_type'],
                                     'account_head_id' => $data['account_head_id'],
                                     'bank_name' => $data['bank_name'] ?: null,
                                     'company_id' => $tenant?->id,
                                     'created_by' => Auth::id(),
-                                ]);
+                                ]));
                             } catch (UniqueConstraintViolationException) {
                                 Notification::make()
                                     ->danger()

--- a/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
+++ b/tests/Feature/Filament/ImportedFileTransactionsRelationManagerTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Enums\MatchType;
 use App\Filament\Resources\ImportedFileResource\Pages\ViewImportedFile;
 use App\Filament\Resources\ImportedFileResource\RelationManagers\TransactionsRelationManager;
+use App\Models\AccountHead;
+use App\Models\HeadMapping;
 use App\Models\ImportedFile;
 use App\Models\Transaction;
 
@@ -96,5 +99,37 @@ describe('ImportedFile Transactions RelationManager', function () {
             'pageClass' => ViewImportedFile::class,
         ])
             ->assertTableActionDoesNotExist('create');
+    });
+
+    it('shows a danger notification and does not create a duplicate mapping rule', function () {
+        $head = AccountHead::factory()->create();
+        $file = ImportedFile::factory()->create();
+        $transaction = Transaction::factory()
+            ->mapped($head)
+            ->for($file, 'importedFile')
+            ->create(['description' => 'SALARY CREDIT']);
+
+        HeadMapping::factory()->create([
+            'company_id' => tenant()->id,
+            'pattern' => 'SALARY CREDIT',
+            'match_type' => MatchType::Contains,
+            'account_head_id' => $head->id,
+        ]);
+
+        $countBefore = HeadMapping::count();
+
+        livewire(TransactionsRelationManager::class, [
+            'ownerRecord' => $file,
+            'pageClass' => ViewImportedFile::class,
+        ])
+            ->callTableAction('create_rule', $transaction, [
+                'pattern' => 'SALARY CREDIT',
+                'match_type' => MatchType::Contains,
+                'account_head_id' => $head->id,
+                'bank_name' => null,
+            ])
+            ->assertNotified('Duplicate rule');
+
+        expect(HeadMapping::count())->toBe($countBefore);
     });
 });


### PR DESCRIPTION
## Summary
- TransactionsRelationManager's create_rule action was missing the UniqueConstraintViolationException guard that already exists in ListTransactions, causing a 500 crash when a duplicate mapping rule was submitted from the imported file view
- Wraps HeadMapping::create() in a 	ry-catch that sends a danger notification and throws Halt, matching the existing pattern exactly

## Test plan
- [ ] New test: it shows a danger notification and does not create a duplicate mapping rule asserts ->assertNotified('Duplicate rule') and unchanged HeadMapping::count()
- [ ] Pint: Pass
- [ ] PHPStan: Pass
- [ ] To reproduce manually: open an imported file, find a mapped transaction, click Create Rule with an already-existing pattern/match-type/head combo — should now show the danger notification instead of a 500

Closes #273