### PR TITLE
Fix: Ensure StatementParser correctly classifies credit card refunds and payments

### DIFF
--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -52,7 +52,8 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         - Extract the account holder name (individual or company name) from the statement header. Set it as `account_holder_name`. Leave null if not found.
         - For each transaction, extract: date, description, debit amount, credit amount, and running balance
         - Return each transaction date exactly as it appears in the source document (e.g. "10/03/2026", "05-Apr-2026", "17/03/2026"). Do NOT reformat or convert dates.
-        - Amounts should be numeric (no currency symbols or commas)
+        - CRITICAL RULE FOR SINGLE-COLUMN AMOUNTS: If both charges and refunds are in a single "Amount" column, an amount with a "CR" suffix or minus sign (e.g. "9,148.42 CR") is a refund/payment and MUST be placed in the `credit` field. Amounts with no suffix or a "DR" suffix are standard charges and MUST be placed in the `debit` field. Do NOT guess based on the description.
+        - Strip the "CR" or "DR" suffix and any currency symbols or commas when extracting amounts. They must be purely numeric.
         - If a field is not present, use null
         - Extract reference numbers where available
         - Handle multi-line transaction descriptions by concatenating them

--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -52,8 +52,8 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         - Extract the account holder name (individual or company name) from the statement header. Set it as `account_holder_name`. Leave null if not found.
         - For each transaction, extract: date, description, debit, credit, and running balance
         - Return each transaction date exactly as it appears in the source document (e.g. "10/03/2026", "05-Apr-2026", "17/03/2026"). Do NOT reformat or convert dates.
-        - CRITICAL RULE FOR SINGLE-COLUMN AMOUNTS: If both charges and refunds are in a single "Amount" column, an amount with a "CR" suffix or minus sign (e.g. "9,148.42 CR" or "-9148.42") is a refund/payment and MUST be placed in the `credit` field. Amounts with no suffix or a "DR" suffix are standard charges and MUST be placed in the `debit` field. Do NOT guess based on the description.
-        - Strip any minus signs, "CR" or "DR" suffixes, currency symbols, and commas when extracting amounts. The final values in the debit and credit fields must be purely positive absolute numbers.
+        - CRITICAL RULE FOR SINGLE-COLUMN AMOUNTS: If both charges and refunds are in a single "Amount" column, an amount with a "CR" suffix (e.g. "9,148.42 CR") is a refund/payment and MUST be placed in the `credit` field. Amounts with no suffix or a "DR" suffix are standard charges and MUST be placed in the `debit` field. Do NOT guess based on the description.
+        - Strip "CR" or "DR" suffixes, currency symbols, and commas when extracting amounts. The final values in the debit and credit fields must be purely positive absolute numbers.
         - If a field is not present, use null
         - Extract reference numbers where available
         - Handle multi-line transaction descriptions by concatenating them

--- a/app/Ai/Agents/StatementParser.php
+++ b/app/Ai/Agents/StatementParser.php
@@ -50,10 +50,10 @@ class StatementParser implements Agent, HasMiddleware, HasStructuredOutput
         - Detect the bank name and account number from the header/footer
         - Identify the statement period (start and end dates)
         - Extract the account holder name (individual or company name) from the statement header. Set it as `account_holder_name`. Leave null if not found.
-        - For each transaction, extract: date, description, debit amount, credit amount, and running balance
+        - For each transaction, extract: date, description, debit, credit, and running balance
         - Return each transaction date exactly as it appears in the source document (e.g. "10/03/2026", "05-Apr-2026", "17/03/2026"). Do NOT reformat or convert dates.
-        - CRITICAL RULE FOR SINGLE-COLUMN AMOUNTS: If both charges and refunds are in a single "Amount" column, an amount with a "CR" suffix or minus sign (e.g. "9,148.42 CR") is a refund/payment and MUST be placed in the `credit` field. Amounts with no suffix or a "DR" suffix are standard charges and MUST be placed in the `debit` field. Do NOT guess based on the description.
-        - Strip the "CR" or "DR" suffix and any currency symbols or commas when extracting amounts. They must be purely numeric.
+        - CRITICAL RULE FOR SINGLE-COLUMN AMOUNTS: If both charges and refunds are in a single "Amount" column, an amount with a "CR" suffix or minus sign (e.g. "9,148.42 CR" or "-9148.42") is a refund/payment and MUST be placed in the `credit` field. Amounts with no suffix or a "DR" suffix are standard charges and MUST be placed in the `debit` field. Do NOT guess based on the description.
+        - Strip any minus signs, "CR" or "DR" suffixes, currency symbols, and commas when extracting amounts. The final values in the debit and credit fields must be purely positive absolute numbers.
         - If a field is not present, use null
         - Extract reference numbers where available
         - Handle multi-line transaction descriptions by concatenating them

--- a/tests/Feature/Ai/AgentsTest.php
+++ b/tests/Feature/Ai/AgentsTest.php
@@ -154,6 +154,33 @@ describe('HeadMatcher agent', function () {
 });
 
 describe('StatementParser with Agent::fake()', function () {
+    it('instructs the model to handle CR and DR suffixes without minus sign rule', function () {
+        $agent = new StatementParser;
+        $instructions = (string) $agent->instructions();
+
+        expect($instructions)->toContain('CR" suffix')
+            ->and($instructions)->toContain('DR" suffix')
+            ->and($instructions)->not->toContain('minus sign');
+    });
+
+    it('returns structured response mapping CR to credit and unsuffixed to debit', function () {
+        StatementParser::fake([
+            [
+                'bank_name' => 'HDFC Bank',
+                'transactions' => [
+                    ['date' => '2024-01-01', 'description' => 'REFUND', 'credit' => 9148.42, 'debit' => null, 'balance' => 10000],
+                    ['date' => '2024-01-02', 'description' => 'CHARGE', 'credit' => null, 'debit' => 500.00, 'balance' => 9500],
+                ],
+            ],
+        ]);
+
+        $response = (new StatementParser)->prompt('Parse statement');
+
+        expect($response['transactions'][0]['credit'])->toBe(9148.42)
+            ->and($response['transactions'][0]['debit'])->toBeNull()
+            ->and($response['transactions'][1]['debit'])->toBe(500.00)
+            ->and($response['transactions'][1]['credit'])->toBeNull();
+    });
     it('returns structured response with faked data', function () {
         Storage::fake('local');
         Storage::put('statements/test.pdf', 'fake-pdf-content');


### PR DESCRIPTION
## Description
This PR fixes a critical bug where `StatementParser` occasionally misclassifies credit card refunds, cashbacks, and incoming payments as outgoing debits when parsing statements that combine debits and credits into a single `Amount` column.

Because the previous system prompt lacked explicit rules for handling `CR` (Credit) suffixes, the LLM defaulted to "semantic guessing" based on the transaction description (e.g., assuming a "Subscription" row was a standard charge even if it had a `CR` suffix).

### Changes Made
- Added a `CRITICAL RULE` to the `StatementParser.php` prompt instructing the LLM to strictly rely on `CR` or `DR` suffixes for single-column amounts.
- Explicitly instructed the LLM to place `CR` amounts in the `credit` JSON field and un-suffixed/`DR` amounts in the `debit` field.
- Instructed the LLM to strip the `CR/DR` suffixes (along with currency symbols and commas) so the final JSON values remain strictly numeric.

## Testing
- Verified prompt against existing PDF test statements.
- Confirmed the model extracts `9,148.42 CR` as `credit: 9148.42` rather than `debit: 9148.42`.

closes #313 
