### PR TITLE
fix(reconciliation): reject action correctly un-matches confirmed transactions

### DIFF
--- a/app/Services/Reconciliation/ReconciliationService.php
+++ b/app/Services/Reconciliation/ReconciliationService.php
@@ -543,13 +543,36 @@ class ReconciliationService
     }
 
     /**
-     * Reject all pending suggestions for a bank transaction.
+     * Reject all pending suggestions and confirmed matches for a bank transaction.
      */
     public function rejectAllSuggestions(Transaction $bankTxn): int
     {
-        return $bankTxn->reconciliationMatchesAsBank()
-            ->suggested()
-            ->update(['status' => MatchStatus::Rejected]);
+        return DB::transaction(function () use ($bankTxn) {
+            $suggestedUpdated = $bankTxn->reconciliationMatchesAsBank()
+                ->suggested()
+                ->update(['status' => MatchStatus::Rejected]);
+
+            $confirmedMatches = $bankTxn->reconciliationMatchesAsBank()
+                ->confirmed()
+                ->with(['bankTransaction', 'invoiceTransaction'])
+                ->get();
+
+            $confirmedUpdated = $confirmedMatches->count();
+
+            foreach ($confirmedMatches as $match) {
+                $match->update(['status' => MatchStatus::Rejected]);
+
+                if ($match->bankTransaction) {
+                    $match->bankTransaction->update(['reconciliation_status' => ReconciliationStatus::Unreconciled]);
+                }
+
+                if ($match->invoiceTransaction) {
+                    $match->invoiceTransaction->update(['reconciliation_status' => ReconciliationStatus::Unreconciled]);
+                }
+            }
+
+            return $suggestedUpdated + $confirmedUpdated;
+        });
     }
 
     /**

--- a/tests/Feature/Services/ReconciliationServiceTest.php
+++ b/tests/Feature/Services/ReconciliationServiceTest.php
@@ -855,4 +855,66 @@ describe('ReconciliationService', function () {
                 ->and($match->notes)->toBe('Wrong vendor');
         });
     });
+
+    describe('rejectAllSuggestions', function () {
+        it('rejects all suggested matches for a bank transaction', function () {
+            $bankTxn = Transaction::factory()->create([
+                'imported_file_id' => $this->bankFile->id,
+            ]);
+
+            $invoice1 = Transaction::factory()->create([
+                'imported_file_id' => $this->invoiceFile->id,
+            ]);
+
+            $invoice2 = Transaction::factory()->create([
+                'imported_file_id' => $this->invoiceFile->id,
+            ]);
+
+            $match1 = ReconciliationMatch::factory()->suggested()->create([
+                'bank_transaction_id' => $bankTxn->id,
+                'invoice_transaction_id' => $invoice1->id,
+            ]);
+
+            $match2 = ReconciliationMatch::factory()->suggested()->create([
+                'bank_transaction_id' => $bankTxn->id,
+                'invoice_transaction_id' => $invoice2->id,
+            ]);
+
+            $this->service->rejectAllSuggestions($bankTxn);
+
+            $match1->refresh();
+            $match2->refresh();
+
+            expect($match1->status)->toBe(MatchStatus::Rejected)
+                ->and($match2->status)->toBe(MatchStatus::Rejected);
+        });
+
+        it('rejects confirmed matches and reverts transaction statuses to unreconciled', function () {
+            $bankTxn = Transaction::factory()->create([
+                'imported_file_id' => $this->bankFile->id,
+                'reconciliation_status' => ReconciliationStatus::Matched,
+            ]);
+
+            $invoiceTxn = Transaction::factory()->create([
+                'imported_file_id' => $this->invoiceFile->id,
+                'reconciliation_status' => ReconciliationStatus::Matched,
+            ]);
+
+            $match = ReconciliationMatch::factory()->create([
+                'bank_transaction_id' => $bankTxn->id,
+                'invoice_transaction_id' => $invoiceTxn->id,
+                'status' => MatchStatus::Confirmed,
+            ]);
+
+            $this->service->rejectAllSuggestions($bankTxn);
+
+            $match->refresh();
+            $bankTxn->refresh();
+            $invoiceTxn->refresh();
+
+            expect($match->status)->toBe(MatchStatus::Rejected)
+                ->and($bankTxn->reconciliation_status)->toBe(ReconciliationStatus::Unreconciled)
+                ->and($invoiceTxn->reconciliation_status)->toBe(ReconciliationStatus::Unreconciled);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- `ReconciliationService::rejectAllSuggestions()` only targeted matches in the `suggested` state, causing the reject action to silently fail when trying to reject an already `Matched` transaction (where matches are `confirmed`).
- Updated the `rejectAllSuggestions()` query to additionally find `confirmed` matches, set their status to rejected, and revert the `reconciliation_status` on both the bank and invoice transactions back to `Unreconciled`.
- Wrapped the operations in a `DB::transaction()` to match existing patterns and ensure atomicity so partial updates do not occur.

## Test plan

- [ ] 2 new integration tests pass: `it rejects all suggested matches for a bank transaction` and `it rejects confirmed matches and reverts transaction statuses to unreconciled`
- [ ] All tests in `ReconciliationServiceTest` pass
- [ ] Run reconciliation, confirm a suggestion, select the newly `Matched` transaction from the table, and click "Reject Selected" (or click "Reject" inline) — confirm the bank transaction and the matched invoice transaction both successfully revert back to `Unreconciled`

Closes #269