### PR TITLE
feat(mailing-system): add dashboard widget and modernize inbox UI

### DIFF
--- a/app/Filament/Resources/InboundEmailResource.php
+++ b/app/Filament/Resources/InboundEmailResource.php
@@ -76,7 +76,7 @@ class InboundEmailResource extends Resource
                 Tables\Columns\TextColumn::make('from_address')
                     ->label('Email & Subject')
                     ->weight(FontWeight::Bold)
-                    ->description(fn (InboundEmail $record): ?string => str($record->subject)->limit(50)->toString())
+                    ->description(fn (InboundEmail $record): string => str($record->subject)->limit(50)->toString())
                     ->searchable(['from_address', 'subject']),
 
                 Tables\Columns\TextColumn::make('status')

--- a/app/Filament/Resources/InboundEmailResource.php
+++ b/app/Filament/Resources/InboundEmailResource.php
@@ -67,17 +67,14 @@ class InboundEmailResource extends Resource
                 Tables\Columns\TextColumn::make('received_at')
                     ->label('Date')
                     ->dateTime('d M Y H:i')
-                    ->sortable(),
+                    ->sortable()
+                    ->icon('heroicon-m-calendar'),
 
                 Tables\Columns\TextColumn::make('from_address')
-                    ->label('From')
-                    ->limit(40)
-                    ->searchable(),
-
-                Tables\Columns\TextColumn::make('subject')
-                    ->label('Subject')
-                    ->limit(50)
-                    ->searchable(),
+                    ->label('Email & Subject')
+                    ->weight(\Filament\Support\Enums\FontWeight::Bold)
+                    ->description(fn (InboundEmail $record): ?string => str($record->subject)->limit(50))
+                    ->searchable(['from_address', 'subject']),
 
                 Tables\Columns\TextColumn::make('status')
                     ->label('Status')
@@ -85,13 +82,18 @@ class InboundEmailResource extends Resource
 
                 Tables\Columns\TextColumn::make('attachment_count')
                     ->label('Attachments')
-                    ->alignCenter(),
+                    ->alignCenter()
+                    ->icon('heroicon-m-paper-clip'),
 
                 Tables\Columns\TextColumn::make('processed_count')
                     ->label('Processed')
-                    ->alignCenter(),
+                    ->alignCenter()
+                    ->color('success'),
             ])
             ->defaultSort('received_at', 'desc')
+            ->emptyStateHeading('No inbound emails yet')
+            ->emptyStateDescription('Statements sent to your dedicated email address will automatically appear here.')
+            ->emptyStateIcon('heroicon-o-inbox')
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
                     ->options(InboundEmailStatus::class),
@@ -106,6 +108,11 @@ class InboundEmailResource extends Resource
                             ->when($data['from'], fn (Builder $q, string $date) => $q->whereDate('received_at', '>=', $date))
                             ->when($data['until'], fn (Builder $q, string $date) => $q->whereDate('received_at', '<=', $date));
                     }),
+            ])
+            ->actions([
+                \Filament\Actions\ActionGroup::make([
+                    \Filament\Actions\ViewAction::make(),
+                ])->icon('heroicon-m-ellipsis-vertical'),
             ])
             ->recordUrl(fn (InboundEmail $record): string => static::getUrl('view', ['record' => $record]));
     }

--- a/app/Filament/Resources/InboundEmailResource.php
+++ b/app/Filament/Resources/InboundEmailResource.php
@@ -8,10 +8,13 @@ use App\Filament\Resources\InboundEmailResource\Pages;
 use App\Models\Company;
 use App\Models\InboundEmail;
 use BackedEnum;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\ViewAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\DatePicker;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
+use Filament\Support\Enums\FontWeight;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -72,8 +75,8 @@ class InboundEmailResource extends Resource
 
                 Tables\Columns\TextColumn::make('from_address')
                     ->label('Email & Subject')
-                    ->weight(\Filament\Support\Enums\FontWeight::Bold)
-                    ->description(fn (InboundEmail $record): ?string => str($record->subject)->limit(50))
+                    ->weight(FontWeight::Bold)
+                    ->description(fn (InboundEmail $record): ?string => str($record->subject)->limit(50)->toString())
                     ->searchable(['from_address', 'subject']),
 
                 Tables\Columns\TextColumn::make('status')
@@ -110,8 +113,8 @@ class InboundEmailResource extends Resource
                     }),
             ])
             ->actions([
-                \Filament\Actions\ActionGroup::make([
-                    \Filament\Actions\ViewAction::make(),
+                ActionGroup::make([
+                    ViewAction::make(),
                 ])->icon('heroicon-m-ellipsis-vertical'),
             ])
             ->recordUrl(fn (InboundEmail $record): string => static::getUrl('view', ['record' => $record]));

--- a/app/Filament/Widgets/MailingSystemWidget.php
+++ b/app/Filament/Widgets/MailingSystemWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets;
 
 use App\Enums\InboundEmailStatus;
 use App\Filament\Resources\InboundEmailResource;
+use App\Models\Company;
 use App\Models\InboundEmail;
 use Filament\Facades\Filament;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
@@ -14,9 +15,16 @@ class MailingSystemWidget extends BaseWidget
 {
     protected static ?int $sort = 3;
 
+    public static function canView(): bool
+    {
+        return auth()->user()->currentRole()?->canManageTeam() ?? false;
+    }
+
     protected function getStats(): array
     {
-        $tenantId = Filament::getTenant()?->id;
+        /** @var Company|null $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant?->id;
 
         if (! $tenantId) {
             return [];

--- a/app/Filament/Widgets/MailingSystemWidget.php
+++ b/app/Filament/Widgets/MailingSystemWidget.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\InboundEmailStatus;
+use App\Filament\Resources\InboundEmailResource;
+use App\Models\InboundEmail;
+use Filament\Facades\Filament;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
+
+class MailingSystemWidget extends BaseWidget
+{
+    protected static ?int $sort = 3;
+
+    protected function getStats(): array
+    {
+        $tenantId = Filament::getTenant()?->id;
+
+        if (! $tenantId) {
+            return [];
+        }
+
+        $baseQuery = InboundEmail::where('company_id', $tenantId);
+
+        $recentEmails = (clone $baseQuery)
+            ->where('received_at', '>=', Carbon::now()->subDays(7))
+            ->count();
+
+        $rejectedEmails = (clone $baseQuery)
+            ->where('status', InboundEmailStatus::Rejected)
+            ->count();
+
+        $noAttachments = (clone $baseQuery)
+            ->where('status', InboundEmailStatus::NoAttachments)
+            ->count();
+
+        $url = InboundEmailResource::getUrl('index');
+
+        return [
+            Stat::make('Emails Received (7 Days)', $recentEmails)
+                ->description('Inbound statements')
+                ->icon('heroicon-o-envelope')
+                ->color('primary')
+                ->url($url),
+
+            Stat::make('Rejected', $rejectedEmails)
+                ->description('Failed processing')
+                ->icon('heroicon-o-x-circle')
+                ->color($rejectedEmails > 0 ? 'danger' : 'success')
+                ->url($url),
+
+            Stat::make('No Attachments', $noAttachments)
+                ->description('Emails with no files')
+                ->icon('heroicon-o-paper-clip')
+                ->color($noAttachments > 0 ? 'warning' : 'success')
+                ->url($url),
+        ];
+    }
+}

--- a/tests/Feature/Filament/InboundEmailResourceTest.php
+++ b/tests/Feature/Filament/InboundEmailResourceTest.php
@@ -61,6 +61,20 @@ describe('InboundEmail Resource', function () {
             livewire(ListInboundEmails::class)
                 ->assertCanNotSeeTableRecords([$otherEmail]);
         });
+
+        it('renders the subject as the description in from_address column', function () {
+            asUser(role: UserRole::Admin);
+            $company = tenant();
+
+            $email = InboundEmail::factory()->create([
+                'company_id' => $company->id,
+                'from_address' => 'sender@example.com',
+                'subject' => 'Important Monthly Statement',
+            ]);
+
+            livewire(ListInboundEmails::class)
+                ->assertTableColumnHasDescription('from_address', 'Important Monthly Statement', $email);
+        });
     });
 
     describe('Filters', function () {

--- a/tests/Feature/Filament/MailingSystemWidgetTest.php
+++ b/tests/Feature/Filament/MailingSystemWidgetTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Enums\InboundEmailStatus;
+use App\Filament\Widgets\MailingSystemWidget;
+use App\Models\Company;
+use App\Models\InboundEmail;
+use Illuminate\Support\Carbon;
+
+use function Pest\Livewire\livewire;
+
+describe('MailingSystemWidget', function () {
+    beforeEach(function () {
+        asUser();
+    });
+
+    it('can render', function () {
+        livewire(MailingSystemWidget::class)->assertSuccessful();
+    });
+
+    it('shows correct counts and isolates tenant data', function () {
+        $company = tenant();
+
+        // Emails for the active company
+        InboundEmail::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'received_at' => Carbon::now()->subDays(2), // within 7 days
+        ]);
+
+        InboundEmail::factory()->create([
+            'company_id' => $company->id,
+            'received_at' => Carbon::now()->subDays(10), // older than 7 days
+        ]);
+
+        InboundEmail::factory()->create([
+            'company_id' => $company->id,
+            'received_at' => Carbon::now()->subDays(2),
+            'status' => InboundEmailStatus::Rejected,
+        ]);
+
+        InboundEmail::factory()->count(3)->create([
+            'company_id' => $company->id,
+            'received_at' => Carbon::now()->subDays(2),
+            'status' => InboundEmailStatus::NoAttachments,
+        ]);
+
+        // Other company emails (should be ignored completely)
+        $otherCompany = Company::factory()->create();
+        InboundEmail::factory()->count(5)->create([
+            'company_id' => $otherCompany->id,
+            'received_at' => Carbon::now(),
+            'status' => InboundEmailStatus::Rejected,
+        ]);
+
+        // Expected counts for active company:
+        // recentEmails = 2 + 1 + 3 = 6
+        // rejectedEmails = 1
+        // noAttachments = 3
+
+        livewire(MailingSystemWidget::class)
+            ->assertSee('Emails Received (7 Days)')
+            ->assertSeeHtml('6')
+            ->assertSee('Rejected')
+            ->assertSeeHtml('1')
+            ->assertSee('No Attachments')
+            ->assertSeeHtml('3');
+    });
+});

--- a/tests/Feature/Filament/MailingSystemWidgetTest.php
+++ b/tests/Feature/Filament/MailingSystemWidgetTest.php
@@ -56,12 +56,19 @@ describe('MailingSystemWidget', function () {
         // rejectedEmails = 1
         // noAttachments = 3
 
-        livewire(MailingSystemWidget::class)
-            ->assertSee('Emails Received (7 Days)')
-            ->assertSeeHtml('6')
-            ->assertSee('Rejected')
-            ->assertSeeHtml('1')
-            ->assertSee('No Attachments')
-            ->assertSeeHtml('3');
+        $widget = new MailingSystemWidget();
+        $method = new ReflectionMethod($widget, 'getStats');
+        $stats = $method->invoke($widget);
+
+        expect($stats)->toHaveCount(3);
+        
+        expect($stats[0]->getLabel())->toBe('Emails Received (7 Days)');
+        expect($stats[0]->getValue())->toBe(6);
+
+        expect($stats[1]->getLabel())->toBe('Rejected');
+        expect($stats[1]->getValue())->toBe(1);
+
+        expect($stats[2]->getLabel())->toBe('No Attachments');
+        expect($stats[2]->getValue())->toBe(3);
     });
 });

--- a/tests/Feature/Filament/MailingSystemWidgetTest.php
+++ b/tests/Feature/Filament/MailingSystemWidgetTest.php
@@ -1,20 +1,33 @@
 <?php
 
 use App\Enums\InboundEmailStatus;
+use App\Enums\UserRole;
 use App\Filament\Widgets\MailingSystemWidget;
 use App\Models\Company;
 use App\Models\InboundEmail;
+use App\Models\User;
 use Illuminate\Support\Carbon;
-
-use function Pest\Livewire\livewire;
 
 describe('MailingSystemWidget', function () {
     beforeEach(function () {
         asUser();
     });
 
-    it('can render', function () {
-        livewire(MailingSystemWidget::class)->assertSuccessful();
+    describe('Access control', function () {
+        it('renders for authorized users', function () {
+            asUser(role: UserRole::Admin);
+            expect(MailingSystemWidget::canView())->toBeTrue();
+        });
+
+        it('denies access to viewer users', function () {
+            asUser(User::factory()->viewer()->create(), UserRole::Viewer);
+            expect(MailingSystemWidget::canView())->toBeFalse();
+        });
+
+        it('denies access to accountant users', function () {
+            asUser(User::factory()->accountant()->create(), UserRole::Accountant);
+            expect(MailingSystemWidget::canView())->toBeFalse();
+        });
     });
 
     it('shows correct counts and isolates tenant data', function () {
@@ -56,12 +69,12 @@ describe('MailingSystemWidget', function () {
         // rejectedEmails = 1
         // noAttachments = 3
 
-        $widget = new MailingSystemWidget();
+        $widget = new MailingSystemWidget;
         $method = new ReflectionMethod($widget, 'getStats');
         $stats = $method->invoke($widget);
 
         expect($stats)->toHaveCount(3);
-        
+
         expect($stats[0]->getLabel())->toBe('Emails Received (7 Days)');
         expect($stats[0]->getValue())->toBe(6);
 

--- a/tests/Feature/Filament/MailingSystemWidgetTest.php
+++ b/tests/Feature/Filament/MailingSystemWidgetTest.php
@@ -8,6 +8,8 @@ use App\Models\InboundEmail;
 use App\Models\User;
 use Illuminate\Support\Carbon;
 
+use function Pest\Livewire\livewire;
+
 describe('MailingSystemWidget', function () {
     beforeEach(function () {
         asUser();
@@ -30,58 +32,64 @@ describe('MailingSystemWidget', function () {
         });
     });
 
-    it('shows correct counts and isolates tenant data', function () {
+    it('renders the three stat cards through the public component surface', function () {
+        livewire(MailingSystemWidget::class)
+            ->assertSuccessful()
+            ->assertSee('Emails Received (7 Days)')
+            ->assertSee('Rejected')
+            ->assertSee('No Attachments');
+    });
+
+    it('renders tenant-scoped counts and excludes other companies', function () {
         $company = tenant();
 
-        // Emails for the active company
+        // Active company — within the 7-day window.
         InboundEmail::factory()->count(2)->create([
             'company_id' => $company->id,
-            'received_at' => Carbon::now()->subDays(2), // within 7 days
+            'received_at' => Carbon::now()->subDays(2),
         ]);
 
+        // Active company — older than 7 days, excluded from the recent count.
         InboundEmail::factory()->create([
             'company_id' => $company->id,
-            'received_at' => Carbon::now()->subDays(10), // older than 7 days
+            'received_at' => Carbon::now()->subDays(10),
         ]);
 
+        // Active company — a single rejected email within the window.
         InboundEmail::factory()->create([
             'company_id' => $company->id,
             'received_at' => Carbon::now()->subDays(2),
             'status' => InboundEmailStatus::Rejected,
         ]);
 
+        // Active company — no-attachment emails within the window.
         InboundEmail::factory()->count(3)->create([
             'company_id' => $company->id,
             'received_at' => Carbon::now()->subDays(2),
             'status' => InboundEmailStatus::NoAttachments,
         ]);
 
-        // Other company emails (should be ignored completely)
+        // Another company — must be excluded entirely from every stat. If tenant
+        // scoping leaked, the rejected count would jump from 1 to 9.
         $otherCompany = Company::factory()->create();
-        InboundEmail::factory()->count(5)->create([
+        InboundEmail::factory()->count(8)->create([
             'company_id' => $otherCompany->id,
-            'received_at' => Carbon::now(),
+            'received_at' => Carbon::now()->subDays(2),
             'status' => InboundEmailStatus::Rejected,
         ]);
 
-        // Expected counts for active company:
-        // recentEmails = 2 + 1 + 3 = 6
-        // rejectedEmails = 1
-        // noAttachments = 3
-
-        $widget = new MailingSystemWidget;
-        $method = new ReflectionMethod($widget, 'getStats');
-        $stats = $method->invoke($widget);
-
-        expect($stats)->toHaveCount(3);
-
-        expect($stats[0]->getLabel())->toBe('Emails Received (7 Days)');
-        expect($stats[0]->getValue())->toBe(6);
-
-        expect($stats[1]->getLabel())->toBe('Rejected');
-        expect($stats[1]->getValue())->toBe(1);
-
-        expect($stats[2]->getLabel())->toBe('No Attachments');
-        expect($stats[2]->getValue())->toBe(3);
+        // Expected for the active company:
+        //   recent (any status, within 7 days) = 2 + 1 rejected + 3 no-attachment = 6
+        //   rejected (all time)                = 1
+        //   no attachments (all time)          = 3
+        livewire(MailingSystemWidget::class)
+            ->assertSuccessful()
+            ->assertSeeText('Emails Received (7 Days)')
+            ->assertSeeText('6')
+            ->assertSeeText('No Attachments')
+            ->assertSeeText('3')
+            ->assertSeeText('Rejected')
+            // The other company's 8 rejected emails must not leak into any stat.
+            ->assertDontSeeText('9');
     });
 });


### PR DESCRIPTION
## Summary
The Mailing System previously required navigating through menus to view recent activity, and the data table was slightly cluttered with individual horizontal columns for the sender address and email subject. 

**Changes:**
- Created a new `MailingSystemWidget` using `StatsOverviewWidget` to instantly display recent "Emails Received (7 Days)", "Rejected", and "No Attachments" metrics directly on the main dashboard.
- Refactored `InboundEmailResource` table to merge the sender email and subject into a single, compact column utilizing Filament's `description()` helper.
- Implemented semantic empty states with an intuitive inbox icon and guidance messaging for fresh accounts.
- Consolidated row actions into a sleek vertical ellipsis dropdown (`ActionGroup`) to reduce visual noise.
- Ensured all new dashboard metrics strictly respect tenant isolation by scoping to the active `company_id`.

## Test plan

- [ ] Run `php artisan test` — confirm core widget auto-discovery layout tests continue to pass.
- [ ] **Manual:** In the UI, log in as an admin and navigate to the Dashboard. Verify the new Mailing System widget is visible and accurately reflects the metrics for the currently active company.
- [ ] **Manual:** Click on any stat card in the widget. Verify it flawlessly redirects to the Inbound Emails table view.
- [ ] **Manual:** Verify the Inbound Emails table correctly displays the new stacked Sender & Subject column, and successfully shows the new "Empty State" UI if a company has zero recorded emails.

closes #297