### PR TITLE
fix(ui): Ensure precise target highlighting for all Page Tours

### DIFF
--- a/app/Filament/Resources/AccountHeadResource.php
+++ b/app/Filament/Resources/AccountHeadResource.php
@@ -148,7 +148,8 @@ class AccountHeadResource extends Resource
             ])
             ->headerActions([
                 self::makeTallyImportAction('import_tally')
-                    ->color('info'),
+                    ->color('info')
+                    ->extraAttributes(['class' => 'tour-import-tally']),
             ])
             ->emptyStateHeading('No account heads yet')
             ->emptyStateDescription('Import your chart of accounts from Tally to get started. This enables automatic transaction matching.')

--- a/app/Filament/Resources/HeadMappingResource/Pages/ListHeadMappings.php
+++ b/app/Filament/Resources/HeadMappingResource/Pages/ListHeadMappings.php
@@ -16,7 +16,8 @@ class ListHeadMappings extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->icon('heroicon-o-plus'),
+                ->icon('heroicon-o-plus')
+                ->extraAttributes(['class' => 'tour-create-rule']),
             Action::make('page_tour')
                 ->label('Page Tour')
                 ->icon('heroicon-o-academic-cap')

--- a/app/Filament/Resources/ImportedFileResource.php
+++ b/app/Filament/Resources/ImportedFileResource.php
@@ -275,7 +275,8 @@ class ImportedFileResource extends Resource
             ->headerActions([
                 Actions\CreateAction::make()
                     ->label('Upload Statement')
-                    ->icon('heroicon-o-arrow-up-tray'),
+                    ->icon('heroicon-o-arrow-up-tray')
+                    ->extraAttributes(['class' => 'tour-upload-statement']),
             ])
             ->emptyStateHeading('No imported files yet')
             ->emptyStateDescription('Upload a bank statement, credit card statement, or invoice to get started.')

--- a/app/Filament/Resources/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource.php
@@ -256,6 +256,7 @@ class ReconciliationResource extends Resource
                     ->label('Run Reconciliation')
                     ->icon('heroicon-o-arrow-path')
                     ->color('primary')
+                    ->extraAttributes(['class' => 'tour-run-reconciliation'])
                     ->form([
                         Select::make('bank_file_id')
                             ->label('Bank / CC Statement File')

--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -166,10 +166,14 @@ class TransactionResource extends Resource
                         false: fn (Builder $query) => $query->where('mapping_type', '!=', MappingType::Unmapped),
                     ),
             ])
+            ->filtersTriggerAction(
+                fn ($action) => $action->extraAttributes(['class' => 'tour-filters-button'])
+            )
             ->actions([
                 Action::make('assign_head')
                     ->label('Assign Head')
                     ->icon('heroicon-o-tag')
+                    ->extraAttributes(['class' => 'tour-assign-head'])
                     ->form([
                         Forms\Components\Select::make('account_head_id')
                             ->label('Account Head')
@@ -406,6 +410,7 @@ class TransactionResource extends Resource
                     ->label('Run AI Matching')
                     ->icon('heroicon-o-cpu-chip')
                     ->color('warning')
+                    ->extraAttributes(['class' => 'tour-ai-matching'])
                     ->requiresConfirmation()
                     ->modalDescription('This will run rule-based and AI matching on all unmapped transactions across all files.')
                     ->action(function () {
@@ -512,6 +517,7 @@ class TransactionResource extends Resource
                     ->label('Export')
                     ->icon('heroicon-o-arrow-down-tray')
                     ->color('success')
+                    ->extraAttributes(['class' => 'tour-export-tally'])
                     ->button(),
             ])
             ->emptyStateHeading('No transactions yet')

--- a/app/Filament/Widgets/TransactionStatsOverview.php
+++ b/app/Filament/Widgets/TransactionStatsOverview.php
@@ -33,7 +33,8 @@ class TransactionStatsOverview extends BaseWidget
             Stat::make('Mapped', "{$mappedPercentage}%")
                 ->description("{$mapped} transactions mapped")
                 ->icon('heroicon-o-check-circle')
-                ->color($mappedPercentage >= 80 ? 'success' : 'warning'),
+                ->color($mappedPercentage >= 80 ? 'success' : 'warning')
+                ->extraAttributes(['class' => 'tour-mapping-stats']),
         ];
     }
 }

--- a/config/tours.php
+++ b/config/tours.php
@@ -33,7 +33,7 @@ return [
         [
             'title' => 'Upload a Statement',
             'description' => 'Click "Upload Statement" to add a new file. Select the statement type and bank account, then upload. Processing starts immediately.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-upload-statement',
         ],
         [
             'title' => 'Track Processing Status',
@@ -61,17 +61,17 @@ return [
         [
             'title' => 'Mapping Stats',
             'description' => 'Total transactions, how many are unmapped (your to-do), and your mapped percentage. Green means 80%+ mapped — you are ready to export.',
-            'element' => '.fi-wi-stats-overview',
+            'element' => '.tour-mapping-stats',
         ],
         [
             'title' => 'AI Matching',
             'description' => 'Click "Run AI Matching" to auto-map unmapped transactions using AI. It suggests account heads with confidence scores. High-confidence matches are assigned automatically.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-ai-matching',
         ],
         [
             'title' => 'Assign Heads & Create Rules',
             'description' => 'Click any row\'s "Assign Head" to manually map it. Use "Create Rule" to make a reusable pattern — next time a similar transaction appears, it maps automatically.',
-            'element' => '.fi-ta-header-cell-accountHead-name',
+            'element' => '.tour-assign-head',
         ],
         [
             'title' => 'Bulk Actions',
@@ -81,12 +81,12 @@ return [
         [
             'title' => 'Export to Tally',
             'description' => 'When mapping is complete, use the Export menu (Tally XML, CSV, or Excel). Set a date range to export a specific period. The Tally XML is ready to import directly.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-export-tally',
         ],
         [
             'title' => 'Filters',
             'description' => 'Filter by imported file, mapping type, account head, date range, or unmapped-only. The "Unmapped Only" filter is your fastest path to clearing the backlog.',
-            'element' => '.fi-ta-header-toolbar',
+            'element' => '.tour-filters-button',
         ],
     ],
 
@@ -99,7 +99,7 @@ return [
         [
             'title' => 'Import from Tally XML',
             'description' => 'The fastest way to set up: click "Import from Tally XML" and upload your Tally master file. It creates all heads, groups, and hierarchy automatically. It also detects bank accounts.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-import-tally',
         ],
         [
             'title' => 'Usage Counts',
@@ -122,7 +122,7 @@ return [
         [
             'title' => 'Create Rules',
             'description' => 'Click "New" to create a rule manually, or go to Transactions → click a row → "Create Rule" to pre-fill from an existing transaction. The second approach is faster.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-create-rule',
         ],
         [
             'title' => 'Test Before Applying',
@@ -155,7 +155,7 @@ return [
         [
             'title' => 'Run Reconciliation',
             'description' => 'Click "Run Reconciliation" and select a bank statement + invoice file. The system matches transactions by amount and date, then suggests possible matches.',
-            'element' => '.fi-header-actions',
+            'element' => '.tour-run-reconciliation',
         ],
         [
             'title' => 'Review Matches',

--- a/config/tours.php
+++ b/config/tours.php
@@ -38,7 +38,7 @@ return [
         [
             'title' => 'Track Processing Status',
             'description' => 'The Status column shows: Pending → Processing → Completed (or Failed). If a PDF is password-protected, you will see "Needs Password" — click the row actions to set it.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-status',
         ],
         [
             'title' => 'Row Actions',
@@ -71,7 +71,7 @@ return [
         [
             'title' => 'Assign Heads & Create Rules',
             'description' => 'Click any row\'s "Assign Head" to manually map it. Use "Create Rule" to make a reusable pattern — next time a similar transaction appears, it maps automatically.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-accountHead-name',
         ],
         [
             'title' => 'Bulk Actions',
@@ -104,12 +104,12 @@ return [
         [
             'title' => 'Usage Counts',
             'description' => 'The "Transactions" column shows how many transactions are mapped to each head. "Rules" shows how many auto-mapping rules target it. Heads with zero usage may be unused.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-transactions-count',
         ],
         [
             'title' => 'Active Toggle',
             'description' => 'Inactive heads are hidden from mapping suggestions, keeping your dropdowns clean. Deactivate heads you do not use instead of deleting them.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-is-active',
         ],
     ],
 
@@ -127,17 +127,17 @@ return [
         [
             'title' => 'Test Before Applying',
             'description' => 'Each rule has a "Test Rule" action in the row menu. It shows how many existing transactions would match — use it to verify your pattern before relying on it.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-actions:first-of-type',
         ],
         [
             'title' => 'Match Types',
             'description' => 'Contains: matches if description includes the text. Exact: must match fully. Regex: for advanced patterns (e.g., "NEFT.*SALARY"). Contains covers 90% of cases.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-match-type',
         ],
         [
             'title' => 'Priority & Usage',
             'description' => 'Rules with lower priority numbers run first. The "Uses" column shows how often a rule matched — high-use rules are your most valuable automation.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-header-cell-priority',
         ],
     ],
 
@@ -160,7 +160,7 @@ return [
         [
             'title' => 'Review Matches',
             'description' => 'Green "Confirm" buttons appear on rows with suggestions. Click to accept. Use "Match Invoice" to manually link a transaction. "Reject All" clears bad suggestions.',
-            'element' => '.fi-ta',
+            'element' => '.fi-ta-actions:first-of-type',
         ],
     ],
 ];

--- a/config/tours.php
+++ b/config/tours.php
@@ -43,7 +43,7 @@ return [
         [
             'title' => 'Row Actions',
             'description' => 'Each row has actions: Download the original file, Re-process if parsing failed, or Set Password for locked PDFs. Look for the "..." menu on each row.',
-            'element' => '.fi-ta-actions:first-of-type',
+            'element' => '.fi-ta-table tbody tr:first-child .fi-ta-actions',
         ],
         [
             'title' => 'Filter by Status',
@@ -127,7 +127,7 @@ return [
         [
             'title' => 'Test Before Applying',
             'description' => 'Each rule has a "Test Rule" action in the row menu. It shows how many existing transactions would match — use it to verify your pattern before relying on it.',
-            'element' => '.fi-ta-actions:first-of-type',
+            'element' => '.fi-ta-table tbody tr:first-child .fi-ta-actions',
         ],
         [
             'title' => 'Match Types',
@@ -160,7 +160,7 @@ return [
         [
             'title' => 'Review Matches',
             'description' => 'Green "Confirm" buttons appear on rows with suggestions. Click to accept. Use "Match Invoice" to manually link a transaction. "Reject All" clears bad suggestions.',
-            'element' => '.fi-ta-actions:first-of-type',
+            'element' => '.fi-ta-table tbody tr:first-child .fi-ta-actions',
         ],
     ],
 ];


### PR DESCRIPTION
**Summary:**
* Replaced generic CSS selectors (`.fi-header-actions`, `.fi-ta`) in `config/tours.php` with highly-specific custom `.tour-*` classes.
* Injected `.tour-assign-head` into the Assign Head row action on the Transactions page.
* Injected `.tour-filters-button` into the Transactions table filter trigger.
* Injected `.tour-mapping-stats` directly onto the Mapped percentage stat card in `TransactionStatsOverview.php` to bypass nth-child targeting issues.
* Injected corresponding `.tour-*` classes onto header actions in Account Heads, Head Mappings, and Reconciliation pages for precise step targeting.

## Changes Made
* **Transactions Page:**
  * Injected `.tour-filters-button` onto the table filter trigger so the tour perfectly highlights the right-sided funnel icon instead of the entire search bar.
  * Injected `.tour-assign-head` into the row action to correctly point to the row-level assignment button.
  * Injected `.tour-mapping-stats` directly onto the third Stat card (Mapped percentage) within the `TransactionStatsOverview` widget to bypass driver.js `:nth-child` targeting issues.
* **Global Tour Actions:** 
  * Replaced generic `.fi-header-actions` selectors in `config/tours.php` with target-specific classes.
  * Injected `.tour-ai-matching` onto the Run AI Matching action.
  * Injected `.tour-export-tally` onto the Export ActionGroup.
  * Injected `.tour-import-tally` onto the Import from Tally action in Account Heads.
  * Injected `.tour-create-rule` onto the Create action in Head Mappings.
  * Injected `.tour-run-reconciliation` onto the Run Reconciliation action in Reconciliation.

## Testing
* Trigger the page tours on the Transactions, Account Heads, Head Mappings, and Reconciliation pages.
* Verify that each step’s spotlight highlights the exact button/widget referenced in the description without floating in empty space.

closes #304 
