### PR TITLE
Fix/281 block account head deletion

### DIFF
--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -135,8 +135,48 @@ class AccountHeadResource extends Resource
             ])
             ->actions([
                 Actions\EditAction::make(),
-                Actions\DeleteAction::make(),
-                Actions\ForceDeleteAction::make(),
+                Actions\DeleteAction::make()
+                    ->before(function (AccountHead $record, Actions\DeleteAction $action) {
+                        $count = $record->transactions()->count();
+                        if ($count > 0) {
+                            Notification::make()
+                                ->danger()
+                                ->title("Cannot delete — {$count} transactions are mapped to this head. Reassign them first.")
+                                ->actions([
+                                    \Filament\Actions\Action::make('view_transactions')
+                                        ->label('View Transactions')
+                                        ->url(\App\Filament\Resources\TransactionResource::getUrl('index', [
+                                            'tableFilters' => [
+                                                'account_head_id' => ['value' => $record->id],
+                                            ],
+                                        ]))
+                                        ->button(),
+                                ])
+                                ->send();
+                            $action->cancel();
+                        }
+                    }),
+                Actions\ForceDeleteAction::make()
+                    ->before(function (AccountHead $record, Actions\ForceDeleteAction $action) {
+                        $count = $record->transactions()->count();
+                        if ($count > 0) {
+                            Notification::make()
+                                ->danger()
+                                ->title("Cannot delete — {$count} transactions are mapped to this head. Reassign them first.")
+                                ->actions([
+                                    \Filament\Actions\Action::make('view_transactions')
+                                        ->label('View Transactions')
+                                        ->url(\App\Filament\Resources\TransactionResource::getUrl('index', [
+                                            'tableFilters' => [
+                                                'account_head_id' => ['value' => $record->id],
+                                            ],
+                                        ]))
+                                        ->button(),
+                                ])
+                                ->send();
+                            $action->cancel();
+                        }
+                    }),
                 Actions\RestoreAction::make(),
             ])
             ->bulkActions([

--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -141,7 +141,7 @@ class AccountHeadResource extends Resource
                         if ($count > 0) {
                             Notification::make()
                                 ->danger()
-                                ->title("Cannot delete — {$count} transactions are mapped to this head. Reassign them first.")
+                                ->title("Cannot delete — " . ($count === 1 ? "1 transaction is" : "{$count} transactions are") . " mapped to this head. Reassign them first.")
                                 ->actions([
                                     \Filament\Actions\Action::make('view_transactions')
                                         ->label('View Transactions')
@@ -162,7 +162,7 @@ class AccountHeadResource extends Resource
                         if ($count > 0) {
                             Notification::make()
                                 ->danger()
-                                ->title("Cannot delete — {$count} transactions are mapped to this head. Reassign them first.")
+                                ->title("Cannot delete — " . ($count === 1 ? "1 transaction is" : "{$count} transactions are") . " mapped to this head. Reassign them first.")
                                 ->actions([
                                     \Filament\Actions\Action::make('view_transactions')
                                         ->label('View Transactions')

--- a/app/Models/AccountHead.php
+++ b/app/Models/AccountHead.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-use App\Services\AggregateService;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,30 +17,6 @@ class AccountHead extends Model
     use LogsActivity;
     use SoftDeletes;
 
-    protected static function booted(): void
-    {
-        static::deleting(function (AccountHead $head) {
-            if (! $head->isForceDeleting()) {
-                $yearMonths = Transaction::where('account_head_id', $head->id)
-                    ->distinct()
-                    ->selectRaw("TO_CHAR(date, 'YYYY-MM') AS year_month")
-                    ->pluck('year_month');
-
-                if ($yearMonths->isEmpty()) {
-                    return;
-                }
-
-                Transaction::withoutEvents(function () use ($head) {
-                    $head->transactions()->update(['account_head_id' => null]);
-                });
-
-                $service = app(AggregateService::class);
-                foreach ($yearMonths as $yearMonth) {
-                    $service->rebuild($head->company_id, $yearMonth);
-                }
-            }
-        });
-    }
 
     protected $fillable = [
         'company_id',

--- a/tests/Feature/Filament/AccountHeadResourceTest.php
+++ b/tests/Feature/Filament/AccountHeadResourceTest.php
@@ -215,4 +215,30 @@ describe('AccountHeadResource', function () {
 
         expect(AccountHead::where('name', 'Bank Charges')->count())->toBe(1);
     });
+
+    it('blocks deletion of account head when transactions are mapped', function () {
+        $head = AccountHead::factory()->create();
+        \App\Models\Transaction::factory()->mapped($head)->count(3)->create();
+
+        livewire(ListAccountHeads::class)
+            ->callTableAction('delete', $head)
+            ->assertSuccessful()
+            ->assertNotified('Cannot delete — 3 transactions are mapped to this head. Reassign them first.');
+
+        expect(AccountHead::find($head->id))->not->toBeNull();
+    });
+
+    it('blocks force deletion of account head when transactions are mapped', function () {
+        $head = AccountHead::factory()->create();
+        $head->delete(); // Needs to be soft-deleted to run forceDelete action in most Filament setups
+        \App\Models\Transaction::factory()->mapped($head)->count(2)->create();
+
+        livewire(ListAccountHeads::class)
+            ->filterTable('trashed', true)
+            ->callTableAction('forceDelete', $head)
+            ->assertSuccessful()
+            ->assertNotified('Cannot delete — 2 transactions are mapped to this head. Reassign them first.');
+
+        expect(AccountHead::withTrashed()->find($head->id))->not->toBeNull();
+    });
 });

--- a/tests/Feature/Models/AccountHeadTest.php
+++ b/tests/Feature/Models/AccountHeadTest.php
@@ -82,73 +82,7 @@ describe('AccountHead::fullPath', function () {
     });
 });
 
-describe('AccountHead soft-delete cascade', function () {
-    beforeEach(function () {
-        asUser();
-    });
 
-    it('nulls account_head_id on mapped transactions when soft-deleted', function () {
-        $head = AccountHead::factory()->create();
-        $txn = Transaction::factory()->mapped($head)->create();
-
-        $head->delete();
-
-        expect($txn->fresh()->account_head_id)->toBeNull();
-    });
-
-    it('updates TransactionAggregate when soft-deleting an account head', function () {
-        $company = tenant();
-        $head = AccountHead::factory()->create(['company_id' => $company->id]);
-
-        Transaction::factory()->mapped($head)->debit(5000)->create([
-            'company_id' => $company->id,
-            'date' => '2025-04-15',
-        ]);
-
-        // Aggregate should have the head assigned
-        expect(TransactionAggregate::where('company_id', $company->id)
-            ->where('account_head_id', $head->id)
-            ->exists()
-        )->toBeTrue();
-
-        $head->delete();
-
-        // Aggregate should now be under null head
-        expect(TransactionAggregate::where('company_id', $company->id)
-            ->where('account_head_id', $head->id)
-            ->exists()
-        )->toBeFalse()
-            ->and(TransactionAggregate::where('company_id', $company->id)
-                ->whereNull('account_head_id')
-                ->exists()
-            )->toBeTrue();
-    });
-
-    it('does not re-map transactions when an account head is restored', function () {
-        $head = AccountHead::factory()->create();
-        $txn = Transaction::factory()->mapped($head)->create();
-
-        $head->delete();
-
-        // After soft-delete: transaction is unmapped
-        expect($txn->fresh()->account_head_id)->toBeNull();
-
-        $head->restore();
-
-        // After restore: transaction remains unmapped
-        expect($txn->fresh()->account_head_id)->toBeNull();
-    });
-
-    it('does not null transactions when force-deleted (DB cascade handles it)', function () {
-        $head = AccountHead::factory()->create();
-        $txn = Transaction::factory()->mapped($head)->create();
-
-        $head->forceDelete();
-
-        // DB nullOnDelete fires — transaction's account_head_id is nulled by PostgreSQL
-        expect($txn->fresh()->account_head_id)->toBeNull();
-    });
-});
 
 describe('AccountHead relationships', function () {
     it('has children', function () {


### PR DESCRIPTION
## Summary

- The `AccountHead` model previously had a silent `deleting` hook that automatically nulled out `account_head_id` on every mapped transaction when an account head was deleted, completely destroying all AI and manual mapping work without warning.
- Removed the silent `deleting` hook from `AccountHead::booted()`.
- Added a `before()` guard to `DeleteAction` and `ForceDeleteAction` in `AccountHeadResource.php`. If mapped transactions exist, it halts the deletion (`$action->cancel()`) and displays a red notification.
- The notification dynamically checks the transaction count (e.g., "1 transaction is" vs "X transactions are") and includes an action button that takes the user to the Transactions page pre-filtered to that specific account head so they can reassign them.

## Test plan

- [ ] 2 new integration tests pass in `AccountHeadResourceTest`: verifies that both `DeleteAction` and `ForceDeleteAction` are successfully blocked, the action is canceled, and the correct notification is fired when transactions are mapped.
- [ ] The `AccountHeadTest` unit tests pass, confirming the model relationships and that the old soft-delete logic was successfully removed.
- [ ] **Manual Verification:** Map exactly 1 transaction to an Account Head and click Delete. Confirm the notification says "Cannot delete — 1 transaction is mapped...". Map 2 transactions and confirm it pluralizes to "2 transactions are mapped...". Click the "View Transactions" button to ensure it routes you correctly.

Closes #281
