### PR TITLE
fix(reconciliation): allow incremental automated reconciliation of flagged transactions

### DIFF
--- a/app/Filament/Resources/ReconciliationResource.php
+++ b/app/Filament/Resources/ReconciliationResource.php
@@ -132,7 +132,7 @@ class ReconciliationResource extends Resource
                                 ->options(function (Transaction $record) {
                                     return Transaction::whereHas('importedFile', fn (Builder $q) => $q->where('statement_type', StatementType::Invoice)
                                         ->where('company_id', $record->importedFile?->company_id))
-                                        ->whereIn('reconciliation_status', [ReconciliationStatus::Unreconciled, ReconciliationStatus::Flagged])
+                                        ->matchable()
                                         ->orderByDesc('date')
                                         ->limit(500)
                                         ->get()

--- a/app/Models/ImportedFile.php
+++ b/app/Models/ImportedFile.php
@@ -163,6 +163,7 @@ class ImportedFile extends Model
         return $this->belongsTo(CreditCard::class);
     }
 
+    /** @return HasMany<Transaction, $this> */
     public function transactions(): HasMany
     {
         return $this->hasMany(Transaction::class);

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -139,6 +139,23 @@ class Transaction extends Model
     }
 
     /**
+     * Transactions eligible for automated matching.
+     *
+     * Flagged is included because it is only ever set by the reconciliation
+     * engine to mean "tried and failed", never by a user decision — so those
+     * rows must be re-examined when new counterparties arrive.
+     *
+     * @param  Builder<Transaction>  $query
+     */
+    public function scopeMatchable(Builder $query): void
+    {
+        $query->whereIn('reconciliation_status', [
+            ReconciliationStatus::Unreconciled,
+            ReconciliationStatus::Flagged,
+        ]);
+    }
+
+    /**
      * @param  Builder<Transaction>  $query
      * @return Builder<Transaction>
      */

--- a/app/Services/Reconciliation/ReconciliationService.php
+++ b/app/Services/Reconciliation/ReconciliationService.php
@@ -57,7 +57,10 @@ class ReconciliationService
         $result = new ReconciliationResult;
 
         $bankTransactions = $bankFile->transactions()
-            ->where('reconciliation_status', ReconciliationStatus::Unreconciled)
+            ->whereIn('reconciliation_status', [
+                ReconciliationStatus::Unreconciled,
+                ReconciliationStatus::Flagged,
+            ])
             ->get();
 
         $invoiceFilesCollection = $invoiceFiles instanceof ImportedFile
@@ -67,7 +70,10 @@ class ReconciliationService
         $invoiceFileIds = $invoiceFilesCollection->pluck('id')->all();
 
         $invoiceTransactions = Transaction::whereIn('imported_file_id', $invoiceFileIds)
-            ->where('reconciliation_status', ReconciliationStatus::Unreconciled)
+            ->whereIn('reconciliation_status', [
+                ReconciliationStatus::Unreconciled,
+                ReconciliationStatus::Flagged,
+            ])
             ->get();
 
         if ($bankTransactions->isEmpty() || $invoiceTransactions->isEmpty()) {
@@ -464,20 +470,26 @@ class ReconciliationService
         $companyId = $invoiceFilesCollection->first()->company_id;
         $invoiceFileIds = $invoiceFilesCollection->pluck('id')->all();
 
-        // Get all unreconciled invoice transactions from these files
+        // Get all unreconciled or flagged invoice transactions from these files
         /** @var Collection<int, Transaction> $invoiceTransactions */
         $invoiceTransactions = Transaction::whereIn('imported_file_id', $invoiceFileIds)
-            ->where('reconciliation_status', ReconciliationStatus::Unreconciled)
+            ->whereIn('reconciliation_status', [
+                ReconciliationStatus::Unreconciled,
+                ReconciliationStatus::Flagged,
+            ])
             ->get();
 
         if ($invoiceTransactions->isEmpty()) {
             return 0;
         }
 
-        // Get all unreconciled bank/CC transactions for this company
+        // Get all unreconciled or flagged bank/CC transactions for this company
         $bankTransactions = Transaction::query()
             ->where('company_id', $companyId)
-            ->where('reconciliation_status', ReconciliationStatus::Unreconciled)
+            ->whereIn('reconciliation_status', [
+                ReconciliationStatus::Unreconciled,
+                ReconciliationStatus::Flagged,
+            ])
             ->whereHas('importedFile', fn ($q) => $q->whereIn('statement_type', [
                 StatementType::Bank,
                 StatementType::CreditCard,

--- a/app/Services/Reconciliation/ReconciliationService.php
+++ b/app/Services/Reconciliation/ReconciliationService.php
@@ -56,12 +56,7 @@ class ReconciliationService
     ): ReconciliationResult {
         $result = new ReconciliationResult;
 
-        $bankTransactions = $bankFile->transactions()
-            ->whereIn('reconciliation_status', [
-                ReconciliationStatus::Unreconciled,
-                ReconciliationStatus::Flagged,
-            ])
-            ->get();
+        $bankTransactions = $bankFile->transactions()->matchable()->get();
 
         $invoiceFilesCollection = $invoiceFiles instanceof ImportedFile
             ? collect([$invoiceFiles])
@@ -69,12 +64,7 @@ class ReconciliationService
 
         $invoiceFileIds = $invoiceFilesCollection->pluck('id')->all();
 
-        $invoiceTransactions = Transaction::whereIn('imported_file_id', $invoiceFileIds)
-            ->whereIn('reconciliation_status', [
-                ReconciliationStatus::Unreconciled,
-                ReconciliationStatus::Flagged,
-            ])
-            ->get();
+        $invoiceTransactions = $this->matchableInvoicesFrom($invoiceFileIds);
 
         if ($bankTransactions->isEmpty() || $invoiceTransactions->isEmpty()) {
             $this->flagUnmatched($bankFile, $invoiceFilesCollection);
@@ -455,6 +445,16 @@ class ReconciliationService
      * Scan for invoice match candidates and create suggested matches.
      * Returns the number of suggestions created.
      *
+     * Cost characteristic: the bank side is scoped by company, not by file, and
+     * flagUnmatched() never moves a row out of Flagged. So the candidate pool
+     * grows monotonically and every run re-scans the full history of bank rows
+     * that have never produced a pending suggestion. This is deliberate — an
+     * invoice can legitimately arrive months after the payment cleared, and a
+     * date window would silently stop reconciling those. At this scale (one
+     * small accounts team) the re-scan is cheap; if it stops being cheap, bound
+     * it with a lookback window on Transaction::date rather than by narrowing
+     * the status filter, since the statuses are what make the pass correct.
+     *
      * @param  ImportedFile|Collection<int, ImportedFile>|array<int, ImportedFile>  $invoiceFiles
      */
     public function suggestMatches(ImportedFile|Collection|array $invoiceFiles): int
@@ -468,28 +468,16 @@ class ReconciliationService
         }
 
         $companyId = $invoiceFilesCollection->first()->company_id;
-        $invoiceFileIds = $invoiceFilesCollection->pluck('id')->all();
 
-        // Get all unreconciled or flagged invoice transactions from these files
-        /** @var Collection<int, Transaction> $invoiceTransactions */
-        $invoiceTransactions = Transaction::whereIn('imported_file_id', $invoiceFileIds)
-            ->whereIn('reconciliation_status', [
-                ReconciliationStatus::Unreconciled,
-                ReconciliationStatus::Flagged,
-            ])
-            ->get();
+        $invoiceTransactions = $this->matchableInvoicesFrom($invoiceFilesCollection->pluck('id')->all());
 
         if ($invoiceTransactions->isEmpty()) {
             return 0;
         }
 
-        // Get all unreconciled or flagged bank/CC transactions for this company
         $bankTransactions = Transaction::query()
             ->where('company_id', $companyId)
-            ->whereIn('reconciliation_status', [
-                ReconciliationStatus::Unreconciled,
-                ReconciliationStatus::Flagged,
-            ])
+            ->matchable()
             ->whereHas('importedFile', fn ($q) => $q->whereIn('statement_type', [
                 StatementType::Bank,
                 StatementType::CreditCard,
@@ -682,6 +670,19 @@ class ReconciliationService
 
             return $match;
         });
+    }
+
+    /**
+     * Invoice transactions from the given imported files that are still eligible for matching.
+     *
+     * @param  array<int, mixed>  $invoiceFileIds
+     * @return Collection<int, Transaction>
+     */
+    private function matchableInvoicesFrom(array $invoiceFileIds): Collection
+    {
+        return Transaction::whereIn('imported_file_id', $invoiceFileIds)
+            ->matchable()
+            ->get();
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -188,12 +188,6 @@ parameters:
 			path: app/Models/ImportedFile.php
 
 		-
-			message: '#^Method App\\Models\\ImportedFile\:\:transactions\(\) return type with generic class Illuminate\\Database\\Eloquent\\Relations\\HasMany does not specify its types\: TRelatedModel, TDeclaringModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: app/Models/ImportedFile.php
-
-		-
 			message: '#^Class App\\Models\\ReconciliationMatch uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
 			identifier: missingType.generics
 			count: 1
@@ -303,12 +297,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<\(int\|string\),Illuminate\\Database\\Eloquent\\Model\>\:\:map\(\) expects callable\(Illuminate\\Database\\Eloquent\\Model, int\|string\)\: array\{id\: int, description\: string, debit\: string\|null, credit\: string\|null\}, Closure\(App\\Models\\Transaction\)\: array\{id\: int, description\: string, debit\: string\|null, credit\: string\|null\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Services/HeadMatcher/HeadMatcherService.php
-
-		-
-			message: '#^Parameter \#1 \$transactions of method App\\Services\\HeadMatcher\\RuleBasedMatcher\:\:match\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Transaction\>, Illuminate\\Database\\Eloquent\\Collection\<int, Illuminate\\Database\\Eloquent\\Model\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: app/Services/HeadMatcher/HeadMatcherService.php

--- a/tests/Feature/Services/ReconciliationServiceTest.php
+++ b/tests/Feature/Services/ReconciliationServiceTest.php
@@ -1176,4 +1176,3 @@ describe('ReconciliationService', function () {
         });
     });
 });
-

--- a/tests/Feature/Services/ReconciliationServiceTest.php
+++ b/tests/Feature/Services/ReconciliationServiceTest.php
@@ -1123,4 +1123,57 @@ describe('ReconciliationService', function () {
                 ->and($invoiceTxn->reconciliation_status)->toBe(ReconciliationStatus::Unreconciled);
         });
     });
+
+    describe('incremental auto-matching with Flagged status', function () {
+        it('reconcile() matches previously flagged transactions when a new matching invoice arrives', function () {
+            // A bank transaction left as Flagged from an earlier unsuccessful reconciliation
+            $bankTxn = Transaction::factory()->debit(7500.00)->create([
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Vendor Payment',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Flagged,
+            ]);
+
+            // A newly uploaded invoice file arrives with the exact invoice
+            $invoice = Transaction::factory()->debit(7500.00)->create([
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-7500 Vendor Payment',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            $result = $this->service->reconcile($this->bankFile, $this->invoiceFile);
+
+            $bankTxn->refresh();
+            $invoice->refresh();
+
+            expect($result->matched)->toBe(1)
+                ->and($bankTxn->reconciliation_status)->toBe(ReconciliationStatus::Matched)
+                ->and($invoice->reconciliation_status)->toBe(ReconciliationStatus::Matched);
+        });
+
+        it('suggestMatches() generates suggestions for previously flagged transactions', function () {
+            $bankTxn = Transaction::factory()->debit(4200.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Consulting',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Flagged,
+            ]);
+
+            $invoice = Transaction::factory()->debit(4200.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-4200 Consulting',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            $count = $this->service->suggestMatches($this->invoiceFile);
+
+            expect($count)->toBe(1)
+                ->and(ReconciliationMatch::where('bank_transaction_id', $bankTxn->id)->count())->toBe(1);
+        });
+    });
 });
+

--- a/tests/Feature/Services/ReconciliationServiceTest.php
+++ b/tests/Feature/Services/ReconciliationServiceTest.php
@@ -1174,5 +1174,94 @@ describe('ReconciliationService', function () {
             expect($count)->toBe(1)
                 ->and(ReconciliationMatch::where('bank_transaction_id', $bankTxn->id)->count())->toBe(1);
         });
+
+        it('reconcile() leaves already matched transactions alone', function () {
+            $matchedTxn = Transaction::factory()->debit(9000.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Already Settled',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Matched,
+            ]);
+
+            $flaggedTxn = Transaction::factory()->debit(3300.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Still Open',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Flagged,
+            ]);
+
+            // An invoice that would match the settled transaction on amount alone
+            $duplicateInvoice = Transaction::factory()->debit(9000.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-9000 Already Settled',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            $openInvoice = Transaction::factory()->debit(3300.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-3300 Still Open',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            $result = $this->service->reconcile($this->bankFile, $this->invoiceFile);
+
+            $matchedTxn->refresh();
+            $flaggedTxn->refresh();
+            $duplicateInvoice->refresh();
+            $openInvoice->refresh();
+
+            expect($result->matched)->toBe(1)
+                ->and(ReconciliationMatch::where('bank_transaction_id', $matchedTxn->id)->count())->toBe(0)
+                ->and($matchedTxn->reconciliation_status)->toBe(ReconciliationStatus::Matched)
+                ->and($duplicateInvoice->reconciliation_status)->toBe(ReconciliationStatus::Flagged)
+                ->and($flaggedTxn->reconciliation_status)->toBe(ReconciliationStatus::Matched)
+                ->and($openInvoice->reconciliation_status)->toBe(ReconciliationStatus::Matched);
+        });
+
+        it('suggestMatches() skips already matched transactions', function () {
+            $matchedTxn = Transaction::factory()->debit(9000.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Already Settled',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Matched,
+            ]);
+
+            $flaggedTxn = Transaction::factory()->debit(3300.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->bankFile->id,
+                'description' => 'NEFT-Still Open',
+                'date' => '2025-04-15',
+                'reconciliation_status' => ReconciliationStatus::Flagged,
+            ]);
+
+            Transaction::factory()->debit(9000.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-9000 Already Settled',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            Transaction::factory()->debit(3300.00)->create([
+                'company_id' => $this->company->id,
+                'imported_file_id' => $this->invoiceFile->id,
+                'description' => 'INV-3300 Still Open',
+                'date' => '2025-04-12',
+                'reconciliation_status' => ReconciliationStatus::Unreconciled,
+            ]);
+
+            $count = $this->service->suggestMatches($this->invoiceFile);
+
+            expect($count)->toBe(1)
+                ->and(ReconciliationMatch::where('bank_transaction_id', $matchedTxn->id)->count())->toBe(0)
+                ->and(ReconciliationMatch::where('bank_transaction_id', $flaggedTxn->id)->count())->toBe(1);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Updates `ReconciliationService::reconcile()` and `suggestMatches()` to query both `Unreconciled` and `Flagged` transactions (`whereIn('reconciliation_status', [Unreconciled, Flagged])`).
- Allows automated and AI reconciliation engines to re-check previously `Flagged` transactions whenever new invoice files are uploaded over time, enabling seamless incremental matching without requiring users to manually reset transaction statuses.
- Adds comprehensive TDD feature tests in `ReconciliationServiceTest.php` to verify `reconcile()` and `suggestMatches()` correctly process and match `Flagged` items when matching invoices become available.

## Related Issue
Closes #318 

## Type of Change
- [x] `fix` - Bug fix

## Checklist
- [x] Branch follows naming: `fix/flagged-status-incremental-matching`
- [x] Commits follow format: `fix(ai): allow incremental automated reconciliation of flagged transactions (#issue)`
- [x] PR has a `type:` label (bug) for release notes
- [x] Tests added/updated for changes
- [x] `vendor/bin/pint --dirty` run
- [x] All new models have factories
- [x] Migrations are reversible
- [x] Encrypted fields handled properly (no plaintext in logs/exports)

## Test Results
