### PR TITLE
fix(reconciliation): display confirm and reject buttons inline without overflow (#268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,13 @@ QUEUE_CONNECTION=database
 
 OPENROUTER_API_KEY=
 
-AI_PARSING_MODEL=google/gemini-3.1-flash-lite
-AI_MATCHING_MODEL=google/gemini-3.1-flash-lite
+AI_PARSING_MODEL=deepseek/deepseek-v3.2
+AI_MATCHING_MODEL=mistralai/mistral-large-latest
+
 MAIL_MAILER=mailgun
 MAIL_FROM_ADDRESS=noreply@zysk.tech
 MAIL_FROM_NAME="${APP_NAME}"
-MAILGUN_DOMAIN=mg.yourdomain.com
+MAILGUN_DOMAIN=mg.yourdomain.com 
 MAILGUN_SECRET=<your-mailgun-api-key>
 
 ZOHO_ACCOUNTS_URL=https://accounts.zoho.com

--- a/.env.example
+++ b/.env.example
@@ -23,13 +23,12 @@ QUEUE_CONNECTION=database
 
 OPENROUTER_API_KEY=
 
-AI_PARSING_MODEL=deepseek/deepseek-v3.2
-AI_MATCHING_MODEL=mistralai/mistral-large-latest
-
+AI_PARSING_MODEL=google/gemini-3.1-flash-lite
+AI_MATCHING_MODEL=google/gemini-3.1-flash-lite
 MAIL_MAILER=mailgun
 MAIL_FROM_ADDRESS=noreply@zysk.tech
 MAIL_FROM_NAME="${APP_NAME}"
-MAILGUN_DOMAIN=mg.yourdomain.com 
+MAILGUN_DOMAIN=mg.yourdomain.com
 MAILGUN_SECRET=<your-mailgun-api-key>
 
 ZOHO_ACCOUNTS_URL=https://accounts.zoho.com

--- a/app/Filament/Resources/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource.php
@@ -125,7 +125,7 @@ class ReconciliationResource extends Resource
                     ->visible(fn (Transaction $record) => $record->reconciliationMatchesAsBank->isNotEmpty()),
 
                 Actions\Action::make('reject_suggestions')
-                    ->label('Reject')
+                    ->label('Reject All')
                     ->icon('heroicon-o-x-circle')
                     ->color('danger')
                     ->button()

--- a/app/Filament/Resources/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource.php
@@ -70,9 +70,10 @@ class ReconciliationResource extends Resource
 
                 Tables\Columns\TextColumn::make('description')
                     ->label('Description')
-                    ->limit(40)
+                    ->limit(30)
                     ->tooltip(fn (Transaction $record): string => $record->description)
                     ->searchable()
+                    ->wrap()
                     ->description(function (Transaction $record): ?string {
                         $invoiceTxn = $record->reconciliationMatchesAsBank->first()?->invoiceTransaction;
 
@@ -109,6 +110,8 @@ class ReconciliationResource extends Resource
                     ->label('Confirm')
                     ->icon('heroicon-o-check-circle')
                     ->color('success')
+                    ->button()
+                    ->size('sm')
                     ->action(function (Transaction $record) {
                         $match = $record->reconciliationMatchesAsBank()->suggested()->firstOrFail();
 
@@ -117,6 +120,23 @@ class ReconciliationResource extends Resource
                         Notification::make()
                             ->title('Suggestion confirmed')
                             ->success()
+                            ->send();
+                    })
+                    ->visible(fn (Transaction $record) => $record->reconciliationMatchesAsBank->isNotEmpty()),
+
+                Actions\Action::make('reject_suggestions')
+                    ->label('Reject')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->button()
+                    ->size('sm')
+                    ->requiresConfirmation()
+                    ->action(function (Transaction $record) {
+                        app(ReconciliationService::class)->rejectAllSuggestions($record);
+
+                        Notification::make()
+                            ->title('All suggestions rejected')
+                            ->warning()
                             ->send();
                     })
                     ->visible(fn (Transaction $record) => $record->reconciliationMatchesAsBank->isNotEmpty()),
@@ -156,21 +176,6 @@ class ReconciliationResource extends Resource
                                 ->send();
                         })
                         ->visible(fn (Transaction $record) => $record->reconciliation_status !== ReconciliationStatus::Matched),
-
-                    Actions\Action::make('reject_suggestions')
-                        ->label('Reject All')
-                        ->icon('heroicon-o-x-circle')
-                        ->color('danger')
-                        ->requiresConfirmation()
-                        ->action(function (Transaction $record) {
-                            app(ReconciliationService::class)->rejectAllSuggestions($record);
-
-                            Notification::make()
-                                ->title('All suggestions rejected')
-                                ->warning()
-                                ->send();
-                        })
-                        ->visible(fn (Transaction $record) => $record->reconciliationMatchesAsBank->isNotEmpty()),
                 ]),
             ])
             ->toolbarActions([

--- a/tests/Feature/Filament/ReconciliationPageTest.php
+++ b/tests/Feature/Filament/ReconciliationPageTest.php
@@ -230,6 +230,8 @@ describe('Reconciliation Page', function () {
         ]);
 
         livewire(ListReconciliation::class)
+            ->assertTableActionExists('confirm_suggestion', record: $bankTxn)
+            ->assertTableActionVisible('confirm_suggestion', $bankTxn)
             ->callTableAction('confirm_suggestion', $bankTxn);
 
         $match->refresh();
@@ -265,12 +267,47 @@ describe('Reconciliation Page', function () {
         ]);
 
         livewire(ListReconciliation::class)
+            ->assertTableActionExists('reject_suggestions', record: $bankTxn)
+            ->assertTableActionVisible('reject_suggestions', $bankTxn)
             ->callTableAction('reject_suggestions', $bankTxn);
 
         $match1->refresh();
         $match2->refresh();
         expect($match1->status)->toBe(MatchStatus::Rejected)
             ->and($match2->status)->toBe(MatchStatus::Rejected);
+    });
+
+    it('displays confirm and reject all inline table actions only when suggestions exist', function () {
+        $bankFile = ImportedFile::factory()->completed()->create([
+            'statement_type' => StatementType::Bank,
+        ]);
+        $invoiceFile = ImportedFile::factory()->completed()->create([
+            'statement_type' => StatementType::Invoice,
+        ]);
+
+        $bankTxnWithSuggestion = Transaction::factory()->debit(5000.00)->create([
+            'imported_file_id' => $bankFile->id,
+            'reconciliation_status' => ReconciliationStatus::Unreconciled,
+        ]);
+        $bankTxnWithoutSuggestion = Transaction::factory()->debit(2000.00)->create([
+            'imported_file_id' => $bankFile->id,
+            'reconciliation_status' => ReconciliationStatus::Unreconciled,
+        ]);
+
+        ReconciliationMatch::factory()->suggested()->create([
+            'bank_transaction_id' => $bankTxnWithSuggestion->id,
+            'invoice_transaction_id' => Transaction::factory()->create([
+                'imported_file_id' => $invoiceFile->id,
+            ])->id,
+        ]);
+
+        livewire(ListReconciliation::class)
+            ->assertTableActionExists('confirm_suggestion', record: $bankTxnWithSuggestion)
+            ->assertTableActionVisible('confirm_suggestion', $bankTxnWithSuggestion)
+            ->assertTableActionExists('reject_suggestions', record: $bankTxnWithSuggestion)
+            ->assertTableActionVisible('reject_suggestions', $bankTxnWithSuggestion)
+            ->assertTableActionHidden('confirm_suggestion', $bankTxnWithoutSuggestion)
+            ->assertTableActionHidden('reject_suggestions', $bankTxnWithoutSuggestion);
     });
 
     it('can bulk confirm selected suggested matches', function () {


### PR DESCRIPTION
## Summary
- Moved the `Reject All` action out of the ActionGroup dropdown so it is displayed inline alongside the `Confirm` button
- Replaced the icon-only layout with text buttons and sized them to `'sm'` for a compact look
- Enabled text-wrapping on the Description column to prevent horizontal page scrolling


## Test plan
- [x] `can render the reconciliation page` — asserts the page renders correctly with the new layout changes
- [x] Full reconciliation page suite: 19 tests, 53 assertions, all passing
- [x] Pint: Pass 
Closes #268