### PR TITLE
fix(authorization): prevent Viewer role from bulk deleting financial resources (#292)

### DIFF
--- a/app/Policies/AccountHeadPolicy.php
+++ b/app/Policies/AccountHeadPolicy.php
@@ -31,4 +31,9 @@ class AccountHeadPolicy
     {
         return $user->currentRole()?->canWrite() ?? false;
     }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->currentRole()?->canWrite() ?? false;
+    }
 }

--- a/app/Policies/HeadMappingPolicy.php
+++ b/app/Policies/HeadMappingPolicy.php
@@ -31,4 +31,9 @@ class HeadMappingPolicy
     {
         return $user->currentRole()?->canWrite() ?? false;
     }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->currentRole()?->canWrite() ?? false;
+    }
 }

--- a/app/Policies/ImportedFilePolicy.php
+++ b/app/Policies/ImportedFilePolicy.php
@@ -31,4 +31,9 @@ class ImportedFilePolicy
     {
         return $user->currentRole()?->canWrite() ?? false;
     }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->currentRole()?->canWrite() ?? false;
+    }
 }

--- a/app/Policies/TransactionPolicy.php
+++ b/app/Policies/TransactionPolicy.php
@@ -31,4 +31,9 @@ class TransactionPolicy
     {
         return $user->currentRole()?->canWrite() ?? false;
     }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->currentRole()?->canWrite() ?? false;
+    }
 }

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -38,6 +38,15 @@ describe('Authorization Policies', function () {
 
             expect($policy->delete($admin, $head))->toBeTrue();
         });
+
+        it('can bulk delete resources', function () {
+            $admin = auth()->user();
+
+            expect((new AccountHeadPolicy)->deleteAny($admin))->toBeTrue()
+                ->and((new ImportedFilePolicy)->deleteAny($admin))->toBeTrue()
+                ->and((new TransactionPolicy)->deleteAny($admin))->toBeTrue()
+                ->and((new HeadMappingPolicy)->deleteAny($admin))->toBeTrue();
+        });
     });
 
     describe('Accountant role', function () {
@@ -75,6 +84,15 @@ describe('Authorization Policies', function () {
 
             expect((new AccountHeadPolicy)->delete($accountant, $head))->toBeTrue();
         });
+
+        it('can bulk delete resources', function () {
+            $accountant = auth()->user();
+
+            expect((new AccountHeadPolicy)->deleteAny($accountant))->toBeTrue()
+                ->and((new ImportedFilePolicy)->deleteAny($accountant))->toBeTrue()
+                ->and((new TransactionPolicy)->deleteAny($accountant))->toBeTrue()
+                ->and((new HeadMappingPolicy)->deleteAny($accountant))->toBeTrue();
+        });
     });
 
     describe('Viewer role', function () {
@@ -111,6 +129,15 @@ describe('Authorization Policies', function () {
             $head = AccountHead::factory()->create();
 
             expect((new AccountHeadPolicy)->delete($viewer, $head))->toBeFalse();
+        });
+
+        it('cannot bulk delete resources', function () {
+            $viewer = auth()->user();
+
+            expect((new AccountHeadPolicy)->deleteAny($viewer))->toBeFalse()
+                ->and((new ImportedFilePolicy)->deleteAny($viewer))->toBeFalse()
+                ->and((new TransactionPolicy)->deleteAny($viewer))->toBeFalse()
+                ->and((new HeadMappingPolicy)->deleteAny($viewer))->toBeFalse();
         });
     });
 


### PR DESCRIPTION
## Summary

- While single-item deletion was correctly protected by `delete()` in policy classes, Filament's `DeleteBulkAction` relies on `deleteAny()`, which was missing across four core financial resources (`Transaction`, `AccountHead`, `ImportedFile`, and `HeadMapping`).
- Due to the missing method, Filament's bulk action authorization check defaulted to allowed (failed open), enabling read-only **Viewer** accounts to destroy records.
- Added `deleteAny(User $user)` to all four model policies, ensuring it checks `$user->currentRole()?->canWrite() ?? false;`.
- Viewers are now properly blocked from seeing or executing bulk deletions, while Admins and Accountants retain full bulk deletion privileges.

## Test plan

- [x] All 15 tests in `AuthorizationTest` suite pass successfully (36 assertions), including new tests for bulk delete authorization
- [x] Confirmed zero regressions across all 121 project files via static analysis (`phpstan analyse`) and code formatting (`pint`)
- [x] Logged in as a **Viewer** and verified that the "Delete selected" bulk action button is hidden/blocked across Transactions, Account Heads, Imported Files, and Mapping Rules
- [x] Logged in as an **Admin/Accountant** and confirmed that bulk deletion remains functional

Closes #292
