### PR TITLE
feat: add manual cash transactions module (fixes #326)

### DIFF
--- a/app/Exports/CashTransactionExcelExport.php
+++ b/app/Exports/CashTransactionExcelExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Exports;
 
+use App\Models\CashTransaction;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
@@ -18,7 +19,7 @@ class CashTransactionExcelExport implements FromCollection, ShouldAutoSize, With
     protected Collection $records;
 
     /**
-     * @param Collection<int, CashTransaction> $records
+     * @param  Collection<int, CashTransaction>  $records
      */
     public function __construct(Collection $records)
     {

--- a/app/Exports/CashTransactionExcelExport.php
+++ b/app/Exports/CashTransactionExcelExport.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class CashTransactionExcelExport implements FromCollection, ShouldAutoSize, WithHeadings, WithStyles
+{
+    /**
+     * @var Collection<int, CashTransaction>
+     */
+    protected Collection $records;
+
+    /**
+     * @param Collection<int, CashTransaction> $records
+     */
+    public function __construct(Collection $records)
+    {
+        $this->records = $records;
+    }
+
+    /**
+     * @return Collection<int, mixed>
+     */
+    public function collection(): Collection
+    {
+        $data = $this->records->map(function ($transaction) {
+            return [
+                $transaction->date,
+                $transaction->description,
+                $transaction->amount,
+                $transaction->accountHead?->name,
+            ];
+        });
+
+        $totalAmount = $this->records->sum('amount');
+
+        $data->push([
+            '',
+            'Total',
+            $totalAmount,
+            '',
+        ]);
+
+        return $data;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function headings(): array
+    {
+        return [
+            'Date',
+            'Description',
+            'Amount',
+            'Account Head',
+        ];
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function styles(Worksheet $sheet): array
+    {
+        $lastRow = $sheet->getHighestRow();
+        $lastCol = $sheet->getHighestColumn();
+        $range = 'A1:'.$lastCol.$lastRow;
+
+        return [
+            1 => ['font' => ['bold' => true]],
+            $range => [
+                'borders' => [
+                    'allBorders' => [
+                        'borderStyle' => Border::BORDER_THIN,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Filament/Resources/CashTransactions/CashTransactionResource.php
+++ b/app/Filament/Resources/CashTransactions/CashTransactionResource.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Filament\Resources\CashTransactions;
+
+use App\Models\CashTransaction;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class CashTransactionResource extends Resource
+{
+    protected static ?string $model = CashTransaction::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?int $navigationSort = 3;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                DatePicker::make('date')
+                    ->required(),
+                TextInput::make('description')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('amount')
+                    ->required()
+                    ->numeric(),
+                Select::make('account_head_id')
+                    ->relationship('accountHead', 'name')
+                    ->nullable(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('date')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('description')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('amount')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('accountHead.name')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                // Removed TrashedFilter to simplify UI as requested
+            ])
+            ->actions([
+                Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ManageCashTransactions::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CashTransactions/Pages/ManageCashTransactions.php
+++ b/app/Filament/Resources/CashTransactions/Pages/ManageCashTransactions.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Resources\CashTransactions\Pages;
+
+use App\Exports\CashTransactionExcelExport;
+use App\Filament\Resources\CashTransactions\CashTransactionResource;
+use App\Models\CashTransaction;
+use Filament\Actions;
+use Filament\Forms\Components\DatePicker;
+use Filament\Resources\Pages\ManageRecords;
+use Maatwebsite\Excel\Facades\Excel;
+
+class ManageCashTransactions extends ManageRecords
+{
+    protected static string $resource = CashTransactionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('export_excel')
+                ->label('Export to Excel')
+                ->icon('heroicon-o-document-arrow-down')
+                ->color('success')
+                ->form([
+                    DatePicker::make('from')
+                        ->label('From Date'),
+                    DatePicker::make('until')
+                        ->label('Until Date'),
+                ])
+                ->action(function (array $data) {
+                    $query = CashTransaction::with('accountHead');
+
+                    if (! empty($data['from'])) {
+                        $query->whereDate('date', '>=', $data['from']);
+                    }
+                    if (! empty($data['until'])) {
+                        $query->whereDate('date', '<=', $data['until']);
+                    }
+
+                    return Excel::download(
+                        new CashTransactionExcelExport($query->get()),
+                        'cash_transactions_'.now()->format('Y_m_d_His').'.xlsx'
+                    );
+                }),
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/CashTransaction.php
+++ b/app/Models/CashTransaction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CashTransaction extends Model
+{
+    /** @use HasFactory<\Database\Factories\CashTransactionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'company_id',
+        'date',
+        'description',
+        'amount',
+        'account_head_id',
+    ];
+
+    /**
+     * @return BelongsTo<Company, $this>
+     */
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    /**
+     * @return BelongsTo<AccountHead, $this>
+     */
+    public function accountHead(): BelongsTo
+    {
+        return $this->belongsTo(AccountHead::class);
+    }
+}

--- a/app/Models/CashTransaction.php
+++ b/app/Models/CashTransaction.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use Database\Factories\CashTransactionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class CashTransaction extends Model
 {
-    /** @use HasFactory<\Database\Factories\CashTransactionFactory> */
+    /** @use HasFactory<CashTransactionFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/database/factories/CashTransactionFactory.php
+++ b/database/factories/CashTransactionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AccountHead;
+use App\Models\CashTransaction;
+use App\Models\Company;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CashTransaction>
+ */
+class CashTransactionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'date' => fake()->date(),
+            'description' => fake()->sentence(),
+            'amount' => fake()->randomFloat(2, 10, 1000),
+            'account_head_id' => AccountHead::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_05_090947_create_cash_transactions_table.php
+++ b/database/migrations/2026_08_05_090947_create_cash_transactions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cash_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained('companies')->cascadeOnDelete();
+            $table->date('date');
+            $table->text('description');
+            $table->decimal('amount', 15, 2);
+            $table->foreignId('account_head_id')->nullable()->constrained('account_heads')->nullOnDelete();
+            $table->timestampsTz();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cash_transactions');
+    }
+};

--- a/tests/Architecture/ArchTest.php
+++ b/tests/Architecture/ArchTest.php
@@ -66,6 +66,7 @@ describe('Filament Resources', function () {
             ->ignoring('App\Filament\Resources\DuplicateFlags\Pages')
             ->ignoring('App\Filament\Resources\BudgetResource\Pages')
             ->ignoring('App\Filament\Resources\InboundEmailResource\Pages')
+            ->ignoring('App\Filament\Resources\CashTransactions\Pages')
             ->ignoring('App\Filament\Resources\ImportedFileResource\RelationManagers');
     });
 })->group('architecture');

--- a/tests/Feature/Filament/CashTransactionResourceTest.php
+++ b/tests/Feature/Filament/CashTransactionResourceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Filament\Resources\CashTransactions\CashTransactionResource;
+use App\Filament\Resources\CashTransactions\Pages\ManageCashTransactions;
+use App\Models\CashTransaction;
+use Carbon\Carbon;
+use Filament\Actions\CreateAction;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->user = asUser();
+    $this->company = tenant();
+});
+
+describe('CashTransactionResource', function () {
+    it('can render the index page', function () {
+        $this->get(CashTransactionResource::getUrl('index'))
+            ->assertSuccessful();
+    });
+
+    it('can list cash transactions', function () {
+        CashTransaction::factory()->count(3)->create(['company_id' => $this->company->id]);
+
+        livewire(ManageCashTransactions::class)
+            ->assertCanSeeTableRecords(CashTransaction::all());
+    });
+
+    it('can create a cash transaction', function () {
+        $date = Carbon::now()->format('Y-m-d');
+        livewire(ManageCashTransactions::class)
+            ->callAction(CreateAction::class, data: [
+                'date' => $date,
+                'description' => 'Office Supplies',
+                'amount' => 150.50,
+            ])
+            ->assertHasNoActionErrors();
+
+        $this->assertDatabaseHas('cash_transactions', [
+            'description' => 'Office Supplies',
+            'amount' => 150.50,
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Added `CashTransaction` model, factory, and migration
- Built Filament UI (`CashTransactionResource`) for manual entry of cash transactions
- Added custom Excel export with bold headers, date filters, and bottom total rows
- Configured exact sidebar navigation sorting for the module

## Related Issue
Closes #326

## Type of Change
- [x] `feat` - New feature
- [ ] `fix` - Bug fix
- [ ] `refactor` - Code improvement (no behavior change)
- [ ] `test` - Tests only
- [ ] `docs` - Documentation
- [ ] `chore` - Maintenance, dependencies

## Checklist
- [x] Branch follows naming: `<type>/<issue#>-<description>`
- [x] Commits follow format: `<type>(scope): message (#issue)`
- [x] PR has a `type:` label (feature, bug, refactor, docs, chore) for release notes
- [x] Tests added/updated for changes
- [x] `vendor/bin/pint --dirty` run
- [x] All new models have factories
- [x] Migrations are reversible
- [x] Encrypted fields handled properly (no plaintext in logs/exports)

## Test Results
```text
php artisan test --filter=CashTransactionResourceTest --compact

   PASS  Tests\Feature\Filament\CashTransactionResourceTest
  ✓ CashTransactionResource → it can render the index page
  ✓ CashTransactionResource → it can list cash transactions
  ✓ CashTransactionResource → it can create a cash transaction

  Tests:    3 passed (10 assertions)
